### PR TITLE
Filters are now taken from the action when requesting

### DIFF
--- a/themes/theme-gmd/pages/Category/subscriptions.js
+++ b/themes/theme-gmd/pages/Category/subscriptions.js
@@ -1,3 +1,4 @@
+import { ENOTFOUND } from '@shopgate/pwa-core/constants/Pipeline';
 import getCurrentRoute from '@virtuous/conductor-helpers/getCurrentRoute';
 import { getActiveFilters } from '@shopgate/pwa-common-commerce/filter/selectors';
 import { historyPop } from '@shopgate/pwa-common/actions/router';
@@ -39,7 +40,7 @@ export default function category(subscribe) {
     const { errorCode } = action;
     let message = 'modal.body_error';
 
-    if (errorCode === 'ENOTFOUND') {
+    if (errorCode === ENOTFOUND) {
       message = 'category.error.not_found';
     }
 
@@ -52,10 +53,10 @@ export default function category(subscribe) {
     dispatch(historyPop());
   });
 
-  subscribe(categoryFiltersDidUpdate$, ({ dispatch }) => {
+  subscribe(categoryFiltersDidUpdate$, ({ action, dispatch }) => {
     const { params } = getCurrentRoute();
     const categoryId = hex2bin(params.categoryId);
-    const filters = getActiveFilters();
+    const { filters } = action;
 
     dispatch(fetchCategoryProducts({
       categoryId, filters,


### PR DESCRIPTION
# Description
When removing filters via the category route, the request for products now contains the current selection instead of the previous selection.

- [ x ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.