### PR TITLE
Re-added hiding of the legacy menu bar on app start

### DIFF
--- a/libraries/common/helpers/legacy/index.js
+++ b/libraries/common/helpers/legacy/index.js
@@ -1,6 +1,4 @@
 import hideMenuBar from '@shopgate/pwa-core/commands/hideMenuBar';
-import hideNavigationBar from '@shopgate/pwa-core/commands/hideNavigationBar';
-import showNavigationBar from '@shopgate/pwa-core/commands/showNavigationBar';
 import broadcastEvent from '@shopgate/pwa-core/commands/broadcastEvent';
 import showTab from '@shopgate/pwa-core/commands/showTab';
 
@@ -17,31 +15,20 @@ let currentPageContext = {};
 export const getPageContext = () => currentPageContext;
 
 /**
- * Hides the legacy navigation views.
+ * Prepares the NavigationBar and the MenuBar of the app legacy part for the PWA.
  */
-export const hideLegacyNavigation = () => {
-  hideMenuBar({ animation: null });
-  hideNavigationBar({ animation: 'none' });
-};
-
-/**
- * Shows the legacy navigation views.
- */
-export const showLegacyNavigation = () => {
-  showNavigationBar({ animation: 'none' });
-};
-
-/**
- * Broadcasts an event to the pwa_navigation_bar webview
- * and updates the navigation bar with type "none".
- * Event parameters are defined accordingly to
- * the specification of the native updateNavigationBar event.
- */
-export const updateNavigationBarNone = () => {
+export const prepareLegacyNavigation = () => {
+  /**
+   * Broadcasts an event to the pwa_navigation_bar webview and updates the navigation bar with
+   * type "none". Event parameters are defined accordingly to the specification of the native
+   * updateNavigationBar event.
+   */
   broadcastEvent({
     event: 'updateNavigationBar',
     parameters: ['', 'none', { type: 'none' }],
   });
+
+  hideMenuBar({ animation: null });
 };
 
 /**

--- a/libraries/common/helpers/legacy/index.spec.js
+++ b/libraries/common/helpers/legacy/index.spec.js
@@ -1,0 +1,23 @@
+import hideMenuBar from '@shopgate/pwa-core/commands/hideMenuBar';
+import broadcastEvent from '@shopgate/pwa-core/commands/broadcastEvent';
+import { prepareLegacyNavigation } from './index';
+
+jest.mock('@shopgate/pwa-core/classes/AppCommand');
+jest.mock('@shopgate/pwa-core/commands/hideMenuBar', () => jest.fn());
+jest.mock('@shopgate/pwa-core/commands/broadcastEvent', () => jest.fn());
+
+describe('Legacy helpers', () => {
+  describe('prepareLegacyNavigation()', () => {
+    it('should dispatch the correct commands', () => {
+      prepareLegacyNavigation();
+
+      expect(broadcastEvent).toHaveBeenCalledTimes(1);
+      expect(broadcastEvent).toHaveBeenCalledWith({
+        event: 'updateNavigationBar',
+        parameters: ['', 'none', { type: 'none' }],
+      });
+      expect(hideMenuBar).toHaveBeenCalledTimes(1);
+      expect(hideMenuBar).toHaveBeenCalledWith({ animation: null });
+    });
+  });
+});

--- a/libraries/common/subscriptions/app.js
+++ b/libraries/common/subscriptions/app.js
@@ -18,7 +18,7 @@ import registerLinkEvents from '../actions/app/registerLinkEvents';
 import showModal from '../actions/modal/showModal';
 import { isAndroid } from '../selectors/client';
 import {
-  updateNavigationBarNone,
+  prepareLegacyNavigation,
   showPreviousTab,
   pageContext,
 } from '../helpers/legacy';
@@ -68,7 +68,7 @@ export default function app(subscribe) {
     // Add event callbacks
     event.addCallback('pageContext', pageContext);
     // Handle native/legacy navigation bar
-    event.addCallback('viewWillAppear', updateNavigationBarNone);
+    event.addCallback('viewWillAppear', prepareLegacyNavigation);
     event.addCallback('showPreviousTab', showPreviousTab);
     /**
      * This event is triggered form the desktop shop in the inAppBrowser.


### PR DESCRIPTION
# Description
This ticket is about to fix an issue that occurs when a shop is switched from legacy to connect. The main content is reliable replaced by the PWA, but the menu bar is still visible. So we need to dispatch the hideMenu command to hide the bar.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.
