### PR TITLE
Fixed an inAppBrowser issue where previous opened pages got visible again

### DIFF
--- a/libraries/common/components/Router/helpers/parsed-link/actions.js
+++ b/libraries/common/components/Router/helpers/parsed-link/actions.js
@@ -31,6 +31,7 @@ const externalLink = (url) => {
     previewSrc: 'sgapi:page_preview',
     emulateBrowser: true,
     targetTab: 'in_app_browser',
+    animated: false,
     navigationBarParams: {
       type: 'in-app-browser-default',
       popTab: 'in_app_browser',

--- a/libraries/common/components/Router/helpers/parsed-link/actions.js
+++ b/libraries/common/components/Router/helpers/parsed-link/actions.js
@@ -45,8 +45,6 @@ const externalLink = (url) => {
  * @param {string} options.url Link url.
  * @param {string} options.targetTab Target tab where the page should be opened.
  * @param {string} options.navigationType Type of the navigation bar that should be displayed.
- * @param {string} options.popTabToRoot Type of the navigation bar that should be displayed.
- * @param {string} options.flushTab The tab that should be flushed
  * @param {string} options.backCallback
  *   Javascript callback that is executed when hitting the back button.
  */

--- a/libraries/common/components/Router/helpers/parsed-link/actions.js
+++ b/libraries/common/components/Router/helpers/parsed-link/actions.js
@@ -1,6 +1,4 @@
-import flushTab from '@shopgate/pwa-core/commands/flushTab';
 import openPage from '@shopgate/pwa-core/commands/openPage';
-import popTabToRoot from '@shopgate/pwa-core/commands/popTabToRoot';
 import showTab from '@shopgate/pwa-core/commands/showTab';
 import { getPageContext } from '../../../../helpers/legacy';
 import { isFunction } from '../../../../helpers/validation';
@@ -39,10 +37,6 @@ const externalLink = (url) => {
       animation: 'none',
     },
   });
-
-  flushTab({
-    targetTab: 'in_app_browser',
-  });
 };
 
 /**
@@ -78,18 +72,6 @@ const legacyLink = (options) => {
 
   if (options.targetTab) {
     showTab({
-      targetTab: options.targetTab,
-    });
-  }
-
-  if (options.flushTab) {
-    flushTab({
-      targetTab: options.flushTab,
-    });
-  }
-
-  if (options.popTabToRoot) {
-    popTabToRoot({
       targetTab: options.targetTab,
     });
   }

--- a/libraries/common/components/Router/helpers/parsed-link/actions.spec.js
+++ b/libraries/common/components/Router/helpers/parsed-link/actions.spec.js
@@ -48,6 +48,7 @@ describe('Tests link actions', () => {
         previewSrc: 'sgapi:page_preview',
         emulateBrowser: true,
         targetTab: 'in_app_browser',
+        animated: false,
         navigationBarParams: {
           type: 'in-app-browser-default',
           popTab: 'in_app_browser',

--- a/libraries/common/components/Router/helpers/parsed-link/actions.spec.js
+++ b/libraries/common/components/Router/helpers/parsed-link/actions.spec.js
@@ -37,26 +37,22 @@ describe('Tests link actions', () => {
 
   describe('Tests external link', () => {
     it('should open a link in the in app browser', () => {
-      actions.externalLink('http://google.de', () => {
-        resetMocks();
+      resetMocks();
+      actions.externalLink('http://google.de');
 
-        expect(showTab).toHaveBeenCalledTimes(1);
-        expect(showTab).toHaveBeenCalledWith({ targetTab: 'in_app_browser' });
-        expect(openPage).toHaveBeenCalledTimes(1);
-        expect(openPage).toHaveBeenCalledWith({
-          src: 'http://google.de',
-          previewSrc: 'sgapi:page_preview',
-          emulateBrowser: true,
-          targetTab: 'in_app_browser',
-          navigationBarParams: {
-            type: 'in-app-browser-url',
-            popTab: 'in_app_browser',
-            animation: 'none',
-            rightButtonCallback: 'SGAction.showTab({ targetTab: "main" });',
-          },
-        });
-        expect(flushTab).toHaveBeenCalledTimes(1);
-        expect(flushTab).toHaveBeenCalledWith({ targetTab: 'in_app_browser' });
+      expect(showTab).toHaveBeenCalledTimes(1);
+      expect(showTab).toHaveBeenCalledWith({ targetTab: 'in_app_browser', animation: 'slideInFromBottom' });
+      expect(openPage).toHaveBeenCalledTimes(1);
+      expect(openPage).toHaveBeenCalledWith({
+        src: 'http://google.de',
+        previewSrc: 'sgapi:page_preview',
+        emulateBrowser: true,
+        targetTab: 'in_app_browser',
+        navigationBarParams: {
+          type: 'in-app-browser-default',
+          popTab: 'in_app_browser',
+          animation: 'none',
+        },
       });
     });
   });
@@ -153,7 +149,6 @@ describe('Tests link actions', () => {
           leftButtonCallback: 'SGAction.popTabToRoot()',
         },
       });
-      expect(popTabToRoot).toHaveBeenCalledTimes(1);
       expect(showTab).toHaveBeenCalledWith({ targetTab: 'cart' });
     });
   });

--- a/libraries/common/components/Router/helpers/parsed-link/options.js
+++ b/libraries/common/components/Router/helpers/parsed-link/options.js
@@ -122,7 +122,6 @@ function getSimpleLinkParserOptions(path, queryParams, url) {
     case 'checkout_legacy':
       this.addLinkAction('legacyLink', {
         targetTab: 'cart',
-        flushTab: 'cart',
         navigationType: 'checkout',
         url: '/checkout/default',
         backCallback: 'SGAction.popTabToRoot(); SGAction.showTab({ targetTab: "main" });',

--- a/libraries/common/subscriptions/app.js
+++ b/libraries/common/subscriptions/app.js
@@ -26,6 +26,7 @@ import ParsedLink from '../components/Router/helpers/parsed-link';
 import { appError, pipelineError } from '../action-creators/error';
 import { embeddedMedia } from '../collections';
 import { Vimeo, YouTube } from '../collections/media-providers';
+import clearUpInAppBrowser from './helpers/clearUpInAppBrowser';
 
 /**
  * App subscriptions.
@@ -82,11 +83,14 @@ export default function app(subscribe) {
       closeInAppBrowser(isAndroid(getState()));
     });
 
+    event.addCallback('viewDidAppear', () => {
+      clearUpInAppBrowser(isAndroid(getState()));
+    });
+
     /**
      * The following events are sometimes sent by the app, but don't need to be handled right now.
      * To avoid console warnings from the event system, empty handlers are registered here.
      */
-    event.addCallback('viewDidAppear', () => {});
     event.addCallback('viewWillDisappear', () => {});
     event.addCallback('viewDidDisappear', () => {});
     event.addCallback('pageInsetsChanged', () => {});

--- a/libraries/common/subscriptions/helpers/clearUpInAppBrowser.js
+++ b/libraries/common/subscriptions/helpers/clearUpInAppBrowser.js
@@ -1,22 +1,17 @@
-import popTabToRoot from '@shopgate/pwa-core/commands/popTabToRoot';
 import cleanTab from '@shopgate/pwa-core/commands/cleanTab';
 
 /**
  * @param {boolean} isAndroid Tells if the function was called on an Android device.
  */
 const clearUpInAppBrowser = (isAndroid) => {
-  const params = {
-    targetTab: 'in_app_browser',
-  };
-
   /**
-   * Remove leftover pages from the inAppBrowser when the PWA view reappears.
-   * Depending on the app, a different strategy is needed.
+   * Remove leftover pages from the inAppBrowser on Android when the PWA view reappears.
+   * Otherwise it the previous page would get visible again when the native back button is pressed.
    */
   if (isAndroid) {
-    cleanTab(params);
-  } else {
-    popTabToRoot(params);
+    cleanTab({
+      targetTab: 'in_app_browser',
+    });
   }
 };
 

--- a/libraries/common/subscriptions/helpers/clearUpInAppBrowser.js
+++ b/libraries/common/subscriptions/helpers/clearUpInAppBrowser.js
@@ -1,0 +1,23 @@
+import popTabToRoot from '@shopgate/pwa-core/commands/popTabToRoot';
+import cleanTab from '@shopgate/pwa-core/commands/cleanTab';
+
+/**
+ * @param {boolean} isAndroid Tells if the function was called on an Android device.
+ */
+const clearUpInAppBrowser = (isAndroid) => {
+  const params = {
+    targetTab: 'in_app_browser',
+  };
+
+  /**
+   * Remove leftover pages from the inAppBrowser when the PWA view reappears.
+   * Depending on the app, a different strategy is needed.
+   */
+  if (isAndroid) {
+    cleanTab(params);
+  } else {
+    popTabToRoot(params);
+  }
+};
+
+export default clearUpInAppBrowser;

--- a/libraries/common/subscriptions/helpers/clearUpInAppBrowser.spec.js
+++ b/libraries/common/subscriptions/helpers/clearUpInAppBrowser.spec.js
@@ -1,0 +1,22 @@
+import popTabToRoot from '@shopgate/pwa-core/commands/popTabToRoot';
+import cleanTab from '@shopgate/pwa-core/commands/cleanTab';
+import clearUpInAppBrowser from './clearUpInAppBrowser';
+
+jest.mock('@shopgate/pwa-core/commands/popTabToRoot', () => jest.fn());
+jest.mock('@shopgate/pwa-core/commands/cleanTab', () => jest.fn());
+
+describe('clearUpInAppBrowser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call the cleanTab command on Android devices', () => {
+    clearUpInAppBrowser(true);
+    expect(cleanTab).toHaveBeenCalled();
+  });
+
+  it('should call the popTabToRoot command on iOS devices', () => {
+    clearUpInAppBrowser(false);
+    expect(popTabToRoot).toHaveBeenCalled();
+  });
+});

--- a/libraries/common/subscriptions/helpers/clearUpInAppBrowser.spec.js
+++ b/libraries/common/subscriptions/helpers/clearUpInAppBrowser.spec.js
@@ -1,4 +1,3 @@
-import popTabToRoot from '@shopgate/pwa-core/commands/popTabToRoot';
 import cleanTab from '@shopgate/pwa-core/commands/cleanTab';
 import clearUpInAppBrowser from './clearUpInAppBrowser';
 
@@ -17,6 +16,6 @@ describe('clearUpInAppBrowser', () => {
 
   it('should call the popTabToRoot command on iOS devices', () => {
     clearUpInAppBrowser(false);
-    expect(popTabToRoot).toHaveBeenCalled();
+    expect(cleanTab).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# Description
This bugfix tackles an issue where previously opened pages got visible again for a short amount of time, when the inAppBrowser was opened. It should be fixed now by executing clear up logic after the inAppBrowser was closed.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Add some external links to an HTML widget and play around with them. You shouldn't see the previous page floating out again when you open those links. Also try to do the same with the registration form.