### PR TITLE
Corrected bug where page configs were fetched on every page …

### DIFF
--- a/libraries/common/actions/page/getPageConfig.js
+++ b/libraries/common/actions/page/getPageConfig.js
@@ -9,12 +9,12 @@ import { getPageConfigById } from '../../selectors/page';
  * @param {string} pageId The ID of the page to request.
  * @return {Function} The dispatched action.
  */
-export default function getPageConfig(pageId) {
+export default function getPageConfig(pageId, force = false) {
   return (dispatch, getState) => {
     const state = getState();
     const pageConfig = getPageConfigById(state, { pageId });
 
-    if (!shouldFetchData(pageConfig)) {
+    if (!force && !shouldFetchData(pageConfig)) {
       return null;
     }
 

--- a/libraries/common/actions/page/getPageConfig.js
+++ b/libraries/common/actions/page/getPageConfig.js
@@ -7,6 +7,7 @@ import { getPageConfigById } from '../../selectors/page';
 /**
  * Retrieves the config for a page.
  * @param {string} pageId The ID of the page to request.
+ * @param {boolean} [force=true] When true, the request will go out without being checked.
  * @return {Function} The dispatched action.
  */
 export default function getPageConfig(pageId, force = false) {

--- a/libraries/common/reducers/page/index.js
+++ b/libraries/common/reducers/page/index.js
@@ -39,7 +39,7 @@ export default function pageReducer(state = {}, action) {
           title: action.config.title,
           widgets: enrichWidgets(action),
           isFetching: false,
-          expires: Date.now() + 86400000,
+          expires: Date.now() + 86400000, // One day
         },
       };
     }

--- a/libraries/common/reducers/page/index.js
+++ b/libraries/common/reducers/page/index.js
@@ -39,7 +39,7 @@ export default function pageReducer(state = {}, action) {
           title: action.config.title,
           widgets: enrichWidgets(action),
           isFetching: false,
-          expires: Date.now() + 86400000, // One day
+          expires: Date.now() + 3600000, // One hour
         },
       };
     }

--- a/libraries/common/reducers/page/index.js
+++ b/libraries/common/reducers/page/index.js
@@ -39,7 +39,7 @@ export default function pageReducer(state = {}, action) {
           title: action.config.title,
           widgets: enrichWidgets(action),
           isFetching: false,
-          expires: Date.now(),
+          expires: Date.now() + 86400000,
         },
       };
     }

--- a/themes/theme-gmd/pages/StartPage/subscriptions.js
+++ b/themes/theme-gmd/pages/StartPage/subscriptions.js
@@ -2,12 +2,15 @@ import { PAGE_ID_INDEX } from '@shopgate/pwa-common/constants/PageIDs';
 import getPageConfig from '@shopgate/pwa-common/actions/page/getPageConfig';
 import { startPageWillEnter$ } from './streams';
 
+let force = true;
+
 /**
  * Page subscriptions.
  * @param {Function} subscribe The subscribe function.
  */
 export default function page(subscribe) {
   subscribe(startPageWillEnter$, ({ dispatch }) => {
-    dispatch(getPageConfig(PAGE_ID_INDEX));
+    dispatch(getPageConfig(PAGE_ID_INDEX, force));
+    force = false;
   });
 }

--- a/themes/theme-ios11/pages/StartPage/subscriptions.js
+++ b/themes/theme-ios11/pages/StartPage/subscriptions.js
@@ -2,12 +2,15 @@ import { PAGE_ID_INDEX } from '@shopgate/pwa-common/constants/PageIDs';
 import getPageConfig from '@shopgate/pwa-common/actions/page/getPageConfig';
 import { startPageWillEnter$ } from './streams';
 
+let force = true;
+
 /**
  * Page subscriptions.
  * @param {Function} subscribe The subscribe function.
  */
 export default function page(subscribe) {
   subscribe(startPageWillEnter$, ({ dispatch }) => {
-    dispatch(getPageConfig(PAGE_ID_INDEX));
+    dispatch(getPageConfig(PAGE_ID_INDEX, force));
+    force = false;
   });
 }


### PR DESCRIPTION
- [ x ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.