### PR TITLE
Added AppBar to product gallery to be able to go back

### DIFF
--- a/libraries/ui-ios/AppBar/components/Icon/index.jsx
+++ b/libraries/ui-ios/AppBar/components/Icon/index.jsx
@@ -25,7 +25,7 @@ class AppBarIcon extends PureComponent {
    */
   render() {
     const {
-      background, badge: Badge, color, icon: Icon, onClick,
+      background, badge: Badge, color, icon: Icon, onClick, ...iconProps
     } = this.props;
 
     return (
@@ -37,7 +37,7 @@ class AppBarIcon extends PureComponent {
           color,
         }}
       >
-        <Icon />
+        <Icon {...iconProps} />
         {Badge && <Badge />}
       </button>
     );

--- a/libraries/ui-ios/AppBar/index.jsx
+++ b/libraries/ui-ios/AppBar/index.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import Field from './components/Field';
 import Icon from './components/Icon';
 import Title from './components/Title';
@@ -13,6 +14,7 @@ class AppBar extends PureComponent {
     backgroundColor: PropTypes.string,
     below: PropTypes.shape(),
     center: PropTypes.shape(),
+    classes: PropTypes.shape(),
     left: PropTypes.shape(),
     right: PropTypes.shape(),
     textColor: PropTypes.string,
@@ -22,6 +24,7 @@ class AppBar extends PureComponent {
     backgroundColor: 'linear-gradient(to bottom, #fff 0%, rgba(255, 255, 255, 0.85) 60%)',
     below: null,
     center: null,
+    classes: { inner: '', outer: '' },
     left: null,
     right: null,
     textColor: '#000',
@@ -48,17 +51,17 @@ class AppBar extends PureComponent {
    */
   render() {
     const {
-      below, center, left, right,
+      below, center, left, right, classes,
     } = this.props;
 
     return (
       <header
-        className={styles.outer}
+        className={classnames(styles.outer, classes.outer)}
         data-test-id="Navigator"
         role="banner"
         style={this.style}
       >
-        <div className={styles.inner}>
+        <div className={classnames(styles.inner, classes.inner)}>
           {left}
           {center}
           {right}

--- a/libraries/ui-ios/AppBar/style.js
+++ b/libraries/ui-ios/AppBar/style.js
@@ -7,14 +7,14 @@ const outer = css({
   top: 0,
   width: '100%',
   zIndex: 2,
-});
+}).toString();
 
 const inner = css({
   display: 'flex',
   justifyContent: 'space-between',
   position: 'relative',
   zIndex: 1,
-});
+}).toString();
 
 export default {
   outer,

--- a/themes/theme-ios11/pages/ProductGallery/components/AppBar/connector.js
+++ b/themes/theme-ios11/pages/ProductGallery/components/AppBar/connector.js
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+import { historyPop } from '@shopgate/pwa-common/actions/router';
+
+/**
+ * @param {Function} dispatch The store dispatch method.
+ * @return {Object} The extended component props.
+ */
+const mapDispatchToProps = dispatch => ({
+  goBack: () => dispatch(historyPop()),
+});
+
+export default connect(null, mapDispatchToProps);

--- a/themes/theme-ios11/pages/ProductGallery/components/AppBar/index.jsx
+++ b/themes/theme-ios11/pages/ProductGallery/components/AppBar/index.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DefaultBar } from 'Components/AppBar/presets';
+import { AppBar } from '@shopgate/pwa-ui-ios';
+import { ArrowIcon } from '@shopgate/pwa-ui-shared';
+import styles from './styles';
+import connect from './connector';
+
+/**
+ * The CategoryAppBar component.
+ * @returns {JSX}
+ */
+const GalleryAppBar = ({ goBack }) => (
+  <DefaultBar
+    classes={{ outer: styles.outer }}
+    backgroundColor="rgba(0, 0, 0, 0)"
+    textColor="#fff"
+    left={<AppBar.Icon icon={ArrowIcon} onClick={goBack} shadow />}
+  />
+);
+
+GalleryAppBar.propTypes = {
+  goBack: PropTypes.func.isRequired,
+};
+
+export default connect(GalleryAppBar);

--- a/themes/theme-ios11/pages/ProductGallery/components/AppBar/styles.js
+++ b/themes/theme-ios11/pages/ProductGallery/components/AppBar/styles.js
@@ -1,0 +1,10 @@
+import { css } from 'glamor';
+
+const outer = css({
+  backdropFilter: 'none',
+}).toString();
+
+export default {
+  outer,
+};
+

--- a/themes/theme-ios11/pages/ProductGallery/index.jsx
+++ b/themes/theme-ios11/pages/ProductGallery/index.jsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { hex2bin } from '@shopgate/pwa-common/helpers/data';
 import { RouteContext } from '@virtuous/react-conductor/Router';
 import View from 'Components/View';
 import ProductGalleryContent from './components/Content';
+import ProductGalleryAppBar from './components/AppBar';
 
 /**
  * @param {Object} props The component props.
@@ -11,7 +12,12 @@ import ProductGalleryContent from './components/Content';
  */
 const ProductGallery = ({ id, initialSlide }) => (
   <View>
-    {id && <ProductGalleryContent productId={id} initialSlide={initialSlide} />}
+    {id && (
+      <Fragment>
+        <ProductGalleryAppBar />
+        <ProductGalleryContent productId={id} initialSlide={initialSlide} />
+      </Fragment>
+    )}
   </View>
 );
 


### PR DESCRIPTION
# Description

Added the transparent app bar back to the product gallery page so that iOS users can still navigate back.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.
