### PR TITLE
Increased hit area of the cart item context menu

### DIFF
--- a/libraries/ui-shared/ContextMenu/index.jsx
+++ b/libraries/ui-shared/ContextMenu/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component, Children } from 'react';
 import PropTypes from 'prop-types';
 import Portal from 'react-portal';
+import classNames from 'classnames';
 import Backdrop from '@shopgate/pwa-common/components/Backdrop';
 import MoreVertIcon from '../icons/MoreVertIcon';
 import Position from './components/Position';
@@ -15,10 +16,12 @@ class ContextMenu extends Component {
 
   static propTypes = {
     children: PropTypes.node,
+    classes: PropTypes.shape(),
   };
 
   static defaultProps = {
     children: null,
+    classes: { container: '', button: '' },
   };
 
   /**
@@ -71,16 +74,19 @@ class ContextMenu extends Component {
    * @returns {JSX}
    */
   render() {
-    const { children } = this.props;
+    const { children, classes } = this.props;
     const { active } = this.state;
 
     return (
       <div
         data-test-id="contextMenu"
         ref={(ref) => { this.elementRef = ref; }}
-        className={styles.container}
+        className={classNames(styles.container, classes.container)}
       >
-        <button className={styles.button} onClick={this.handleMenuToggle}>
+        <button
+          className={classNames(styles.button, classes.button)}
+          onClick={this.handleMenuToggle}
+        >
           <MoreVertIcon />
         </button>
         <Portal isOpened={active}>

--- a/themes/theme-gmd/pages/Cart/components/Item/components/Product/components/Layout/components/Title/index.jsx
+++ b/themes/theme-gmd/pages/Cart/components/Item/components/Product/components/Layout/components/Title/index.jsx
@@ -7,6 +7,11 @@ import * as portals from '@shopgate/pwa-common-commerce/cart/constants/Portals';
 import ContextMenu from '@shopgate/pwa-ui-shared/ContextMenu';
 import styles from './style';
 
+const contextMenuClasses = {
+  button: styles.menuToggleButton,
+  container: styles.menuToggleContainer,
+};
+
 /**
  * The Cart Product Title component.
  * @param {Object} props The component properties.
@@ -25,16 +30,14 @@ const Title = ({ value, handleRemove, toggleEditMode }, context) => (
       <Portal name={portals.CART_ITEM_NAME_AFTER} props={context} />
     </Grid.Item>
     <Grid.Item className={styles.menuContainer} shrink={0}>
-      <div className={styles.menuToggle}>
-        <ContextMenu>
-          <ContextMenu.Item onClick={handleRemove}>
-            <I18n.Text string="cart.remove" />
-          </ContextMenu.Item>
-          <ContextMenu.Item onClick={() => toggleEditMode(true)}>
-            <I18n.Text string="cart.edit" />
-          </ContextMenu.Item>
-        </ContextMenu>
-      </div>
+      <ContextMenu classes={contextMenuClasses}>
+        <ContextMenu.Item onClick={handleRemove}>
+          <I18n.Text string="cart.remove" />
+        </ContextMenu.Item>
+        <ContextMenu.Item onClick={() => toggleEditMode(true)}>
+          <I18n.Text string="cart.edit" />
+        </ContextMenu.Item>
+      </ContextMenu>
     </Grid.Item>
   </Grid>
 );

--- a/themes/theme-gmd/pages/Cart/components/Item/components/Product/components/Layout/components/Title/style.js
+++ b/themes/theme-gmd/pages/Cart/components/Item/components/Product/components/Layout/components/Title/style.js
@@ -9,11 +9,11 @@ const title = css({
 }).toString();
 
 const menuContainer = css({
-  marginTop: `-${variables.gap.bigger}px`,
+  marginTop: `-${variables.gap.big}px`,
   marginRight: `-${variables.gap.big}px`,
 }).toString();
 
-const menuToggleSize = variables.gap.big * 2.5;
+const menuToggleSize = variables.gap.big * 2;
 const menuToggleFontSize = variables.gap.big * 1.5;
 
 const menuToggleContainer = css({
@@ -26,7 +26,7 @@ const menuToggleButton = css({
   fontSize: menuToggleFontSize,
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'center',
+  justifyContent: 'flex-end',
 }).toString();
 
 export default {

--- a/themes/theme-gmd/pages/Cart/components/Item/components/Product/components/Layout/components/Title/style.js
+++ b/themes/theme-gmd/pages/Cart/components/Item/components/Product/components/Layout/components/Title/style.js
@@ -9,25 +9,29 @@ const title = css({
 }).toString();
 
 const menuContainer = css({
+  marginTop: `-${variables.gap.bigger}px`,
   marginRight: `-${variables.gap.big}px`,
-  marginLeft: variables.gap.big,
-  pointerEvents: 'none',
 }).toString();
 
-const menuToggleSize = variables.gap.big * 2;
+const menuToggleSize = variables.gap.big * 2.5;
 const menuToggleFontSize = variables.gap.big * 1.5;
 
-const menuToggle = css({
+const menuToggleContainer = css({
+  margin: variables.gap.small,
+}).toString();
+
+const menuToggleButton = css({
   height: menuToggleSize,
   width: menuToggleSize,
-  marginTop: `-${variables.gap.small}px`,
   fontSize: menuToggleFontSize,
-  padding: variables.gap.small * 0.5,
-  pointerEvents: 'all',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
 }).toString();
 
 export default {
   title,
   menuContainer,
-  menuToggle,
+  menuToggleContainer,
+  menuToggleButton,
 };

--- a/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/components/Title/index.jsx
+++ b/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/components/Title/index.jsx
@@ -7,6 +7,11 @@ import * as portals from '@shopgate/pwa-common-commerce/cart/constants/Portals';
 import ContextMenu from '@shopgate/pwa-ui-shared/ContextMenu';
 import styles from './style';
 
+const contextMenuClasses = {
+  button: styles.menuToggleButton,
+  container: styles.menuToggleContainer,
+};
+
 /**
  * The Cart Product Title component.
  * @param {Object} props The component properties.
@@ -25,16 +30,14 @@ const Title = ({ value, handleRemove, toggleEditMode }, context) => (
       <Portal name={portals.CART_ITEM_NAME_AFTER} props={context} />
     </Grid.Item>
     <Grid.Item className={styles.menuContainer} shrink={0}>
-      <div className={styles.menuToggle}>
-        <ContextMenu>
-          <ContextMenu.Item onClick={handleRemove}>
-            <I18n.Text string="cart.remove" />
-          </ContextMenu.Item>
-          <ContextMenu.Item onClick={() => toggleEditMode(true)}>
-            <I18n.Text string="cart.edit" />
-          </ContextMenu.Item>
-        </ContextMenu>
-      </div>
+      <ContextMenu classes={contextMenuClasses}>
+        <ContextMenu.Item onClick={handleRemove}>
+          <I18n.Text string="cart.remove" />
+        </ContextMenu.Item>
+        <ContextMenu.Item onClick={() => toggleEditMode(true)}>
+          <I18n.Text string="cart.edit" />
+        </ContextMenu.Item>
+      </ContextMenu>
     </Grid.Item>
   </Grid>
 );

--- a/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/components/Title/style.js
+++ b/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/components/Title/style.js
@@ -9,11 +9,11 @@ const title = css({
 }).toString();
 
 const menuContainer = css({
-  marginTop: `-${variables.gap.bigger}px`,
+  marginTop: `-${variables.gap.big}px`,
   marginRight: `-${variables.gap.big}px`,
 }).toString();
 
-const menuToggleSize = variables.gap.big * 2.5;
+const menuToggleSize = variables.gap.big * 2;
 const menuToggleFontSize = variables.gap.big * 1.5;
 
 const menuToggleContainer = css({
@@ -26,7 +26,7 @@ const menuToggleButton = css({
   fontSize: menuToggleFontSize,
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'center',
+  justifyContent: 'flex-end',
 }).toString();
 
 export default {

--- a/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/components/Title/style.js
+++ b/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/components/Title/style.js
@@ -9,25 +9,29 @@ const title = css({
 }).toString();
 
 const menuContainer = css({
+  marginTop: `-${variables.gap.bigger}px`,
   marginRight: `-${variables.gap.big}px`,
-  marginLeft: variables.gap.big,
-  pointerEvents: 'none',
 }).toString();
 
-const menuToggleSize = variables.gap.big * 2;
+const menuToggleSize = variables.gap.big * 2.5;
 const menuToggleFontSize = variables.gap.big * 1.5;
 
-const menuToggle = css({
+const menuToggleContainer = css({
+  margin: variables.gap.small,
+}).toString();
+
+const menuToggleButton = css({
   height: menuToggleSize,
   width: menuToggleSize,
-  marginTop: `-${variables.gap.small}px`,
   fontSize: menuToggleFontSize,
-  padding: variables.gap.small * 0.5,
-  pointerEvents: 'all',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
 }).toString();
 
 export default {
   title,
   menuContainer,
-  menuToggle,
+  menuToggleContainer,
+  menuToggleButton,
 };


### PR DESCRIPTION
# Description
This ticket is about to increase the click area around the `ContextMenu` dots to avoid mistakenly opening cart products.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [x] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.
