### PR TITLE
CartButton and SearchButton are now reliably hidden on cart page

### DIFF
--- a/themes/theme-gmd/pages/subscribers.js
+++ b/themes/theme-gmd/pages/subscribers.js
@@ -33,6 +33,7 @@ import search from 'Pages/Search/subscriptions';
 import reviews from 'Pages/Reviews/subscriptions';
 import filterbar from 'Components/FilterBar/subscriptions';
 import writeReview from 'Pages/WriteReview/subscriptions';
+import cart from 'Pages/Cart/subscriptions';
 import appConfig from '@shopgate/pwa-common/helpers/config';
 // Extensions
 import extensions from 'Extensions/subscribers';
@@ -73,6 +74,7 @@ const subscriptions = [
   search,
   reviews,
   writeReview,
+  cart,
   // Extensions
   ...extensions,
 ];


### PR DESCRIPTION
# Description
Re-added the cart subscriptions to the page subscribers, so that the buttons are hidden when the cart page appears.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.

## How to test it
- put some products into the cart
- goto the cart page
- press the checkout button
- leave the login form via the close button
- the navigator should not show the SearchButton or the CartButton