### PR TITLE
Detector fix

### DIFF
--- a/libraries/core/helpers/version.js
+++ b/libraries/core/helpers/version.js
@@ -15,6 +15,14 @@ let requesting = false;
 
 const md = new MobileDetect(navigator.userAgent);
 const isAndroid = md.is('AndroidOS');
+const fullVersion = typeof detector === 'object' && detector.os ? detector.os.fullVersion : null;
+
+// Eslint doesn't allow to use one liner here.
+let model = null;
+if (fullVersion) {
+  model = isAndroid ? 'Android' : `iPhone${fullVersion}`;
+}
+
 export const defaultClientInformation = {
   libVersion: '17.0',
   appVersion: '5.18.0',
@@ -24,9 +32,9 @@ export const defaultClientInformation = {
     type: (!md.tablet() ? 'phone' : 'tablet'),
     os: {
       platform: isAndroid ? PLATFORM_ANDROID : PLATFORM_IOS,
-      ver: detector.os.fullVersion,
+      ver: fullVersion,
     },
-    model: isAndroid ? 'Android' : `iPhone${detector.os.fullVersion}`,
+    model,
   },
 };
 


### PR DESCRIPTION
# Description
Detector can be an empty object, when this module is imported in an environment different than a browser it throws

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.

## How to test it

Try to unit test shopgate-ext-upsell outside of monorepository with removed __mocks__ folder