### PR TITLE
PWA-313: Fixed app crash on closeInAppBrowser command dispatch

### DIFF
--- a/libraries/core/classes/AppCommand/__mocks__/index.js
+++ b/libraries/core/classes/AppCommand/__mocks__/index.js
@@ -1,9 +1,10 @@
 let dispatchError = false;
 
-export const mockedSetCommandName = jest.fn();
-export const mockedSetCommandParams = jest.fn();
-export const mockedSetLibVersion = jest.fn();
-export const mockedDispatch = jest.fn();
+export const mockedSetCommandName = jest.fn(name => name);
+export const mockedSetCommandParams = jest.fn(params => params);
+export const mockedSetLibVersion = jest.fn(version => version);
+export const mockedBuildCommand = jest.fn(command => command);
+export const mockedDispatch = jest.fn(params => params);
 
 /**
  * Causes that the dispatch method resolves with FALSE.
@@ -13,21 +14,37 @@ export const triggerDispatchError = (value = true) => {
   dispatchError = value;
 };
 
-const mockedAppCommand = jest.fn().mockImplementation(function AppCommand() {
-  this.setCommandName = (...args) => {
-    mockedSetCommandName(...args);
+const mockedAppCommand = jest.fn().mockImplementation(function MockedAppCommand() {
+  this.name = '';
+  this.params = null;
+  this.libVersion = '9.0';
+
+  this.setCommandName = (name) => {
+    this.name = mockedSetCommandName(name);
     return this;
   };
-  this.setCommandParams = (...args) => {
-    mockedSetCommandParams(...args);
+
+  this.setCommandParams = (params) => {
+    this.params = mockedSetCommandParams(params);
     return this;
   };
-  this.setLibVersion = (...args) => {
-    mockedSetLibVersion(...args);
+
+  this.setLibVersion = (version) => {
+    this.libVersion = mockedSetLibVersion(version);
     return this;
   };
-  this.dispatch = (...args) => {
-    mockedDispatch(...args);
+
+  this.buildCommand = () => {
+    const command = this.name ? {
+      c: this.name,
+      ...this.params && { p: this.params },
+    } : null;
+
+    return mockedBuildCommand(command);
+  };
+
+  this.dispatch = (params) => {
+    mockedDispatch(params);
     const success = !dispatchError;
     dispatchError = false;
     return Promise.resolve(success);

--- a/libraries/core/classes/AppCommand/__mocks__/index.spec.js
+++ b/libraries/core/classes/AppCommand/__mocks__/index.spec.js
@@ -1,0 +1,26 @@
+// Mock some underlying classes to avoid faulty code exection.
+jest.mock('../../DevServerBridge', () => {});
+jest.mock('../../../commands/webStorage', () => {});
+
+// List of known "private" methods within the original class.
+const privateMethods = ['constructor', 'logCommand'];
+
+describe('AppCommand mock', () => {
+  describe('check if the mock provides all "public" methods', () => {
+    const OriginalAppCommand = require.requireActual('../index').default;
+    const MockedAppCommand = require.requireMock('../index').default;
+
+    // Collect the "public" methods from the original class.
+    const publicMethods = Object.getOwnPropertyNames(OriginalAppCommand.prototype)
+      .filter(method => !privateMethods.includes(method));
+
+    // To access the methods of the mock, an instance is necessary.
+    const mockedInstance = new MockedAppCommand();
+
+    publicMethods.forEach((method) => {
+      it(`should contain a method called ${method}`, () => {
+        expect(typeof mockedInstance[method]).toBe('function');
+      });
+    });
+  });
+});

--- a/libraries/core/classes/AppCommand/index.js
+++ b/libraries/core/classes/AppCommand/index.js
@@ -87,7 +87,6 @@ class AppCommand {
 
   /**
    * Creates the command object which will be dispatched through the JavaScript bridge.
-   * @private
    * @return {Object|null}
    */
   buildCommand() {

--- a/libraries/core/commands/closeInAppBrowser.js
+++ b/libraries/core/commands/closeInAppBrowser.js
@@ -12,7 +12,10 @@ export default (isAndroid) => {
     targetTab: 'in_app_browser',
   };
 
-  const delayedCommand = (isAndroid ? cleanTabCmd(targetTab) : popTabToRootCmd(targetTab)).command;
+  const delayedCommand = (isAndroid
+    ? cleanTabCmd(targetTab)
+    : popTabToRootCmd(targetTab)
+  ).buildCommand();
 
   performCommandsAfterDelay({
     cmds: [delayedCommand],

--- a/libraries/core/commands/closeInAppBrowser.spec.js
+++ b/libraries/core/commands/closeInAppBrowser.spec.js
@@ -1,0 +1,71 @@
+import {
+  mockedSetCommandName,
+  mockedSetCommandParams,
+  mockedBuildCommand,
+  mockedDispatch,
+} from '../classes/AppCommand';
+
+import closeInAppBrowser from './closeInAppBrowser';
+
+jest.mock('../classes/AppCommand');
+jest.mock('../helpers', () => ({
+  hasSGJavaScriptBridge: () => true,
+}));
+
+describe('closeInAppBrowser command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * The default test for a command parameter which is not set, or set to false.
+   * @param {boolean} isAndroid The parameter value for the command.
+   * @param {string} delayedCommand The name of the delayed command.
+   */
+  const execTest = (isAndroid, delayedCommand) => {
+    const expectedDelayedCommand = {
+      c: delayedCommand,
+      p: {
+        targetTab: 'in_app_browser',
+      },
+    };
+
+    let actualDelayedCommand;
+
+    mockedBuildCommand.mockImplementationOnce((command) => {
+      // Intercept the command assignment.
+      actualDelayedCommand = command;
+      return command;
+    });
+
+    closeInAppBrowser(isAndroid);
+
+    // Check if the correct commands where dispatched.
+    expect(mockedSetCommandName).toHaveBeenCalledTimes(3);
+    expect(mockedSetCommandName).toHaveBeenCalledWith(delayedCommand);
+    expect(mockedSetCommandName).toHaveBeenCalledWith('performCommandsAfterDelay');
+    expect(mockedSetCommandName).toHaveBeenCalledWith('showTab');
+
+    expect(mockedBuildCommand).toHaveBeenCalledTimes(1);
+    expect(actualDelayedCommand).toEqual(expectedDelayedCommand);
+
+    expect(mockedSetCommandParams).toHaveBeenCalledWith({
+      cmds: [expectedDelayedCommand],
+      delay: expect.any(Number),
+    });
+
+    expect(mockedDispatch).toHaveBeenCalledTimes(2);
+  };
+
+  it('should dispatch the commands as expected without any params', () => {
+    execTest(undefined, 'popTabToRoot');
+  });
+
+  it('should dispatch the commands as expected when params is set to false', () => {
+    execTest(false, 'popTabToRoot');
+  });
+
+  it('should dispatch the commands as expected when params is set to true', () => {
+    execTest(true, 'cleanTab');
+  });
+});


### PR DESCRIPTION
- updated the command to use the official buildCommand method of the AppCommand to create the payload of performCommandsAfterDelay
- extended AppCommandMock to provide a mock the buildCommand method
- extended AppCommandMock to behave more like the real command
- added test for the AppCommandMock to compare it's methods agains the "public" onces of the real AppCommand