### PR TITLE
Added iOS styled headlines to category routes and widgets

### DIFF
--- a/themes/theme-gmd/components/FilterBar/components/Content/components/FilterButton/style.js
+++ b/themes/theme-gmd/components/FilterBar/components/Content/components/FilterButton/style.js
@@ -11,6 +11,7 @@ const button = css({
   height: variables.filterbar.height,
   position: 'relative',
   zIndex: 1,
+  overflow: 'hidden',
 }).toString();
 
 const filterButton = css({

--- a/themes/theme-gmd/pages/Category/components/Bar/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/Category/components/Bar/__snapshots__/spec.jsx.snap
@@ -369,7 +369,7 @@ exports[`<Bar /> should match snapshot 1`] = `
                             }
                           >
                             <button
-                              className="css-1x5kceo"
+                              className="css-1xhkstf"
                               data-test-id="filterButton"
                               onClick={[Function]}
                             >

--- a/themes/theme-ios11/components/FilterBar/components/Content/components/FilterButton/style.js
+++ b/themes/theme-ios11/components/FilterBar/components/Content/components/FilterButton/style.js
@@ -11,6 +11,7 @@ const button = css({
   height: variables.filterbar.height,
   position: 'relative',
   zIndex: 1,
+  overflow: 'hidden',
 }).toString();
 
 const filterButton = css({

--- a/themes/theme-ios11/components/Headline/index.jsx
+++ b/themes/theme-ios11/components/Headline/index.jsx
@@ -1,18 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Ellipsis from '@shopgate/pwa-common/components/Ellipsis';
+import I18n from '@shopgate/pwa-common/components/I18n';
 import styles from './style';
 
 /**
  * The headline component.
- * @param {string} props The component props.
+ * @param {Object} props The component props.
  * @returns {JSX}
  */
-const Headline = ({ text }) => (
-  text.length ? <h3 className={styles.headline}>{text}</h3> : null
-);
+const Headline = (props) => {
+  const className = props.small ? styles.small : styles.large;
+  const Component = props.small ? 'h2' : 'h1';
+
+  const hasContent = props.children || (props.text && props.text.length);
+
+  const content = props.children || <I18n.Text string={props.text} />;
+
+  return hasContent ? (
+    <Component className={className} data-test-id="greeting">
+      <Ellipsis rows={3}>
+        {content}
+      </Ellipsis>
+    </Component>) : null;
+};
 
 Headline.propTypes = {
-  text: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  small: PropTypes.bool,
+  text: PropTypes.string,
+};
+
+Headline.defaultProps = {
+  children: null,
+  small: false,
+  text: '',
 };
 
 export default Headline;

--- a/themes/theme-ios11/components/Headline/style.js
+++ b/themes/theme-ios11/components/Headline/style.js
@@ -1,12 +1,27 @@
 import { css } from 'glamor';
 import variables from 'Styles/variables';
 
-const headline = css({
-  fontSize: 18,
-  margin: `${variables.gap.big * 2}px 0 ${variables.gap.big}px`,
-  textAlign: 'center',
+const headline = {
+  fontWeight: 700,
+  lineHeight: 1.17,
+  wordBreak: ['keep-all', 'break-word'],
+  hyphens: 'auto',
+  display: 'inline-block',
+};
+
+const large = css({
+  ...headline,
+  fontSize: 34,
+  margin: `${variables.gap.small}px 20px 20px`,
+}).toString();
+
+const small = css({
+  ...headline,
+  fontSize: 22,
+  margin: `${variables.gap.big}px 20px 16px`,
 }).toString();
 
 export default {
-  headline,
+  large,
+  small,
 };

--- a/themes/theme-ios11/pages/Category/components/Bar/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Category/components/Bar/__snapshots__/spec.jsx.snap
@@ -369,7 +369,7 @@ exports[`<Bar /> should match snapshot 1`] = `
                             }
                           >
                             <button
-                              className="css-1x5kceo"
+                              className="css-1xhkstf"
                               data-test-id="filterButton"
                               onClick={[Function]}
                             >

--- a/themes/theme-ios11/pages/Category/components/Content/index.jsx
+++ b/themes/theme-ios11/pages/Category/components/Content/index.jsx
@@ -5,6 +5,7 @@ import Empty from '../Empty';
 import CategoryListContent from '../CategoryListContent';
 import connect from './connector';
 import AppBar from '../AppBar';
+import Headline from '../Headline';
 
 /**
  * @param {Object} props.categoryId The category id.
@@ -13,6 +14,7 @@ import AppBar from '../AppBar';
 const CategoryContent = ({ categoryId, hasChildren, hasProducts }) => (
   <Fragment>
     <AppBar hasProducts={hasProducts} hasChildren={hasChildren} />
+    <Headline />
     <CategoryListContent categoryId={categoryId} />
     <ProductsContent categoryId={categoryId} hasProducts={hasProducts} />
     <Empty

--- a/themes/theme-ios11/pages/Category/components/Headline/connector.js
+++ b/themes/theme-ios11/pages/Category/components/Headline/connector.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import { getCategoryName } from '@shopgate/pwa-common-commerce/category/selectors';
+
+/**
+ * Maps the contents of the state to the component props.
+ * @param {Object} state The current application state.
+ * @param {Object} props The component props.
+ * @return {Object} The extended component props.
+ */
+const mapStateToProps = (state, props) => ({
+  title: getCategoryName(state, props),
+});
+
+export default connect(mapStateToProps);

--- a/themes/theme-ios11/pages/Category/components/Headline/index.jsx
+++ b/themes/theme-ios11/pages/Category/components/Headline/index.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Headline from 'Components/Headline';
+import connect from './connector';
+import styles from './style';
+
+/**
+ * The CategoryHeadline component.
+ * @returns {JSX}
+ */
+function CategoryHeadline({ title }) {
+  return (
+    <div className={styles}>
+      <Headline text={title} />
+    </div>
+  );
+}
+
+CategoryHeadline.propTypes = {
+  title: PropTypes.string,
+};
+
+CategoryHeadline.defaultProps = {
+  title: '',
+};
+
+export default connect(CategoryHeadline);

--- a/themes/theme-ios11/pages/Category/components/Headline/style.js
+++ b/themes/theme-ios11/pages/Category/components/Headline/style.js
@@ -1,0 +1,7 @@
+import { css } from 'glamor';
+import colors from 'Styles/colors';
+
+export default css({
+  background: colors.light,
+  paddingTop: 12,
+});

--- a/themes/theme-ios11/pages/RootCategory/components/Headline/index.jsx
+++ b/themes/theme-ios11/pages/RootCategory/components/Headline/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Headline from 'Components/Headline';
+import styles from './style';
+
+/**
+ * The CategoryHeadline component.
+ * @returns {JSX}
+ */
+function CategoryHeadline() {
+  return (
+    <div className={styles}>
+      <Headline text="titles.categories" />
+    </div>
+  );
+}
+
+export default CategoryHeadline;

--- a/themes/theme-ios11/pages/RootCategory/components/Headline/style.js
+++ b/themes/theme-ios11/pages/RootCategory/components/Headline/style.js
@@ -1,0 +1,7 @@
+import { css } from 'glamor';
+import colors from 'Styles/colors';
+
+export default css({
+  background: colors.light,
+  paddingTop: 12,
+});

--- a/themes/theme-ios11/pages/RootCategory/index.jsx
+++ b/themes/theme-ios11/pages/RootCategory/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import CategoryList from 'Components/CategoryList';
 import View from 'Components/View';
 import { BackBar } from 'Components/AppBar/presets';
+import Headline from './components/Headline';
 import connect from './connector';
 
 /**
@@ -24,6 +25,7 @@ class RootCategory extends PureComponent {
     return (
       <View>
         <BackBar title="titles.categories" />
+        <Headline text="titles.categories" />
         <CategoryList categories={this.props.categories} prerender={8} />
       </View>
     );

--- a/themes/theme-ios11/widgets/CategoryList/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/widgets/CategoryList/__snapshots__/spec.jsx.snap
@@ -45,11 +45,46 @@ exports[`<CategoryListWidget /> should render the CategoryListWidget 1`] = `
     className="css-1tgouoh"
     data-test-id="categoryList"
   >
-    <h3
-      className="css-twewb4"
+    <Headline
+      small={true}
+      text="Yay Categories"
     >
-      Yay Categories
-    </h3>
+      <h2
+        className="css-1j7zrmn"
+        data-test-id="greeting"
+      >
+        <Ellipsis
+          className=""
+          ellipsis="..."
+          rows={3}
+        >
+          <Dotdotdot
+            clamp={3}
+            className=""
+            ellipsis="..."
+            tagName="div"
+            truncationChar="…"
+            useNativeClamp={true}
+          >
+            <div
+              className=""
+            >
+              <Translate
+                className=""
+                params={Object {}}
+                string="Yay Categories"
+              >
+                <span
+                  className=""
+                >
+                  Yay Categories
+                </span>
+              </Translate>
+            </div>
+          </Dotdotdot>
+        </Ellipsis>
+      </h2>
+    </Headline>
     <List
       className={null}
       hasImages={false}

--- a/themes/theme-ios11/widgets/CategoryList/index.jsx
+++ b/themes/theme-ios11/widgets/CategoryList/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { bin2hex } from '@shopgate/pwa-common/helpers/data';
 import Image from '@shopgate/pwa-common/components/Image';
 import List from 'Components/List';
+import Headline from 'Components/Headline';
 import isEqual from 'lodash/isEqual';
 import connect from './connector';
 import styles from './style';
@@ -55,7 +56,7 @@ class CategoryListWidget extends Component {
 
     return (
       <div className={styles.container} data-test-id="categoryList">
-        {(settings.headline) ? <h3 className={styles.headline}>{settings.headline}</h3> : null}
+        {(settings.headline) ? <Headline text={settings.headline} small /> : null}
         <List hasImages={settings.showImages}>
           {items.map((item) => {
             // We have to decode the link before using it.

--- a/themes/theme-ios11/widgets/ProductSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/widgets/ProductSlider/__snapshots__/spec.jsx.snap
@@ -6,11 +6,10 @@ exports[`<ProductSlider /> should limit output to a maximum of 30 products 1`] =
 <div
   className="css-1qazn57"
 >
-  <h3
-    className="css-rsku8h"
-  >
-    Lorem ipsum
-  </h3>
+  <Headline
+    small={true}
+    text="Lorem ipsum"
+  />
   <Connect(Slider)
     autoPlay={false}
     classNames={
@@ -1387,11 +1386,10 @@ exports[`<ProductSlider /> should render the headline 1`] = `
 <div
   className="css-1qazn57"
 >
-  <h3
-    className="css-rsku8h"
-  >
-    Lorem ipsum
-  </h3>
+  <Headline
+    small={true}
+    text="Lorem ipsum"
+  />
   <Connect(Slider)
     autoPlay={false}
     classNames={

--- a/themes/theme-ios11/widgets/ProductSlider/index.jsx
+++ b/themes/theme-ios11/widgets/ProductSlider/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Slider from '@shopgate/pwa-common/components/Slider';
 import Card from '@shopgate/pwa-ui-shared/Card';
 import ProductCard from 'Components/ProductCard';
+import Headline from 'Components/Headline';
 import { transformDisplayOptions } from '@shopgate/pwa-common/helpers/data';
 import connect from './connector';
 import styles from './style';
@@ -92,9 +93,7 @@ class ProductSlider extends Component {
   renderHeadline = () => {
     if (this.props.settings.headline) {
       return (
-        <h3 className={styles.headline}>
-          {this.props.settings.headline}
-        </h3>
+        <Headline text={this.props.settings.headline} small />
       );
     }
 

--- a/themes/theme-ios11/widgets/ProductSlider/spec.jsx
+++ b/themes/theme-ios11/widgets/ProductSlider/spec.jsx
@@ -145,7 +145,7 @@ describe('<ProductSlider />', () => {
     />);
 
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('h3').length).toBe(0);
+    expect(wrapper.find('Headline').length).toBe(0);
   });
 
   it('should render the headline', () => {
@@ -157,7 +157,7 @@ describe('<ProductSlider />', () => {
     />);
 
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('h3').length).toBe(1);
+    expect(wrapper.find('Headline').length).toBe(1);
   });
 
   it('should limit output to a maximum of 30 products', () => {

--- a/themes/theme-ios11/widgets/ProductSlider/style.js
+++ b/themes/theme-ios11/widgets/ProductSlider/style.js
@@ -1,6 +1,5 @@
 import { css } from 'glamor';
 import colors from 'Styles/colors';
-import variables from 'Styles/variables';
 
 const sliderContainer = css({
   marginLeft: 'auto',
@@ -62,15 +61,8 @@ const card = css({
   margin: '0px 8px',
 }).toString();
 
-const headline = css({
-  fontSize: 18,
-  margin: `0 0 ${variables.gap.big}px`,
-  textAlign: 'center',
-}).toString();
-
 export default {
   card,
-  headline,
   sliderContainer,
   slider,
   sliderItem,

--- a/themes/theme-ios11/widgets/Products/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/widgets/Products/__snapshots__/spec.jsx.snap
@@ -7,6 +7,7 @@ exports[`<ProductsWidget /> should render the products in the list view 1`] = `
   className="css-13tch1f"
 >
   <Headline
+    small={true}
     text=""
   />
   <ProductList

--- a/themes/theme-ios11/widgets/Products/index.jsx
+++ b/themes/theme-ios11/widgets/Products/index.jsx
@@ -171,7 +171,7 @@ class ProductsWidget extends Component {
 
     return (
       <div {...isList ? { className: styles.listView } : {}}>
-        <Headline text={headline} />
+        <Headline text={headline} small />
         <ProductComponent
           flags={flags}
           infiniteLoad={false}


### PR DESCRIPTION
# Description
This ticket adds iOS styled headlines to the root category, the common category route and widgets.

## Type of change

- [  ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ x ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.
