### PR TITLE
Fixed a cached selector that caused outdated url in tracking data

### DIFF
--- a/libraries/tracking/subscriptions/pages.js
+++ b/libraries/tracking/subscriptions/pages.js
@@ -1,3 +1,4 @@
+import { getCurrentRoute } from '@shopgate/pwa-common/helpers/router';
 import { categoryIsReady$ } from '../streams/category';
 import { searchIsReady$ } from '../streams/search';
 import { productIsReady$ } from '../streams/product';
@@ -14,7 +15,7 @@ const callPageViewTracker = ({ getState }) => {
 
   track(
     'pageview',
-    getTrackingData(state),
+    getTrackingData(state, getCurrentRoute()),
     state
   );
 };

--- a/libraries/tracking/subscriptions/search.js
+++ b/libraries/tracking/subscriptions/search.js
@@ -1,3 +1,4 @@
+import { getCurrentRoute } from '@shopgate/pwa-common/helpers/router';
 import { searchIsReady$ } from '../streams/search';
 import getTrackingData from '../selectors/search';
 import { track } from '../helpers/index';
@@ -11,7 +12,7 @@ export default function search(subscribe) {
     const state = getState();
 
     track('search', {
-      search: getTrackingData(state),
+      search: getTrackingData(state, getCurrentRoute()),
     }, state);
   });
 }


### PR DESCRIPTION
# Description

Fixed cached selector that caused outdated url in tracking data

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.
