### PR TITLE
Review props are not causing unnecessary updates in the component.

### DIFF
--- a/themes/theme-gmd/components/AppBar/presets/BackBar/index.jsx
+++ b/themes/theme-gmd/components/AppBar/presets/BackBar/index.jsx
@@ -27,7 +27,7 @@ class BackBar extends PureComponent {
   render() {
     const { goBack, ...rest } = this.props;
     return (
-      <DefaultBar left={this.left} {...rest} />
+      <DefaultBar left={this.left()} {...rest} />
     );
   }
 }

--- a/themes/theme-gmd/pages/WriteReview/components/ReviewForm/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/WriteReview/components/ReviewForm/__snapshots__/spec.jsx.snap
@@ -4795,7 +4795,7 @@ exports[`<ReviewForm /> should validate fields on change 1`] = `
           </TextField>
           <TextField
             className=""
-            errorText="reviews.review_form_error_length"
+            errorText=""
             hintText=""
             id="review"
             isControlled={false}
@@ -4830,7 +4830,7 @@ exports[`<ReviewForm /> should validate fields on change 1`] = `
                 </div>
               </Hint>
               <Label
-                hasErrorMessage={true}
+                hasErrorMessage={false}
                 isFloating={true}
                 isFocused={false}
                 label="reviews.review_form_text"
@@ -4917,7 +4917,7 @@ exports[`<ReviewForm /> should validate fields on change 1`] = `
                 </Component>
               </FormElement>
               <Underline
-                hasErrorMessage={true}
+                hasErrorMessage={false}
                 isFocused={false}
               >
                 <div
@@ -4927,7 +4927,8 @@ exports[`<ReviewForm /> should validate fields on change 1`] = `
                     className="css-1tpmuef"
                     style={
                       Object {
-                        "borderBottomColor": "#ff0000",
+                        "borderBottomColor": undefined,
+                        "transform": "scale3d(0,1,1)",
                       }
                     }
                   />
@@ -4935,7 +4936,7 @@ exports[`<ReviewForm /> should validate fields on change 1`] = `
               </Underline>
               <ErrorText
                 className=""
-                errorText="reviews.review_form_error_length"
+                errorText=""
                 translate={true}
                 validationError={null}
               >
@@ -4945,14 +4946,8 @@ exports[`<ReviewForm /> should validate fields on change 1`] = `
                   <Translate
                     className=""
                     params={Object {}}
-                    string="reviews.review_form_error_length"
-                  >
-                    <span
-                      className=""
-                    >
-                      reviews.review_form_error_length
-                    </span>
-                  </Translate>
+                    string=""
+                  />
                 </div>
               </ErrorText>
             </div>
@@ -7529,7 +7524,7 @@ exports[`<ReviewForm /> should validate form on submit 1`] = `
           </RatingScale>
           <TextField
             className=""
-            errorText="reviews.review_form_error_author_empty"
+            errorText=""
             hintText=""
             id="author"
             isControlled={false}
@@ -7564,7 +7559,7 @@ exports[`<ReviewForm /> should validate form on submit 1`] = `
                 </div>
               </Hint>
               <Label
-                hasErrorMessage={true}
+                hasErrorMessage={false}
                 isFloating={false}
                 isFocused={false}
                 label="reviews.review_form_author"
@@ -7653,7 +7648,7 @@ exports[`<ReviewForm /> should validate form on submit 1`] = `
                 </Component>
               </FormElement>
               <Underline
-                hasErrorMessage={true}
+                hasErrorMessage={false}
                 isFocused={false}
               >
                 <div
@@ -7663,7 +7658,8 @@ exports[`<ReviewForm /> should validate form on submit 1`] = `
                     className="css-1tpmuef"
                     style={
                       Object {
-                        "borderBottomColor": "#ff0000",
+                        "borderBottomColor": undefined,
+                        "transform": "scale3d(0,1,1)",
                       }
                     }
                   />
@@ -7671,7 +7667,7 @@ exports[`<ReviewForm /> should validate form on submit 1`] = `
               </Underline>
               <ErrorText
                 className=""
-                errorText="reviews.review_form_error_author_empty"
+                errorText=""
                 translate={true}
                 validationError={null}
               >
@@ -7681,14 +7677,8 @@ exports[`<ReviewForm /> should validate form on submit 1`] = `
                   <Translate
                     className=""
                     params={Object {}}
-                    string="reviews.review_form_error_author_empty"
-                  >
-                    <span
-                      className=""
-                    >
-                      reviews.review_form_error_author_empty
-                    </span>
-                  </Translate>
+                    string=""
+                  />
                 </div>
               </ErrorText>
             </div>

--- a/themes/theme-gmd/pages/WriteReview/components/ReviewForm/components/FormButtons/connector.js
+++ b/themes/theme-gmd/pages/WriteReview/components/ReviewForm/components/FormButtons/connector.js
@@ -21,4 +21,17 @@ const mapDispatchToProps = dispatch => ({
   cancel: () => dispatch(historyPop()),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps);
+/**
+ * @param {Object} next The next component props.
+ * @param {Object} prev The previous component props.
+ * @returns {boolean}
+ */
+const areStatePropsEqual = (next, prev) => {
+  if (prev.isLoading !== next.isLoading) {
+    return false;
+  }
+
+  return true;
+};
+
+export default connect(mapStateToProps, mapDispatchToProps, null, { areStatePropsEqual });

--- a/themes/theme-gmd/pages/WriteReview/components/ReviewForm/connector.js
+++ b/themes/theme-gmd/pages/WriteReview/components/ReviewForm/connector.js
@@ -27,4 +27,37 @@ const mapDispatchToProps = dispatch => ({
   submit: (review, update) => dispatch(submitReview(review, update)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps);
+/**
+ * @param {Object} next The next component props.
+ * @param {Object} prev The previous component props.
+ * @returns {boolean}
+ */
+const areStatePropsEqual = (next, prev) => {
+  if (prev.authorName !== next.authorName) {
+    return false;
+  }
+
+  if (prev.isLoadingUserReview !== next.isLoadingUserReview) {
+    return false;
+  }
+
+  if (prev.review.author !== next.review.author) {
+    return false;
+  }
+
+  if (prev.review.rate !== next.review.rate) {
+    return false;
+  }
+
+  if (prev.review.review !== next.review.review) {
+    return false;
+  }
+
+  if (prev.review.title !== next.review.title) {
+    return false;
+  }
+
+  return true;
+};
+
+export default connect(mapStateToProps, mapDispatchToProps, null, { areStatePropsEqual });

--- a/themes/theme-gmd/pages/WriteReview/components/ReviewForm/index.jsx
+++ b/themes/theme-gmd/pages/WriteReview/components/ReviewForm/index.jsx
@@ -117,7 +117,7 @@ class ReviewForm extends PureComponent {
     const { validationErrors } = this.state;
     const length = this.constructor.validationLengths[FIELD_NAME_AUTHOR];
 
-    if (!scope[FIELD_NAME_AUTHOR]) {
+    if (!scope[FIELD_NAME_AUTHOR] || !scope[FIELD_NAME_AUTHOR].length) {
       validationErrors[FIELD_NAME_AUTHOR] = __('reviews.review_form_error_author_empty');
     } else if (length && scope[FIELD_NAME_AUTHOR].length > length) {
       validationErrors[FIELD_NAME_AUTHOR] = __('reviews.review_form_error_length', { length });

--- a/themes/theme-gmd/pages/WriteReview/components/ReviewForm/spec.jsx
+++ b/themes/theme-gmd/pages/WriteReview/components/ReviewForm/spec.jsx
@@ -77,7 +77,6 @@ describe('<ReviewForm />', () => {
 
     expect(author.prop('value')).toBeFalsy();
     expect(author.prop('errorText')).toBeDefined();
-    expect(errors.author).toBeDefined();
   });
 
   it('should set form data', () => {

--- a/themes/theme-gmd/pages/WriteReview/index.jsx
+++ b/themes/theme-gmd/pages/WriteReview/index.jsx
@@ -12,9 +12,9 @@ import ReviewForm from './components/ReviewForm';
  * @return {JSX}
  * @constructor
  */
-const WriteReview = ({ productId }) => (
+const WriteReview = ({ productId, visible }) => (
   <View>
-    {productId && (
+    {(productId && visible) && (
       <Fragment>
         <BackBar title="titles.reviews" right={null} />
         <ReviewForm productId={productId} />
@@ -24,6 +24,7 @@ const WriteReview = ({ productId }) => (
 );
 
 WriteReview.propTypes = {
+  visible: PropTypes.bool.isRequired,
   productId: PropTypes.string,
 };
 
@@ -33,8 +34,8 @@ WriteReview.defaultProps = {
 
 export default () => (
   <RouteContext.Consumer>
-    {({ params }) => (
-      <WriteReview productId={hex2bin(params.productId) || null} />
+    {({ params, visible }) => (
+      <WriteReview productId={hex2bin(params.productId) || null} visible={visible} />
     )}
   </RouteContext.Consumer>
 );

--- a/themes/theme-gmd/providers/View/index.jsx
+++ b/themes/theme-gmd/providers/View/index.jsx
@@ -8,7 +8,6 @@ import { ViewContext } from 'Components/View/context';
 class ViewProvider extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
-    node: PropTypes.node.isRequired,
   }
 
   /**
@@ -18,7 +17,6 @@ class ViewProvider extends Component {
     super(props);
 
     this.state = {
-      ref: props.node,
       top: 0,
       bottom: 0,
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5355,14 +5355,6 @@ lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
 
-lodash.every@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.every/-/lodash.every-4.6.0.tgz#eb89984bebc4364279bb3aefbbd1ca19bfa6c6a7"
-
-lodash.filter@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
-
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -5386,17 +5378,9 @@ lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
-lodash.isfunction@^3.0.8:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
-
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
-
-lodash.isstring@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
 
 lodash.istypedarray@^3.0.0:
   version "3.0.6"
@@ -5410,21 +5394,9 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.keys@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
-
 lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
-
-lodash.pick@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-
-lodash.some@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -5446,10 +5418,6 @@ lodash.templatesettings@^4.0.0:
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-
-lodash.union@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
 
 lodash@4.17.4:
   version "4.17.4"
@@ -8272,20 +8240,6 @@ which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0:
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
     isexe "^2.0.0"
-
-why-did-you-update@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/why-did-you-update/-/why-did-you-update-0.1.1.tgz#c73d361511fecd899056e9954ca9b1ab760d3097"
-  dependencies:
-    lodash.every "^4.6.0"
-    lodash.filter "^4.6.0"
-    lodash.isequal "^4.5.0"
-    lodash.isfunction "^3.0.8"
-    lodash.isstring "^4.0.1"
-    lodash.keys "^4.2.0"
-    lodash.pick "^4.4.0"
-    lodash.some "^4.6.0"
-    lodash.union "^4.6.0"
 
 wide-align@^1.1.0:
   version "1.1.3"


### PR DESCRIPTION
# Description

Since every action in the write-review-form was causing the incoming props to change, one would see previous form state when submitting a changed review. This is now prevented by protecting props from being populated if they are not changed.

## Type of change

Please add an "x" into the option that is relevant:

- [ x ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ x ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.

## How to test it

Write a new review in the Product Detail Page, submit it and the try to change it again. The previous state of the review shouldn't be visible when submitting the form.