### PR TITLE
Added Missing Portals Around Variant Availability in Variant Picker

### DIFF
--- a/themes/theme-gmd/pages/Product/components/Characteristics/Characteristic/components/VariantAvailability/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Characteristics/Characteristic/components/VariantAvailability/index.jsx
@@ -26,37 +26,20 @@ class VariantAvailability extends PureComponent {
    * @returns {JSX}
    */
   render() {
-    const { availability } = this.props;
-    const { state, text } = availability || {};
-    if (!availability) {
+    if (!this.props.availability) {
       return null;
     }
 
+    const { availability } = this.props;
+    const { state, text } = availability;
+
     return (
       <Fragment>
-        <Portal
-          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_BEFORE}
-          props={{
-            text,
-            state,
-          }}
-        />
-        <Portal
-          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY}
-          props={{
-            text,
-            state,
-          }}
-        >
+        <Portal name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_BEFORE} props={availability} />
+        <Portal name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY} props={availability}>
           <Availability className={styles} state={state} text={text} />
         </Portal>
-        <Portal
-          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_AFTER}
-          props={{
-            text,
-            state,
-          }}
-        />
+        <Portal name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_AFTER} props={availability} />
       </Fragment>
     );
   }

--- a/themes/theme-gmd/pages/Product/components/Characteristics/Characteristic/components/VariantAvailability/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Characteristics/Characteristic/components/VariantAvailability/index.jsx
@@ -1,6 +1,12 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Availability from '@shopgate/pwa-ui-shared/Availability';
+import Portal from '@shopgate/pwa-common/components/Portal';
+import {
+  PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_BEFORE,
+  PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY,
+  PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_AFTER,
+} from '@shopgate/pwa-common-commerce/product/constants/Portals';
 import connect from './connector';
 import styles from './style';
 
@@ -21,13 +27,37 @@ class VariantAvailability extends PureComponent {
    */
   render() {
     const { availability } = this.props;
-
+    const { state, text } = availability || {};
     if (!availability) {
       return null;
     }
 
     return (
-      <Availability className={styles} state={availability.state} text={availability.text} />
+      <Fragment>
+        <Portal
+          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_BEFORE}
+          props={{
+            text,
+            state,
+          }}
+        />
+        <Portal
+          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY}
+          props={{
+            text,
+            state,
+          }}
+        >
+          <Availability className={styles} state={state} text={text} />
+        </Portal>
+        <Portal
+          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_AFTER}
+          props={{
+            text,
+            state,
+          }}
+        />
+      </Fragment>
     );
   }
 }

--- a/themes/theme-ios11/pages/Product/components/Characteristics/Characteristic/components/VariantAvailability/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Characteristics/Characteristic/components/VariantAvailability/index.jsx
@@ -26,37 +26,20 @@ class VariantAvailability extends PureComponent {
    * @returns {JSX}
    */
   render() {
-    const { availability } = this.props;
-    const { state, text } = availability || {};
-    if (!availability) {
+    if (!this.props.availability) {
       return null;
     }
 
+    const { availability } = this.props;
+    const { state, text } = availability;
+
     return (
       <Fragment>
-        <Portal
-          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_BEFORE}
-          props={{
-            text,
-            state,
-          }}
-        />
-        <Portal
-          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY}
-          props={{
-            text,
-            state,
-          }}
-        >
+        <Portal name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_BEFORE} props={availability} />
+        <Portal name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY} props={availability}>
           <Availability className={styles} state={state} text={text} />
         </Portal>
-        <Portal
-          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_AFTER}
-          props={{
-            text,
-            state,
-          }}
-        />
+        <Portal name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_AFTER} props={availability} />
       </Fragment>
     );
   }

--- a/themes/theme-ios11/pages/Product/components/Characteristics/Characteristic/components/VariantAvailability/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Characteristics/Characteristic/components/VariantAvailability/index.jsx
@@ -1,6 +1,12 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Availability from '@shopgate/pwa-ui-shared/Availability';
+import Portal from '@shopgate/pwa-common/components/Portal';
+import {
+  PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_BEFORE,
+  PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY,
+  PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_AFTER,
+} from '@shopgate/pwa-common-commerce/product/constants/Portals';
 import connect from './connector';
 import styles from './style';
 
@@ -21,13 +27,37 @@ class VariantAvailability extends PureComponent {
    */
   render() {
     const { availability } = this.props;
-
+    const { state, text } = availability || {};
     if (!availability) {
       return null;
     }
 
     return (
-      <Availability className={styles} state={availability.state} text={availability.text} />
+      <Fragment>
+        <Portal
+          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_BEFORE}
+          props={{
+            text,
+            state,
+          }}
+        />
+        <Portal
+          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY}
+          props={{
+            text,
+            state,
+          }}
+        >
+          <Availability className={styles} state={state} text={text} />
+        </Portal>
+        <Portal
+          name={PRODUCT_VARIANT_SELECT_PICKER_AVAILABILITY_AFTER}
+          props={{
+            text,
+            state,
+          }}
+        />
+      </Fragment>
     );
   }
 }


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context.

## Type of change

Please add an "x" into the option that is relevant:

- [  ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [x] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.

## How to test it
Check to see if the product.variant-select.picker.availability.before, product.variant-select.picker.availability, and product.variant-select.picker.availability.after are nested around the variant availability in the variant picker.