### PR TITLE
PWA-604: Pages are tracked anymore when the user enters the checkout

### DIFF
--- a/libraries/tracking/helpers/index.js
+++ b/libraries/tracking/helpers/index.js
@@ -158,3 +158,20 @@ export const track = (eventName, data, state) => {
 
   return core.track[eventName](data, undefined, undefined, state);
 };
+
+let pwaWebviewVisible = true;
+
+/**
+ * Sets the visible state of the PWA webview.
+ * It's used to determine, if a legacy page is currently active.
+ * @param {boolean} value Tells if the PWA currently visible.
+ */
+export const setPWAVisibleState = (value = true) => {
+  pwaWebviewVisible = value;
+};
+
+/**
+ * Checks if the PWA webview is currently visible.
+ * @return {boolean}
+ */
+export const isPWAVisible = () => pwaWebviewVisible;

--- a/libraries/tracking/helpers/index.spec.js
+++ b/libraries/tracking/helpers/index.spec.js
@@ -1,0 +1,26 @@
+import { setPWAVisibleState, isPWAVisible } from './index';
+
+describe('Tracking helpers', () => {
+  describe('isPWAVisible()', () => {
+    it('should return true when nothing was set before', () => {
+      expect(isPWAVisible()).toBe(true);
+    });
+
+    it('should return false when the state was set to false', () => {
+      setPWAVisibleState(false);
+      expect(isPWAVisible()).toBe(false);
+    });
+  });
+
+  describe('setPWAVisibleState()', () => {
+    it('should set the state to false', () => {
+      setPWAVisibleState(false);
+      expect(isPWAVisible()).toBe(false);
+    });
+
+    it('should set the state to true', () => {
+      setPWAVisibleState(true);
+      expect(isPWAVisible()).toBe(true);
+    });
+  });
+});

--- a/libraries/tracking/streams/pages.js
+++ b/libraries/tracking/streams/pages.js
@@ -5,6 +5,7 @@ import { ITEM_PATH } from '@shopgate/pwa-common-commerce/product/constants';
 import { CHECKOUT_PATH } from '@shopgate/pwa-common/constants/RoutePaths';
 import { FAVORITES_PATH } from '@shopgate/pwa-common-commerce/favorites/constants';
 import { pwaDidAppear$ } from './app';
+import { isPWAVisible } from '../helpers';
 
 /**
  * A blacklist of paths that should be tracked whithin their individual subscriptions.
@@ -21,6 +22,8 @@ export const blacklistedPaths = [
 /**
  * Emits when one of the tracked paths is entered except some special one.
  */
-export const pagesAreReady$ = routeDidChange$.merge(pwaDidAppear$).filter(({ pathname }) => (
-  !blacklistedPaths.some(path => pathname.startsWith(path))
-));
+export const pagesAreReady$ = routeDidChange$
+  .merge(pwaDidAppear$)
+  .filter(({ pathname }) => (
+    isPWAVisible() && !blacklistedPaths.some(path => pathname.startsWith(path))
+  ));

--- a/libraries/tracking/streams/pages.spec.js
+++ b/libraries/tracking/streams/pages.spec.js
@@ -7,6 +7,7 @@ import {
   blacklistedPaths,
   pagesAreReady$,
 } from './pages';
+import { setPWAVisibleState } from '../helpers';
 
 describe('Pages streams', () => {
   let pagesAreReadySubscriber;
@@ -17,6 +18,10 @@ describe('Pages streams', () => {
   });
 
   describe('pagesAreReady$', () => {
+    beforeEach(() => {
+      setPWAVisibleState(true);
+    });
+
     describe('route changes', () => {
       it('should emit when a route is active which is not blacklisted', () => {
         const pathname = '/somepath';
@@ -32,6 +37,15 @@ describe('Pages streams', () => {
         dispatch(updateHistoryWrapped(pathname));
 
         expect(pagesAreReadySubscriber).not.toHaveBeenCalled();
+      });
+
+      it('should not emit when a route is active, but the PWA is not visible', () => {
+        setPWAVisibleState(false);
+        const pathname = '/somepath';
+        const { dispatch } = createStore(pathname);
+        dispatch(updateHistoryWrapped(pathname));
+
+        expect(pagesAreReadySubscriber).toHaveBeenCalledTimes(0);
       });
     });
 

--- a/libraries/tracking/subscriptions/checkout.js
+++ b/libraries/tracking/subscriptions/checkout.js
@@ -4,7 +4,7 @@ import { routeDidEnter } from '@shopgate/pwa-common/streams/history';
 import { appDidStart$ } from '@shopgate/pwa-common/streams/app';
 import { CHECKOUT_PATH } from '@shopgate/pwa-common/constants/RoutePaths';
 import getCart from '../selectors/cart';
-import { track, formatPurchaseData } from '../helpers/index';
+import { track, formatPurchaseData, setPWAVisibleState } from '../helpers';
 
 /**
  * Checkout tracking subscriptions.
@@ -17,6 +17,8 @@ export default function checkout(subscribe) {
   const checkoutDidEnter$ = routeDidEnter(CHECKOUT_PATH);
 
   subscribe(checkoutDidEnter$, ({ getState }) => {
+    setPWAVisibleState(false);
+
     const state = getState();
 
     track('initiatedCheckout', { cart: getCart(state) }, state);

--- a/libraries/tracking/subscriptions/checkout.spec.js
+++ b/libraries/tracking/subscriptions/checkout.spec.js
@@ -1,0 +1,57 @@
+import getCart from '../selectors/cart';
+import * as helpers from '../helpers';
+import subscription from './checkout';
+
+jest.mock('@shopgate/pwa-common/streams/app', () => ({
+  appDidStart$: jest.fn(),
+}));
+
+jest.mock('@shopgate/pwa-common/streams/app', () => ({
+  appDidStart$: jest.fn(),
+}));
+
+jest.mock('../selectors/cart', () => state => state);
+
+jest.mock('@shopgate/pwa-core/commands/registerEvents', () => jest.fn());
+
+describe('Checkout subscriptions', () => {
+  const subscribe = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    subscription(subscribe);
+  });
+
+  it('should call subscribe as expected', () => {
+    expect(subscribe).toHaveBeenCalledTimes(2);
+  });
+
+  describe('checkoutDidEnter$', () => {
+    let callback;
+
+    beforeAll(() => {
+      [[, callback]] = subscribe.mock.calls;
+    });
+
+    it('should call the expected commands', () => {
+      const setPWAVisibleStateSpy = jest.spyOn(helpers, 'setPWAVisibleState');
+      const trackSpy = jest.spyOn(helpers, 'track');
+      /**
+       * Mocked getState function.
+       * @return {Object}
+       */
+      const getState = () => ({ mocked: 'state' });
+
+      callback({ getState });
+      expect(trackSpy).toHaveBeenCalledTimes(1);
+      expect(trackSpy).toHaveBeenCalledWith(
+        'initiatedCheckout',
+        { cart: getCart(getState()) },
+        getState()
+      );
+
+      expect(setPWAVisibleStateSpy).toHaveBeenCalledTimes(1);
+      expect(setPWAVisibleStateSpy).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/libraries/tracking/subscriptions/pages.js
+++ b/libraries/tracking/subscriptions/pages.js
@@ -3,7 +3,7 @@ import { searchIsReady$ } from '../streams/search';
 import { productIsReady$ } from '../streams/product';
 import { pagesAreReady$ } from '../streams/pages';
 import getTrackingData from '../selectors';
-import { track } from '../helpers/index';
+import { track } from '../helpers';
 
 /**
  * Calls the pageview core tracking function.

--- a/libraries/tracking/subscriptions/product.js
+++ b/libraries/tracking/subscriptions/product.js
@@ -6,7 +6,7 @@ import {
   getCurrentProductFormatted,
 } from '../selectors/product';
 import getPage from '../selectors/page';
-import { track } from '../helpers/index';
+import { track } from '../helpers';
 
 /**
  * Product tracking subscriptions.

--- a/libraries/tracking/subscriptions/setup.js
+++ b/libraries/tracking/subscriptions/setup.js
@@ -13,6 +13,7 @@ import {
 import UnifiedPlugin from '@shopgate/tracking-core/plugins/trackers/Unified';
 import { APP_EVENT_VIEW_DID_APPEAR } from '../constants';
 import { pwaDidAppear } from '../action-creators';
+import { setPWAVisibleState } from '../helpers';
 
 /**
  * Setup tracking subscriptions.
@@ -25,6 +26,7 @@ export default function setup(subscribe) {
     ]);
 
     event.addCallback(APP_EVENT_VIEW_DID_APPEAR, () => {
+      setPWAVisibleState(true);
       dispatch(pwaDidAppear());
     });
   });

--- a/libraries/tracking/subscriptions/setup.spec.js
+++ b/libraries/tracking/subscriptions/setup.spec.js
@@ -3,6 +3,7 @@ import registerEvents from '@shopgate/pwa-core/commands/registerEvents';
 import { appWillStart$ } from '@shopgate/pwa-common/streams/app';
 import { pwaDidAppear } from '../action-creators';
 import { APP_EVENT_VIEW_DID_APPEAR } from '../constants';
+import * as helpers from '../helpers';
 import subscription from './setup';
 
 jest.mock('@shopgate/pwa-core/classes/Event');
@@ -52,8 +53,13 @@ describe('setup subscriptions', () => {
     });
 
     it('should dispatch pwaDidAppear when the app event is triggered', () => {
+      const setPWAVisibleStateSpy = jest.spyOn(helpers, 'setPWAVisibleState');
+
       callback({ dispatch });
       event.call(APP_EVENT_VIEW_DID_APPEAR);
+      expect(setPWAVisibleStateSpy).toHaveBeenCalledTimes(1);
+      expect(setPWAVisibleStateSpy).toHaveBeenCalledWith(true);
+
       expect(dispatch).toHaveBeenCalledTimes(1);
       expect(dispatch).toHaveBeenCalledWith(pwaDidAppear());
     });


### PR DESCRIPTION
- prevented tracking event when PWA logic pop history entries when the user is redirected to the checkout