### PR TITLE
PWA-649: Input component bugfix

### DIFF
--- a/libraries/common/components/Input/components/SimpleInput.jsx
+++ b/libraries/common/components/Input/components/SimpleInput.jsx
@@ -116,6 +116,12 @@ class SimpleInput extends Component {
    * Internal blur event handler.
    */
   handleBlur = () => {
+    /**
+     * When switching between the PWA and legacy pages the handleFocus event calleback was sometime
+     * called in blurred state. By setting the input state explicitly this doesn't happen anymore.
+     */
+    this.ref.blur();
+
     const newState = {
       isFocused: false,
     };


### PR DESCRIPTION
- fixed an issue which caused focusing the input without user interaction when users switched between pwa and legacy pages