### PR TITLE
Change to getProductsById action that keeps original hash when some requested products are already cached. Make Product widget responsive to settings changes after mounting

### DIFF
--- a/libraries/commerce/product/actions/getProductsById.js
+++ b/libraries/commerce/product/actions/getProductsById.js
@@ -1,5 +1,23 @@
-import { shouldFetchData } from '@shopgate/pwa-common/helpers/redux';
-import getProducts from './getProducts';
+import PipelineRequest from '@shopgate/pwa-core/classes/PipelineRequest';
+import { logger } from '@shopgate/pwa-core/helpers';
+import { generateResultHash, shouldFetchData } from '@shopgate/pwa-common/helpers/redux';
+import { getSortOrder } from '@shopgate/pwa-common/selectors/history';
+import * as pipelines from '../constants/Pipelines';
+import requestProducts from '../action-creators/requestProducts';
+import receiveProducts from '../action-creators/receiveProducts';
+import errorProducts from '../action-creators/errorProducts';
+import { getActiveFilters } from '../../filter/selectors';
+
+/**
+ * Gets products that are already cached in state
+ * @param {Array} productIds The product id's that are already cached
+ * @param {Object} state application state
+ * @return {Array} Array of product objects
+ */
+const getProductsFromStateById = (productIds, state) => {
+  const stateProducts = state.product.productsById;
+  return productIds.map(id => stateProducts[id].productData);
+};
 
 /**
  * Retrieves products by id from the store.
@@ -9,24 +27,82 @@ import getProducts from './getProducts';
  */
 const getProductsById = (productIds, componentId = null) => (dispatch, getState) => {
   const state = getState();
-  const products = state.product.productsById;
+  const pipeline = pipelines.SHOPGATE_CATALOG_GET_PRODUCTS;
+  const sort = getSortOrder(state);
+  const filters = getActiveFilters(state);
 
-  // Filter out only the products that are not yet available in the store.
-  const missingIds = productIds.filter(id => shouldFetchData(products[id]));
+  const hash = generateResultHash({
+    pipeline,
+    sort,
+    productIds,
+    ...(filters && Object.keys(filters).length) && { filters },
+    ...componentId && { id: componentId },
+  }, false, false);
 
-  // Then only perform a pipeline request if there are products missing.
-  if (!missingIds.length) {
-    return;
+  const result = state.product.resultsByHash[hash];
+
+  // Stop if we don't need to get any data.
+  if (!shouldFetchData(result, 'products')) {
+    const { products } = result;
+
+    if (Array.isArray(products)) {
+      return Promise.resolve(result);
+    }
+
+    return null;
   }
 
-  dispatch(getProducts({
-    ...componentId && { id: componentId },
-    params: {
-      productIds: missingIds,
-    },
-    includeFilters: false,
-    includeSort: false,
+  // Filter out only the products that are not yet available in the store.
+  const missingIds = productIds.filter(id => shouldFetchData(state.product.productsById[id]));
+
+  dispatch(requestProducts({
+    hash,
+    productIds,
   }));
+
+  // Dispatch receiveProducts with updated hash and the cached products
+  if (!missingIds.length) {
+    const products = getProductsFromStateById(productIds, state);
+
+    return Promise.resolve({ products }).then((response) => {
+      dispatch(receiveProducts({
+        hash,
+        productIds,
+        products,
+        totalResultCount: products.length,
+        cached: true,
+      }));
+      return response;
+    });
+  }
+
+  // Then only perform a pipeline request if there are products missing.
+  const cachedIds = productIds.filter(id => !shouldFetchData(state.product.productsById[id]));
+  return new PipelineRequest(pipeline)
+    .setInput({ productIds: missingIds })
+    .dispatch()
+    .then((response) => {
+      let products = getProductsFromStateById(cachedIds, state);
+      products = products.concat(response.products);
+      dispatch(receiveProducts({
+        hash,
+        productIds,
+        products,
+        totalResultCount: products.length,
+        cached: true,
+      }));
+
+      return response;
+    })
+    .catch((error) => {
+      logger.error(error);
+      dispatch(errorProducts({
+        hash,
+        productIds,
+      }));
+
+      return error;
+    });
 };
 
 export default getProductsById;

--- a/themes/theme-gmd/widgets/Products/index.jsx
+++ b/themes/theme-gmd/widgets/Products/index.jsx
@@ -66,6 +66,12 @@ class ProductsWidget extends Component {
     ) {
       this.productCount = Math.min(nextProps.products.length, this.totalProductCount);
     }
+    // React to case when widget settings change after component mounted
+    if (JSON.stringify(this.props.settings.queryParams)
+      !== JSON.stringify(nextProps.settings.queryParams)
+      && (!nextProps.products || !nextProps.products.length)) {
+      this.getProducts(nextProps.settings);
+    }
   }
 
   /**
@@ -82,15 +88,16 @@ class ProductsWidget extends Component {
 
   /**
    * Build the params for requesting products and then make the request.
+   * @param {Object} [settings] Widget settings object
    */
-  getProducts = () => {
+  getProducts = (settings) => {
     const { getProducts, id } = this.props;
     const {
       productLimit,
       queryParams,
       queryType,
       sortOrder,
-    } = this.props.settings;
+    } = settings || this.props.settings;
 
     const sort = transformDisplayOptions(sortOrder);
 

--- a/themes/theme-ios11/widgets/Products/index.jsx
+++ b/themes/theme-ios11/widgets/Products/index.jsx
@@ -66,6 +66,12 @@ class ProductsWidget extends Component {
     ) {
       this.productCount = Math.min(nextProps.products.length, this.totalProductCount);
     }
+    // React to case when widget settings change after component mounted
+    if (JSON.stringify(this.props.settings.queryParams)
+      !== JSON.stringify(nextProps.settings.queryParams)
+      && (!nextProps.products || !nextProps.products.length)) {
+      this.getProducts(nextProps.settings);
+    }
   }
 
   /**
@@ -82,15 +88,16 @@ class ProductsWidget extends Component {
 
   /**
    * Build the params for requesting products and then make the request.
+   * @param {Object} [settings] Widget settings object
    */
-  getProducts = () => {
+  getProducts = (settings) => {
     const { getProducts, id } = this.props;
     const {
       productLimit,
       queryParams,
       queryType,
       sortOrder,
-    } = this.props.settings;
+    } = settings || this.props.settings;
 
     const sort = transformDisplayOptions(sortOrder);
 


### PR DESCRIPTION
… IDs would not change based on which products were already cached and added another call to getProducts in product widget that responds to widget setting changes

# Description

Please include a summary of the change. Please also include relevant motivation and context.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.

## How to test it

Visit a page with a product list widget that is set up as by product ids. Visit another page. Change the list of product ids in the widget in the merchant admin and publish changes. In the app return to the page with the product list widget. Before this fix no products will be shown. After this fix the new list of products will be shown.

This issue was the result of two problems. 
1) The widget didn't respond to changes to its settings after it mounted.
The getProducts method was only called in the componentDidMount lifecycle hook method and when the get more button was clicked. But it would not be called if the widget settings changed. The widget settings are used to create the hash by which products are selected from redux. When the settings changed the hash would change but no call to get the products using that hash is made. Therefore no products are found.

2) The action to get products by id can change the hash if some of the products being requested are already in redux.
The getProductsById action originally iterated through the list of product ids being requested. If some were already in the redux cache their ids were removed from the query, and then the query was passed to the getProducts action where the hash is generated from the modified query. The product widget component uses a selector that calculates the product hash based on the widget settings. Then it looks for the products using that hash. If some of the products that are in the widget query are already in redux the action will change the hash so it does not contain any of the products already in redux. When this happens the widget is not able to find any of the products it is suppose to display because the hash it is using to find the products will not be in redux. This could presumably cause problems beyond a product widget's settings being changed after mounting. It is likely to cause issues if the shopper navigates around the app. If in doing so some of the products are loaded in to redux that are in a product widgets set up to show by product id the shopper later visits that product widget would be empty.