### PR TITLE
Fixed a bug that caused broken product pages

### DIFF
--- a/themes/theme-gmd/pages/Product/components/ImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/ImageSlider/index.jsx
@@ -102,7 +102,7 @@ class ImageSlider extends PureComponent {
               },
             }}
           >
-            <div data-test-id={`product: ${product.name}`}>{content}</div>
+            <div data-test-id={`product: ${product ? product.name : ''}`}>{content}</div>
           </Hammer>
         </Portal>
         <Portal name={PRODUCT_IMAGE_AFTER} />


### PR DESCRIPTION
# Description
This ticket provides a bugfix to prevent broken product pages when no product data is available inside of the store yet.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Link an image widget to a product which isn't shown at your startpage. When you open the product without the fix applied, you should see a redbox error for a short amount of time. On live the page will stay blank in this situation.