### PR TITLE
Introduced automatic creation of github releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,16 @@ RELEASE_NAME = v$(patsubst v%,%, $(strip $(RELEASE_VERSION)))
 BETA = $(findstring beta, $(RELEASE_NAME))
 ifeq ("$(BETA)", "beta")
 	BETA = "true"
+  PRE_RELEASE = true
 else
 	BETA = "false"
+  PRE_RELEASE = false
 endif
 
 # This causes the Github-API to create draft releases only, without creating tags
 DRAFT_RELEASE = true
+
+
 
 checkout-develop:
 		git checkout origin/develop
@@ -71,7 +75,8 @@ release:
 		$(call build-library-packages)
 		$(call publish-npm-packages)
 		make publish-to-github
-		#(call finalize-release)
+		$(call create-github-releases)
+		$(call finalize-release)
 
 
 
@@ -288,6 +293,27 @@ endef
 
 
 
+# CREATE-GITHUB-RELEASEES ##########################################################################
+
+define create-github-releases
+		$(call create-github-release,$(RELEASE_NAME),releases/$(RELEASE_NAME),pwa)
+		$(foreach theme, $(THEMES),$(call create-github-release,$(RELEASE_NAME),releases/$(RELEASE_NAME),$(call map-theme-to-repo-name,$(theme))))
+		$(foreach extension, $(EXTENSIONS), $(call create-github-release,$(RELEASE_NAME),releases/$(RELEASE_NAME),$(call map-extension-to-repo-name,$(extension))))
+
+endef
+
+define map-theme-to-repo-name
+		$(patsubst @shopgate-%,ext-%,$(1))
+
+endef
+
+define map-extension-to-repo-name
+		$(patsubst ext-tracking-ga-native,tracking-ga-native,$(patsubst @shopgate-%,ext-%,$(1)))
+
+endef
+
+
+
 # define changelog
 # 		@echo "============================================================"
 # 		@echo "| Creating changelog ..."
@@ -301,45 +327,43 @@ endef
 #
 # endef
 
-#
-# define finalize-release
+define finalize-release
 # 		@echo "============================================================"
 # 		@echo "| Finishing release of version $(RELEASE_VERSION)"
 # 		@echo "============================================================"
 # 		@echo " "
 #
 ## 		# Cleanup by removing beta branches via github api
-#
-# 		@echo " "
-# 		@echo "============================================================"
-# 		@echo "| Done releasing!"
-# 		@echo "============================================================"
-# 		@echo " "
-#
-# endef
+		@echo " ";
+		@echo "============================================================";
+		@echo "| Done releasing!";
+		@echo "============================================================";
+		@echo " ";
+
+endef
 
 
 
-# GITHUB API HELPER FUNCTIONS ######################################################################
+####################################################################################################
+# GITHUB API HELPER FUNCTIONS
+####################################################################################################
 
-create-github-release:
-ifeq ($(BETA), "false")
-		curl -X POST --silent --data '{"tag_name": "$(1)","target_commitish": "$(2)","name": "","body": "","draft": $(DRAFT_RELEASE),"prerelease": true}' -H "Content-Type: application/json" -H "Authorization: token $(GITHUB_AUTH_TOKEN)" https://api.github.com/repos/shopgate/$(strip $(3))/releases 2>&1 | grep '^  "id":' | cut -d' ' -f 4 | cut -d',' -f 1
-else
-		curl -X POST --silent --data '{"tag_name": "$(1)","target_commitish": "$(2)","name": "","body": "","draft": $(DRAFT_RELEASE),"prerelease": false}' -H "Content-Type: application/json" -H "Authorization: token $(GITHUB_AUTH_TOKEN)" https://api.github.com/repos/shopgate/$(strip $(3))/releases 2>&1 | grep '^  "id":' | cut -d' ' -f 4 | cut -d',' -f 1
-endif
+define create-github-release
+		curl -X POST --silent --data '{"tag_name": "$(1)","target_commitish": "$(2)","name": "$(1)","body": "","draft": $(DRAFT_RELEASE),"prerelease": $(strip $(PRE_RELEASE))}' -H "Content-Type: application/json" -H "Authorization: token $(GITHUB_AUTH_TOKEN)" https://api.github.com/repos/shopgate/$(strip $(3))/releases 2>&1 | grep '^  "id":' | cut -d' ' -f 4 | cut -d',' -f 1;
+
+endef
 
 # define delete-github-release
-# 		curl -X DELETE --silent -H "Authorization: token $(GITHUB_AUTH_TOKEN)" https://api.github.com/repos/shopgate/$(strip $(1))/releases/$(strip $(2)) 2>&1 | cat
+# 		curl -X DELETE --silent -H "Authorization: token $(GITHUB_AUTH_TOKEN)" https://api.github.com/repos/shopgate/$(strip $(1))/releases/$(strip $(2)) 2>&1 | cat;
 #
 # endef
 #
 # define delete-github-branch
-# 		curl -X DELETE --silent -H "Authorization: token $(GITHUB_AUTH_TOKEN)" https://api.github.com/repos/shopgate/$(strip $(1))/git/refs/heads/$(strip $(2)) 2>&1 | cat
+# 		curl -X DELETE --silent -H "Authorization: token $(GITHUB_AUTH_TOKEN)" https://api.github.com/repos/shopgate/$(strip $(1))/git/refs/heads/$(strip $(2)) 2>&1 | cat;
 #
 # endef
 #
 # define delete-github-tag
-# 		curl -X DELETE --silent -H "Authorization: token $(GITHUB_AUTH_TOKEN)" https://api.github.com/repos/shopgate/$(strip $(1))/git/refs/tags/$(strip $(2)) 2>&1 | cat
+# 		curl -X DELETE --silent -H "Authorization: token $(GITHUB_AUTH_TOKEN)" https://api.github.com/repos/shopgate/$(strip $(1))/git/refs/tags/$(strip $(2)) 2>&1 | cat;
 #
 # endef


### PR DESCRIPTION
# Description

This change introduces a simplification of the release process by automatically creating drafts for github releases within all related repositories.

## Type of change

Please add an "x" into the option that is relevant:

- [  ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [ x ] Internal :house: Only relates to internal processes.

## How to test it

Create a beta release and check if there are github release drafts created in the dedicated repositories.