### PR TITLE
Increased AppBar z-index to avoid overlapping elements

### DIFF
--- a/libraries/ui-material/AppBar/style.js
+++ b/libraries/ui-material/AppBar/style.js
@@ -5,14 +5,14 @@ const outer = css({
   position: 'sticky',
   top: 0,
   width: '100%',
-  zIndex: 2,
+  zIndex: 15,
 });
 
 const inner = css({
   background: 'inherit',
   display: 'flex',
   position: 'relative',
-  zIndex: 1,
+  zIndex: 14,
 });
 
 export default {


### PR DESCRIPTION
# Description
The AppBars had a very low zIndex of 2. So some components like the numeric image gallery indicator overlapped it. This ticket increases the zIndex of the AppBars.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Open `ui-shared/ImageSlider/index.jsx` and set the `maxIndicators` property of the `Slider` to 5. Open a product with many pictures and scroll the page till the numeric indicator is behind the AppBar.