### PR TITLE
Fixed an issue with product variant selection

### DIFF
--- a/libraries/common/components/ProductCharacteristics/helpers/index.js
+++ b/libraries/common/components/ProductCharacteristics/helpers/index.js
@@ -6,7 +6,9 @@
  * @return {Object}
  */
 export function reduceSelection(characteristics, selection, index) {
-  const currentSelection = selection;
+  const currentSelection = {
+    ...selection,
+  };
 
   /**
    * When the given index is the same as the complete set


### PR DESCRIPTION
# Description
This ticket is about to fix an issue with product variant selection. When a variant was once selected, it was not available to pick anymore after another variant was selected.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
- open a product with two attribute pickers
- select a product by picking two attribute values
- switch to another product
- try to select the fist selected product again (without the fix the attribute combination is not pickable anymore)