### PR TITLE
GMD Snackbar adjusts action color to white when accent color to black contrast is less than 4

### DIFF
--- a/themes/theme-gmd/components/SnackBar/components/ActionButton/style.js
+++ b/themes/theme-gmd/components/SnackBar/components/ActionButton/style.js
@@ -1,8 +1,9 @@
 import { css } from 'glamor';
 import color from 'color';
 import colors from 'Styles/colors';
+import { DRAWER_BACKGROUND } from '../../constants';
 
-const textColorContrast = color(colors.accent).contrast(color('black'));
+const textColorContrast = color(colors.accent).contrast(color(DRAWER_BACKGROUND));
 
 export default css({
   color: textColorContrast > 4 ? colors.accent : 'white',

--- a/themes/theme-gmd/components/SnackBar/components/ActionButton/style.js
+++ b/themes/theme-gmd/components/SnackBar/components/ActionButton/style.js
@@ -1,8 +1,11 @@
 import { css } from 'glamor';
+import color from 'color';
 import colors from 'Styles/colors';
 
+const textColorContrast = color(colors.accent).contrast(color('black'));
+
 export default css({
-  color: colors.accent,
+  color: textColorContrast > 4 ? colors.accent : 'white',
   fontWeight: 500,
   flexGrow: 1,
   textTransform: 'uppercase',

--- a/themes/theme-gmd/components/SnackBar/constants.js
+++ b/themes/theme-gmd/components/SnackBar/constants.js
@@ -1,0 +1,1 @@
+export const DRAWER_BACKGROUND = 'black';

--- a/themes/theme-gmd/components/SnackBar/style.js
+++ b/themes/theme-gmd/components/SnackBar/style.js
@@ -1,8 +1,9 @@
 import { css } from 'glamor';
+import { DRAWER_BACKGROUND } from './constants';
 
 const drawer = css({
   width: '100%',
-  background: 'black',
+  background: DRAWER_BACKGROUND,
   padding: '7px 24px',
   bottom: 'calc(var(--tabbar-height) + var(--safe-area-inset-bottom))',
   zIndex: 2,


### PR DESCRIPTION
# Description
GMD Snackbar adjusts action color to white when accent color to black contrast is less than 4 (see https://www.w3.org/TR/WCAG20/)

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.

## How to test it

Choose accent color to something close to or black. Toast should have white action button. For default accent color it should still use it.