### PR TITLE
Fixed opening of child products on favourite list

### DIFF
--- a/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/Image/index.jsx
+++ b/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/Image/index.jsx
@@ -15,7 +15,7 @@ const Image = ({ product }) => (
   <div className={styles.image}>
     <Link
       tagName="a"
-      href={`${ITEM_PATH}/${bin2hex(product.baseProductId || product.id)}`}
+      href={`${ITEM_PATH}/${bin2hex(product.id)}`}
       itemProp="item"
       itemScope
       itemType="http://schema.org/Product"

--- a/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/ProductInfo/index.jsx
+++ b/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/ProductInfo/index.jsx
@@ -20,7 +20,6 @@ const ProductInfo = ({ product }) => {
   const props = { product };
   const {
     availability,
-    baseProductId,
     characteristics,
     id,
     name,
@@ -34,7 +33,7 @@ const ProductInfo = ({ product }) => {
         <div className={styles.name} data-test-id={`favoriteListItem: ${name}`}>
           <Link
             tagName="a"
-            href={`${ITEM_PATH}/${bin2hex(baseProductId || id)}`}
+            href={`${ITEM_PATH}/${bin2hex(id)}`}
             itemProp="item"
             itemScope
             itemType="http://schema.org/Product"

--- a/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/index.jsx
+++ b/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/index.jsx
@@ -51,7 +51,7 @@ class Item extends Component {
   };
 
   /**
-   * Get the element height to determin the translate distance
+   * Get the element height to determine the translate distance
    * @param {Object} element Component ref
    */
   saveRef = (element) => {

--- a/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/Image/index.jsx
+++ b/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/Image/index.jsx
@@ -15,7 +15,7 @@ const Image = ({ product }) => (
   <div className={styles.image}>
     <Link
       tagName="a"
-      href={`${ITEM_PATH}/${bin2hex(product.baseProductId || product.id)}`}
+      href={`${ITEM_PATH}/${bin2hex(product.id)}`}
       itemProp="item"
       itemScope
       itemType="http://schema.org/Product"

--- a/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/ProductInfo/index.jsx
+++ b/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/ProductInfo/index.jsx
@@ -20,7 +20,6 @@ const ProductInfo = ({ product }) => {
   const props = { product };
   const {
     availability,
-    baseProductId,
     characteristics,
     id,
     name,
@@ -34,7 +33,7 @@ const ProductInfo = ({ product }) => {
         <div className={styles.name}>
           <Link
             tagName="a"
-            href={`${ITEM_PATH}/${bin2hex(baseProductId || id)}`}
+            href={`${ITEM_PATH}/${bin2hex(id)}`}
             itemProp="item"
             itemScope
             itemType="http://schema.org/Product"

--- a/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/index.jsx
+++ b/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/index.jsx
@@ -51,7 +51,7 @@ class Item extends Component {
   };
 
   /**
-   * Get the element height to determin the translate distance
+   * Get the element height to determine the translate distance
    * @param {Object} element Component ref
    */
   saveRef = (element) => {


### PR DESCRIPTION
# Description

This ticket is about fixing opening of child products from the favourite list. Before the `baseProductId` was used to open the link if it was available. That caused that in any situation the parent product was opened for the user.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.