### PR TITLE
Correct price formatting on product detail page when price is 0

### DIFF
--- a/themes/theme-gmd/pages/Product/components/Header/components/Price/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Price/index.jsx
@@ -12,7 +12,7 @@ import styles from './style';
  */
 const Price = ({ price }) => (
   <PlaceholderLabel ready={(price !== null)} className={styles.placeholder}>
-    {(price && price.unitPrice) && (
+    {(price && price.unitPrice !== null && price.unitPrice !== undefined) && (
       <PriceBase
         className={styles.price}
         currency={price.currency}

--- a/themes/theme-ios11/pages/Product/components/Header/components/Price/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Price/index.jsx
@@ -12,7 +12,7 @@ import styles from './style';
  */
 const Price = ({ price }) => (
   <PlaceholderLabel ready={(price !== null)} className={styles.placeholder}>
-    {(price && price.unitPrice) && (
+    {(price && price.unitPrice !== null && price.unitPrice !== undefined) && (
       <PriceBase
         className={styles.price}
         discounted={!!price.discount}


### PR DESCRIPTION
# Description

Correct price formatting on product detail page when price is 0

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
Price is shown when value is 0. Still hidden when undefined or null.
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.

## How to test it

Go to a product with a price of 0. It should be formatted like other price like $0.00 or 0,00€