### PR TITLE
Added default limit for getProductsRelations action

### DIFF
--- a/libraries/commerce/product/actions/getProductRelations.js
+++ b/libraries/commerce/product/actions/getProductRelations.js
@@ -7,6 +7,7 @@ import errorProductRelations from '../action-creators/errorProductRelations';
 import { SHOPGATE_CATALOG_GET_PRODUCT_RELATIONS } from '../constants/Pipelines';
 import { generateProductRelationsHash } from '../helpers';
 import { getProductRelationsState } from '../selectors/relations';
+import { PRODUCT_RELATIONS_DEFAULT_LIMIT } from '../constants/';
 
 /**
  * Action starts product relation fetching process.
@@ -17,7 +18,7 @@ import { getProductRelationsState } from '../selectors/relations';
  * @param {number} params.limit Query limit.
  * @returns {Function}
  */
-const getProductRelations = ({ productId, type, limit }) =>
+const getProductRelations = ({ productId, type, limit = PRODUCT_RELATIONS_DEFAULT_LIMIT }) =>
   (dispatch, getState) => {
     const pipeline = SHOPGATE_CATALOG_GET_PRODUCT_RELATIONS;
     const hash = generateProductRelationsHash({


### PR DESCRIPTION
# Description

Added default limit for getProductsRelations action which causes inconsistency between the real fetch and it's hash.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.

## How to test it

Review only needed.