### PR TITLE
Fixed structure of defaultClientInformation

### DIFF
--- a/libraries/core/helpers/version.js
+++ b/libraries/core/helpers/version.js
@@ -21,6 +21,7 @@ export const defaultClientInformation = {
   codebaseVersion: '5.18.0',
   type: (!md.tablet() ? 'phone' : 'tablet'),
   device: {
+    type: (!md.tablet() ? 'phone' : 'tablet'),
     os: {
       platform: isAndroid ? PLATFORM_ANDROID : PLATFORM_IOS,
       ver: detector.os.fullVersion,

--- a/libraries/tracking/subscriptions/setup.js
+++ b/libraries/tracking/subscriptions/setup.js
@@ -1,6 +1,8 @@
 import get from 'lodash/get';
 import event from '@shopgate/pwa-core/classes/Event';
 import logGroup from '@shopgate/pwa-core/helpers/logGroup';
+import { getWebStorageEntry } from '@shopgate/pwa-core/commands/webStorage';
+import { useBrowserConnector } from '@shopgate/pwa-core/helpers';
 import { defaultClientInformation } from '@shopgate/pwa-core/helpers/version';
 import registerEvents from '@shopgate/pwa-core/commands/registerEvents';
 import { TYPE_PHONE, OS_ALL } from '@shopgate/pwa-common/constants/Device';
@@ -40,9 +42,11 @@ export default function setup(subscribe) {
    * Gets triggered when the app starts.
    */
   subscribe(appDidStart$, async ({ getState }) => {
+    const clientInformationResponse = !useBrowserConnector() ? await getWebStorageEntry({ name: 'clientInformation' }) : { value: defaultClientInformation };
+
     const clientInformation = {
-      type: get(defaultClientInformation, 'value.device.type', TYPE_PHONE),
-      os: get(defaultClientInformation, 'value.device.os.platform', OS_ALL),
+      type: get(clientInformationResponse, 'value.device.type', TYPE_PHONE),
+      os: get(clientInformationResponse, 'value.device.os.platform', OS_ALL),
       state: getState(),
     };
 


### PR DESCRIPTION
# Description

- fixed structure of defaultClientInformation to match the real clientInformation returned form device
- only use defaultClientInformation for tracking if the BrowserConnector is used

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.
