### PR TITLE
Split availability text and stock information on product details page.

### DIFF
--- a/libraries/commerce/product/constants/Portals.js
+++ b/libraries/commerce/product/constants/Portals.js
@@ -18,6 +18,7 @@ const INFO = 'info';
 const MANUFACTURER = 'manufacturer';
 const SHIPPING = 'shipping';
 const AVAILABILITY = 'availability';
+const STOCK_INFO = 'stock-info';
 const PRICE_STRIKED = 'price-striked';
 const PRICE = 'price';
 const PRICE_INFO = 'price-info';
@@ -78,6 +79,11 @@ export const PRODUCT_SHIPPING_AFTER = `${PRODUCT}.${SHIPPING}.${AFTER}`;
 export const PRODUCT_AVAILABILITY_BEFORE = `${PRODUCT}.${AVAILABILITY}.${BEFORE}`;
 export const PRODUCT_AVAILABILITY = `${PRODUCT}.${AVAILABILITY}`;
 export const PRODUCT_AVAILABILITY_AFTER = `${PRODUCT}.${AVAILABILITY}.${AFTER}`;
+
+// STOCK INFO
+export const PRODUCT_STOCK_INFO_BEFORE = `${PRODUCT}.${STOCK_INFO}.${BEFORE}`;
+export const PRODUCT_STOCK_INFO = `${PRODUCT}.${STOCK_INFO}`;
+export const PRODUCT_STOCK_INFO_AFTER = `${PRODUCT}.${STOCK_INFO}.${AFTER}`;
 
 // PRICE STRIKED
 export const PRODUCT_PRICE_STRIKED_BEFORE = `${PRODUCT}.${PRICE_STRIKED}.${BEFORE}`;

--- a/themes/theme-gmd/pages/Product/components/Header/components/Availability/connector.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Availability/connector.js
@@ -1,13 +1,26 @@
 import { connect } from 'react-redux';
-import { getProductAvailability } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import { getCurrentProductStock } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import { AVAILABILITY_STATE_OK } from '@shopgate/pwa-common-commerce/product/constants';
 
 /**
  * Maps the contents of the state to the component props.
  * @param {Object} state The current application state.
  * @return {Object} The extended component props.
  */
-const mapStateToProps = state => ({
-  availability: getProductAvailability(state),
-});
+const mapStateToProps = (state) => {
+  const stock = getCurrentProductStock(state);
+  if (!stock) {
+    return {
+      availability: null,
+    };
+  }
+  return {
+    /* Show stock info always as availability on PDP */
+    availability: {
+      text: stock.info,
+      state: AVAILABILITY_STATE_OK,
+    },
+  };
+};
 
 export default connect(mapStateToProps);

--- a/themes/theme-gmd/pages/Product/components/Header/components/StockInfo/connector.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/StockInfo/connector.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+import { getProductAvailability } from '@shopgate/pwa-common-commerce/product/selectors/product';
+
+/**
+ * Maps the contents of the state to the component props.
+ * @param {Object} state The current application state.
+ * @return {Object} The extended component props.
+ */
+const mapStateToProps = state => ({
+  stock: getProductAvailability(state),
+});
+
+export default connect(mapStateToProps);

--- a/themes/theme-gmd/pages/Product/components/Header/components/StockInfo/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/StockInfo/index.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import PlaceholderLabel from '@shopgate/pwa-ui-shared/PlaceholderLabel';
+import AvailableText from '@shopgate/pwa-ui-shared/Availability';
+import connect from './connector';
+import styles from './style';
+
+/**
+ * The StockInfo component.
+ * @param {Object} props The component props.
+ * @return {JSX}
+ */
+const StockInfo = ({ stock }) => (
+  <PlaceholderLabel className={styles.placeholder} ready={(stock !== null)}>
+    {stock && (
+      <AvailableText
+        className={styles.availability}
+        showWhenAvailable={false}
+        text={stock.text}
+        state={stock.state}
+      />
+    )}
+  </PlaceholderLabel>
+);
+
+StockInfo.propTypes = {
+  stock: PropTypes.shape(),
+};
+
+StockInfo.defaultProps = {
+  stock: null,
+};
+
+export default connect(StockInfo);

--- a/themes/theme-gmd/pages/Product/components/Header/components/StockInfo/style.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/StockInfo/style.js
@@ -1,0 +1,17 @@
+import { css } from 'glamor';
+
+const placeholder = css({
+  height: 16,
+  width: '70%',
+  marginTop: 5,
+  marginBottom: 2,
+}).toString();
+
+const availability = css({
+  fontSize: '0.875rem',
+}).toString();
+
+export default {
+  placeholder,
+  availability,
+};

--- a/themes/theme-gmd/pages/Product/components/Header/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/index.jsx
@@ -10,6 +10,7 @@ import Manufacturer from './components/Manufacturer';
 import PriceStriked from './components/PriceStriked';
 import Shipping from './components/Shipping';
 import Availability from './components/Availability';
+import StockInfo from './components/StockInfo';
 import Price from './components/Price';
 import PriceInfo from './components/PriceInfo';
 import Tiers from './components/Tiers';
@@ -81,6 +82,15 @@ const ProductHeader = () => (
                 <Availability />
               </Portal>
               <Portal name={portals.PRODUCT_AVAILABILITY_AFTER} />
+            </div>
+
+            {/* STOCK INFO */}
+            <div className={styles.productInfo}>
+              <Portal name={portals.PRODUCT_STOCK_INFO_BEFORE} />
+              <Portal name={portals.PRODUCT_STOCK_INFO}>
+                <StockInfo />
+              </Portal>
+              <Portal name={portals.PRODUCT_STOCK_INFO_AFTER} />
             </div>
 
           </Portal>

--- a/themes/theme-ios11/pages/Product/components/Header/components/Availability/connector.js
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Availability/connector.js
@@ -1,13 +1,26 @@
 import { connect } from 'react-redux';
-import { getProductAvailability } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import { getCurrentProductStock } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import { AVAILABILITY_STATE_OK } from '@shopgate/pwa-common-commerce/product/constants';
 
 /**
  * Maps the contents of the state to the component props.
  * @param {Object} state The current application state.
  * @return {Object} The extended component props.
  */
-const mapStateToProps = state => ({
-  availability: getProductAvailability(state),
-});
+const mapStateToProps = (state) => {
+  const stock = getCurrentProductStock(state);
+  if (!stock) {
+    return {
+      availability: null,
+    };
+  }
+  return {
+    /* Show stock info always as availability on PDP */
+    availability: {
+      text: stock.info,
+      state: AVAILABILITY_STATE_OK,
+    },
+  };
+};
 
 export default connect(mapStateToProps);

--- a/themes/theme-ios11/pages/Product/components/Header/components/StockInfo/connector.js
+++ b/themes/theme-ios11/pages/Product/components/Header/components/StockInfo/connector.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+import { getProductAvailability } from '@shopgate/pwa-common-commerce/product/selectors/product';
+
+/**
+ * Maps the contents of the state to the component props.
+ * @param {Object} state The current application state.
+ * @return {Object} The extended component props.
+ */
+const mapStateToProps = state => ({
+  stock: getProductAvailability(state),
+});
+
+export default connect(mapStateToProps);

--- a/themes/theme-ios11/pages/Product/components/Header/components/StockInfo/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/StockInfo/index.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import PlaceholderLabel from '@shopgate/pwa-ui-shared/PlaceholderLabel';
+import AvailableText from '@shopgate/pwa-ui-shared/Availability';
+import connect from './connector';
+import styles from './style';
+
+/**
+ * The StockInfo component.
+ * @param {Object} props The component props.
+ * @return {JSX}
+ */
+const StockInfo = ({ stock }) => (
+  <PlaceholderLabel className={styles.placeholder} ready={(stock !== null)}>
+    {stock && (
+      <AvailableText
+        className={styles.availability}
+        showWhenAvailable={false}
+        text={stock.text}
+        state={stock.state}
+      />
+    )}
+  </PlaceholderLabel>
+);
+
+StockInfo.propTypes = {
+  stock: PropTypes.shape(),
+};
+
+StockInfo.defaultProps = {
+  stock: null,
+};
+
+export default connect(StockInfo);

--- a/themes/theme-ios11/pages/Product/components/Header/components/StockInfo/style.js
+++ b/themes/theme-ios11/pages/Product/components/Header/components/StockInfo/style.js
@@ -1,0 +1,17 @@
+import { css } from 'glamor';
+
+const placeholder = css({
+  height: 16,
+  width: '70%',
+  marginTop: 5,
+  marginBottom: 2,
+}).toString();
+
+const availability = css({
+  fontSize: '0.875rem',
+}).toString();
+
+export default {
+  placeholder,
+  availability,
+};

--- a/themes/theme-ios11/pages/Product/components/Header/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/index.jsx
@@ -10,6 +10,7 @@ import Manufacturer from './components/Manufacturer';
 import PriceStriked from './components/PriceStriked';
 import Shipping from './components/Shipping';
 import Availability from './components/Availability';
+import StockInfo from './components/StockInfo';
 import Price from './components/Price';
 import PriceInfo from './components/PriceInfo';
 import Tiers from './components/Tiers';
@@ -81,6 +82,15 @@ const ProductHeader = () => (
               <Availability />
             </Portal>
             <Portal name={portals.PRODUCT_AVAILABILITY_AFTER} />
+          </div>
+
+          {/* STOCK INFO */}
+          <div className={styles.productInfo}>
+            <Portal name={portals.PRODUCT_STOCK_INFO_BEFORE} />
+            <Portal name={portals.PRODUCT_STOCK_INFO}>
+              <StockInfo />
+            </Portal>
+            <Portal name={portals.PRODUCT_STOCK_INFO_AFTER} />
           </div>
 
         </Portal>


### PR DESCRIPTION
# Description

Split availability text and stock information on product details page. Add portals to surround stock information.
## Type of change

Please add an "x" into the option that is relevant:

- [ X ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.