### PR TITLE
Fixed broken terms legacy link on iOS theme

### DIFF
--- a/themes/theme-gmd/components/NavDrawer/components/TermsButton/index.jsx
+++ b/themes/theme-gmd/components/NavDrawer/components/TermsButton/index.jsx
@@ -12,7 +12,7 @@ import { NavDrawer } from '@shopgate/pwa-ui-material';
 import connect from '../../connector';
 
 const LABEL = 'navigation.terms';
-const PAYMENT_PATH = `${PAGE_PATH}/terms`;
+const TERMS_PATH = `${PAGE_PATH}/terms`;
 
 /**
  * @param {Function} props.navigate The navigate action.
@@ -25,7 +25,7 @@ const TermsButton = ({ navigate }) => (
       <NavDrawer.Item
         label={LABEL}
         icon={DescriptionIcon}
-        onClick={navigate(PAYMENT_PATH, LABEL)}
+        onClick={navigate(TERMS_PATH, LABEL)}
         testId="navDrawerTermsButton"
       />
     </Portal>

--- a/themes/theme-ios11/pages/More/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/pages/More/__snapshots__/index.spec.jsx.snap
@@ -264,28 +264,28 @@ exports[`<More /> should render as expected when the user is logged in 1`] = `
                 }
               >
                 <MoreMenuItem
-                  href="/page/navigation_terms"
+                  href="/page/terms"
                   label="navigation.terms"
                   onClick={null}
                   testId={null}
                 >
                   <Connect(Link)
                     className="css-1czs3p1"
-                    href="/page/navigation_terms"
+                    href="/page/terms"
                   >
                     <Link
                       className="css-1czs3p1"
                       disabled={false}
                       historyPush={[Function]}
                       historyReplace={[Function]}
-                      href="/page/navigation_terms"
+                      href="/page/terms"
                       replace={false}
                       state={Object {}}
                       tag="div"
                     >
                       <div
                         className="css-c6ki83 css-1czs3p1"
-                        data-test-id="link: /page/navigation_terms"
+                        data-test-id="link: /page/terms"
                         onClick={[Function]}
                         role="link"
                       >
@@ -1149,28 +1149,28 @@ exports[`<More /> should render as expected when the user is not logged in 1`] =
                 }
               >
                 <MoreMenuItem
-                  href="/page/navigation_terms"
+                  href="/page/terms"
                   label="navigation.terms"
                   onClick={null}
                   testId={null}
                 >
                   <Connect(Link)
                     className="css-1czs3p1"
-                    href="/page/navigation_terms"
+                    href="/page/terms"
                   >
                     <Link
                       className="css-1czs3p1"
                       disabled={false}
                       historyPush={[Function]}
                       historyReplace={[Function]}
-                      href="/page/navigation_terms"
+                      href="/page/terms"
                       replace={false}
                       state={Object {}}
                       tag="div"
                     >
                       <div
                         className="css-c6ki83 css-1czs3p1"
-                        data-test-id="link: /page/navigation_terms"
+                        data-test-id="link: /page/terms"
                         onClick={[Function]}
                         role="link"
                       >

--- a/themes/theme-ios11/pages/More/index.jsx
+++ b/themes/theme-ios11/pages/More/index.jsx
@@ -93,7 +93,7 @@ class More extends Component {
             {/* TERMS */}
             <Portal name={portals.NAV_MENU_TERMS_BEFORE} props={portalProps} />
             <Portal name={portals.NAV_MENU_TERMS} props={portalProps}>
-              <Item href={`${PAGE_PATH}/navigation_terms`} label="navigation.terms" />
+              <Item href={`${PAGE_PATH}/terms`} label="navigation.terms" />
             </Portal>
             <Portal name={portals.NAV_MENU_TERMS_AFTER} props={portalProps} />
 


### PR DESCRIPTION
# Description
This ticket is about to fix a broken terms link at the "more" page within the iOS theme.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.
