### PR TITLE
Fixed product images fallback for variants without own images

### DIFF
--- a/libraries/commerce/product/subscriptions/index.js
+++ b/libraries/commerce/product/subscriptions/index.js
@@ -45,6 +45,7 @@ function product(subscribe) {
 
     if (baseProductId) {
       dispatch(getProduct(baseProductId));
+      dispatch(getProductImages(baseProductId));
     }
 
     if (flags.hasVariants) {


### PR DESCRIPTION
# Description
This ticket is about to fix the product images fallback for product variants without images. In that case a gallery of the base product images should be shown if it has multiple images.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

- put a variant without own images into the cart
- goto the cart and reload the page
- open the product within the cart

Desired outcome:
You see a product image gallery with the images of the parent product.