### PR TITLE
Fixed filter handling for categories and search

### DIFF
--- a/libraries/common/components/InfiniteContainer/index.jsx
+++ b/libraries/common/components/InfiniteContainer/index.jsx
@@ -208,7 +208,7 @@ class InfiniteContainer extends Component {
     /**
      * When items are cached, the initial limit can be "6".
      * Then, new offset should be limited to the "normal" limit (30).
-     * Otherwise, with cached items, this component would skip the inital number of items
+     * Otherwise, with cached items, this component would skip the initial number of items
      * when the cache is out.
      */
     if (start % this.props.limit) {
@@ -228,6 +228,9 @@ class InfiniteContainer extends Component {
       offset: [0, this.props.limit],
       awaitingItems: true,
     });
+
+    this.unbindEvents();
+    this.bindEvents();
   }
 
   /**

--- a/themes/theme-gmd/components/FilterBar/components/Content/components/FilterChips/index.jsx
+++ b/themes/theme-gmd/components/FilterBar/components/Content/components/FilterChips/index.jsx
@@ -22,11 +22,13 @@ class FilterChips extends Component {
     updateFilters: PropTypes.func.isRequired,
     currentPathname: PropTypes.string,
     filters: PropTypes.shape(),
+    scrollTop: PropTypes.func,
   };
 
   static defaultProps = {
     currentPathname: '',
     filters: null,
+    scrollTop: () => {},
   };
 
   /**
@@ -35,7 +37,9 @@ class FilterChips extends Component {
    * @param {number} value The value to remove (multiselect).
    */
   handleRemove = (id, value) => {
-    const { filters, routeId, updateFilters } = this.props;
+    const {
+      filters, routeId, updateFilters, scrollTop,
+    } = this.props;
     const { [id]: selected, ...rest } = filters;
 
     if (selected.type === FILTER_TYPE_MULTISELECT) {
@@ -54,6 +58,7 @@ class FilterChips extends Component {
 
         router.update(routeId, { filters: newFilters });
         updateFilters(newFilters);
+        scrollTop();
         return;
       }
     }
@@ -61,6 +66,7 @@ class FilterChips extends Component {
     const newFilters = (Object.keys(rest).length) ? rest : null;
     router.update(routeId, { filters: newFilters });
     updateFilters(newFilters);
+    scrollTop();
   }
 
   /**
@@ -85,7 +91,7 @@ class FilterChips extends Component {
            * since it rounds to the full nearest number when fractions are deactivated.
            */
           const [minimum, maximum] = filter.value;
-          const piceMin = Math.floor(minimum / 100);
+          const priceMin = Math.floor(minimum / 100);
           const priceMax = Math.ceil(maximum / 100);
 
           chips.push((
@@ -95,7 +101,7 @@ class FilterChips extends Component {
               onRemove={this.handleRemove}
               onClick={openFilters}
             >
-              <I18n.Price price={piceMin} currency={appConfig.currency} fractions={false} />
+              <I18n.Price price={priceMin} currency={appConfig.currency} fractions={false} />
               &nbsp;&mdash;&nbsp;
               <I18n.Price price={priceMax} currency={appConfig.currency} fractions={false} />
             </Chip>

--- a/themes/theme-gmd/components/FilterBar/components/Content/index.jsx
+++ b/themes/theme-gmd/components/FilterBar/components/Content/index.jsx
@@ -1,14 +1,19 @@
 import React, { Fragment } from 'react';
 import { RouteContext } from '@shopgate/pwa-common/context';
+import { ViewContext } from 'Components/View/context';
 import Consume from '@shopgate/pwa-common/components/Consume';
 import Sort from './components/Sort';
 import FilterButton from './components/FilterButton';
 import FilterChips from './components/FilterChips';
 import styles from './style';
 
-const map = {
+const mapRoute = {
   filters: 'state.filters',
   routeId: 'id',
+};
+
+const mapView = {
+  scrollTop: 'scrollTop',
 };
 
 /**
@@ -21,8 +26,14 @@ const FilterBarContent = () => (
       <Sort />
       <FilterButton />
     </div>
-    <Consume context={RouteContext} props={map}>
-      {({ filters, routeId }) => <FilterChips filters={filters} routeId={routeId} />}
+    <Consume context={RouteContext} props={mapRoute}>
+      {({ filters, routeId }) => (
+        <Consume context={ViewContext} props={mapView}>
+          {({ scrollTop }) => (
+            <FilterChips filters={filters} routeId={routeId} scrollTop={scrollTop} />
+          )}
+        </Consume>
+      )}
     </Consume>
   </Fragment>
 );

--- a/themes/theme-gmd/pages/Category/components/Bar/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/Category/components/Bar/__snapshots__/spec.jsx.snap
@@ -489,18 +489,48 @@ exports[`<Bar /> should match snapshot 1`] = `
                     }
                   >
                     <Consumer>
-                      <Connect(FilterChips)
-                        filters={null}
-                        routeId=""
+                      <Consume
+                        context={
+                          Object {
+                            "$$typeof": Symbol(react.context),
+                            "Consumer": Object {
+                              "$$typeof": Symbol(react.context),
+                              "_calculateChangedBits": null,
+                              "_context": [Circular],
+                            },
+                            "Provider": Object {
+                              "$$typeof": Symbol(react.provider),
+                              "_context": [Circular],
+                            },
+                            "_calculateChangedBits": null,
+                            "_currentRenderer": null,
+                            "_currentRenderer2": null,
+                            "_currentValue": undefined,
+                            "_currentValue2": undefined,
+                            "_threadCount": 0,
+                          }
+                        }
+                        props={
+                          Object {
+                            "scrollTop": "scrollTop",
+                          }
+                        }
                       >
-                        <FilterChips
-                          currentPathname="/"
+                        <Connect(FilterChips)
                           filters={null}
-                          openFilters={[Function]}
                           routeId=""
-                          updateFilters={[Function]}
-                        />
-                      </Connect(FilterChips)>
+                          scrollTop={null}
+                        >
+                          <FilterChips
+                            currentPathname="/"
+                            filters={null}
+                            openFilters={[Function]}
+                            routeId=""
+                            scrollTop={null}
+                            updateFilters={[Function]}
+                          />
+                        </Connect(FilterChips)>
+                      </Consume>
                     </Consumer>
                   </Consume>
                 </FilterBarContent>

--- a/themes/theme-gmd/pages/Category/components/Products/actions/getProducts.js
+++ b/themes/theme-gmd/pages/Category/components/Products/actions/getProducts.js
@@ -3,14 +3,16 @@ import fetchCategoryProducts from '@shopgate/pwa-common-commerce/category/action
 
 /**
  * @param {string} categoryId The category id to requests products for.
+ * @param {string} sort The sort order for the products to request.
  * @param {number} offset The offset for the products to request.
  * @return {Function} A redux thunk.
  */
-const getProducts = (categoryId, offset) => (dispatch, getState) => {
+const getProducts = (categoryId, sort, offset) => (dispatch, getState) => {
   const filters = getActiveFilters(getState());
 
   dispatch(fetchCategoryProducts({
     categoryId,
+    sort,
     offset,
     filters,
   }));

--- a/themes/theme-gmd/pages/Category/components/Products/connector.js
+++ b/themes/theme-gmd/pages/Category/components/Products/connector.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state, props) => ({
  * @return {Object} The extended component props.
  */
 const mapDispatchToProps = dispatch => ({
-  getProducts: (categoryId, offset) => dispatch(getProducts(categoryId, offset)),
+  getProducts: (categoryId, sort, offset) => dispatch(getProducts(categoryId, sort, offset)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/themes/theme-gmd/pages/Category/components/Products/index.jsx
+++ b/themes/theme-gmd/pages/Category/components/Products/index.jsx
@@ -8,6 +8,7 @@ import connect from './connector';
  */
 class CategoryProducts extends PureComponent {
   static propTypes = {
+    sort: PropTypes.string.isRequired,
     categoryId: PropTypes.string,
     getProducts: PropTypes.func,
     hash: PropTypes.string,
@@ -24,7 +25,11 @@ class CategoryProducts extends PureComponent {
   };
 
   fetchProducts = () => {
-    this.props.getProducts(this.props.categoryId, this.props.products.length);
+    this.props.getProducts(
+      this.props.categoryId,
+      this.props.sort,
+      this.props.products.length
+    );
   }
 
   /**

--- a/themes/theme-gmd/pages/Category/components/ProductsContent/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/Category/components/ProductsContent/__snapshots__/spec.jsx.snap
@@ -5,29 +5,31 @@ exports[`<ProductsContent /> should render 1`] = `
   categoryId="1234"
   hasProducts={false}
 >
-  <Portal
-    name="product.list.before"
-    props={
-      Object {
-        "categoryId": "1234",
+  <Consumer>
+    <Portal
+      name="product.list.before"
+      props={
+        Object {
+          "categoryId": "1234",
+        }
       }
-    }
-  />
-  <Portal
-    name="product.list"
-    props={
-      Object {
-        "categoryId": "1234",
+    />
+    <Portal
+      name="product.list"
+      props={
+        Object {
+          "categoryId": "1234",
+        }
       }
-    }
-  />
-  <Portal
-    name="product.list.after"
-    props={
-      Object {
-        "categoryId": "1234",
+    />
+    <Portal
+      name="product.list.after"
+      props={
+        Object {
+          "categoryId": "1234",
+        }
       }
-    }
-  />
+    />
+  </Consumer>
 </ProductsContent>
 `;

--- a/themes/theme-gmd/pages/Category/components/ProductsContent/index.jsx
+++ b/themes/theme-gmd/pages/Category/components/ProductsContent/index.jsx
@@ -1,6 +1,8 @@
 import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Portal from '@shopgate/pwa-common/components/Portal';
+import { DEFAULT_SORT } from '@shopgate/pwa-common/constants/DisplayOptions';
+import { RouteContext } from '@shopgate/pwa-common/context';
 import {
   PRODUCT_LIST,
   PRODUCT_LIST_AFTER,
@@ -26,15 +28,24 @@ class ProductsContent extends PureComponent {
    */
   render() {
     const { categoryId, hasProducts } = this.props;
+    const portalProps = { categoryId };
 
     return (
-      <Fragment>
-        <Portal name={PRODUCT_LIST_BEFORE} props={{ categoryId }} />
-        <Portal name={PRODUCT_LIST} props={{ categoryId }}>
-          {hasProducts && <Products categoryId={categoryId} />}
-        </Portal>
-        <Portal name={PRODUCT_LIST_AFTER} props={{ categoryId }} />
-      </Fragment>
+      <RouteContext.Consumer>
+        {({ state, query }) => (
+          <Fragment>
+            <Portal name={PRODUCT_LIST_BEFORE} props={portalProps} />
+            <Portal name={PRODUCT_LIST} props={portalProps}>
+              {hasProducts && <Products
+                categoryId={categoryId}
+                filters={state.filters}
+                sort={query.sort || DEFAULT_SORT}
+              />}
+            </Portal>
+            <Portal name={PRODUCT_LIST_AFTER} props={portalProps} />
+          </Fragment>
+        )}
+      </RouteContext.Consumer>
     );
   }
 }

--- a/themes/theme-gmd/pages/Search/components/Content/index.jsx
+++ b/themes/theme-gmd/pages/Search/components/Content/index.jsx
@@ -4,6 +4,7 @@ import { UIEvents } from '@shopgate/pwa-core';
 import NoResults from '@shopgate/pwa-ui-shared/NoResults';
 import { AppBar } from '@shopgate/pwa-ui-material';
 import { DEFAULT_SORT } from '@shopgate/pwa-common/constants/DisplayOptions';
+import { RouteContext } from '@shopgate/pwa-common/context';
 import { DefaultBar } from 'Components/AppBar/presets';
 import { TOGGLE_SEARCH } from 'Components/Search/constants';
 import Bar from '../Bar';
@@ -44,20 +45,28 @@ class SearchContent extends Component {
     } = this.props;
 
     return (
-      <Fragment>
-        <DefaultBar
-          center={<AppBar.Title title={searchPhrase} onClick={this.showSearch} />}
-          {...showFilterBar && { below: <Bar /> }}
-        />
-        <Products searchPhrase={searchPhrase} sortOrder={DEFAULT_SORT} />
-        {showNoResults && (
-          <NoResults
-            headlineText="search.no_result.heading"
-            bodyText="search.no_result.body"
-            searchPhrase={searchPhrase}
-          />
-        )}
-      </Fragment>
+      <RouteContext.Consumer>
+        {({ state, query }) => (
+          <Fragment>
+            <DefaultBar
+              center={<AppBar.Title title={searchPhrase} onClick={this.showSearch} />}
+              {...showFilterBar && { below: <Bar /> }}
+            />
+            <Products
+              searchPhrase={searchPhrase}
+              filters={state.filters}
+              sort={query.sort || DEFAULT_SORT}
+            />
+            {showNoResults && (
+              <NoResults
+                headlineText="search.no_result.heading"
+                bodyText="search.no_result.body"
+                searchPhrase={searchPhrase}
+              />
+            )}
+          </Fragment>
+          )}
+      </RouteContext.Consumer>
     );
   }
 }

--- a/themes/theme-gmd/pages/Search/components/Products/actions/getProducts.js
+++ b/themes/theme-gmd/pages/Search/components/Products/actions/getProducts.js
@@ -1,0 +1,21 @@
+import { getActiveFilters } from '@shopgate/pwa-common-commerce/filter/selectors';
+import fetchSearchResults from '@shopgate/pwa-common-commerce/search/actions/fetchSearchResults';
+
+/**
+ * @param {string} searchPhrase The search phrase to requests products for.
+ * @param {string} sort The sort order for the products to request.
+ * @param {number} offset The offset for the products to request.
+ * @return {Function} A redux thunk.
+ */
+const getProducts = (searchPhrase, sort, offset) => (dispatch, getState) => {
+  const filters = getActiveFilters(getState(), {});
+
+  dispatch(fetchSearchResults({
+    searchPhrase,
+    offset,
+    filters,
+    sort,
+  }));
+};
+
+export default getProducts;

--- a/themes/theme-gmd/pages/Search/components/Products/connector.js
+++ b/themes/theme-gmd/pages/Search/components/Products/connector.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import { getProductsResult } from '@shopgate/pwa-common-commerce/product/selectors/product';
-import fetchSearchResults from '@shopgate/pwa-common-commerce/search/actions/fetchSearchResults';
+import getProducts from './actions/getProducts';
 
 /**
  * Maps the contents of the state to the component props.
@@ -13,12 +13,14 @@ const mapStateToProps = (state, props) => ({
   ...getProductsResult(state, props),
 });
 
-const mapDispatchToProps = {
-  getProducts: (searchPhrase, offset) => fetchSearchResults({
-    searchPhrase,
-    offset,
-  }),
-};
+/**
+ * Connects the dispatch function to a callable function in the props.
+ * @param {Function} dispatch The redux dispatch function.
+ * @return {Object} The extended component props.
+ */
+const mapDispatchToProps = dispatch => ({
+  getProducts: (categoryId, sort, offset) => dispatch(getProducts(categoryId, sort, offset)),
+});
 
 /**
  * Check to see if the categories have arrived.

--- a/themes/theme-gmd/pages/Search/components/Products/index.jsx
+++ b/themes/theme-gmd/pages/Search/components/Products/index.jsx
@@ -9,7 +9,9 @@ import connect from './connector';
 class SearchProducts extends PureComponent {
   static propTypes = {
     getProducts: PropTypes.func.isRequired,
+    hash: PropTypes.string.isRequired,
     searchPhrase: PropTypes.string.isRequired,
+    sort: PropTypes.string.isRequired,
     products: PropTypes.arrayOf(PropTypes.shape()),
     totalProductCount: PropTypes.number,
   };
@@ -22,6 +24,7 @@ class SearchProducts extends PureComponent {
   fetchProducts = () => {
     this.props.getProducts(
       this.props.searchPhrase,
+      this.props.sort,
       this.props.products.length
     );
   }
@@ -39,6 +42,7 @@ class SearchProducts extends PureComponent {
         handleGetProducts={this.fetchProducts}
         products={this.props.products}
         totalProductCount={this.props.totalProductCount}
+        requestHash={this.props.hash}
       />
     );
   }

--- a/themes/theme-gmd/providers/View/index.jsx
+++ b/themes/theme-gmd/providers/View/index.jsx
@@ -34,6 +34,7 @@ class ViewProvider extends Component {
       setBottom: this.setBottom,
       setContentRef: this.setContentRef,
       getContentRef: this.getContentRef,
+      scrollTop: this.scrollTop,
     };
   }
 
@@ -62,6 +63,17 @@ class ViewProvider extends Component {
    * @return {Object}
    */
   getContentRef = () => this.state.contentRef;
+
+  /**
+   * Scrolls the content ref to the top.
+   * @param {number} [value=0] A number indicating the new scroll position of the content ref.
+   */
+  scrollTop = (value = 0) => {
+    const { current } = this.state.contentRef;
+    if (current) {
+      current.scrollTop = value;
+    }
+  }
 
   /**
    * @param {string} property The state property to set.

--- a/themes/theme-ios11/components/FilterBar/components/Content/components/FilterChips/index.jsx
+++ b/themes/theme-ios11/components/FilterBar/components/Content/components/FilterChips/index.jsx
@@ -22,11 +22,13 @@ class FilterChips extends Component {
     updateFilters: PropTypes.func.isRequired,
     currentPathname: PropTypes.string,
     filters: PropTypes.shape(),
+    scrollTop: PropTypes.func,
   };
 
   static defaultProps = {
     currentPathname: '',
     filters: null,
+    scrollTop: () => { },
   };
 
   /**
@@ -35,7 +37,9 @@ class FilterChips extends Component {
    * @param {number} value The value to remove (multiselect).
    */
   handleRemove = (id, value) => {
-    const { filters, routeId, updateFilters } = this.props;
+    const {
+      filters, routeId, updateFilters, scrollTop,
+    } = this.props;
     const { [id]: selected, ...rest } = filters;
 
     if (selected.type === FILTER_TYPE_MULTISELECT) {
@@ -54,6 +58,7 @@ class FilterChips extends Component {
 
         router.update(routeId, { filters: newFilters });
         updateFilters(newFilters);
+        scrollTop();
         return;
       }
     }
@@ -61,6 +66,7 @@ class FilterChips extends Component {
     const newFilters = (Object.keys(rest).length) ? rest : null;
     router.update(routeId, { filters: newFilters });
     updateFilters(newFilters);
+    scrollTop();
   }
 
   /**
@@ -85,7 +91,7 @@ class FilterChips extends Component {
            * since it rounds to the full nearest number when fractions are deactivated.
            */
           const [minimum, maximum] = filter.value;
-          const piceMin = Math.floor(minimum / 100);
+          const priceMin = Math.floor(minimum / 100);
           const priceMax = Math.ceil(maximum / 100);
 
           chips.push((
@@ -95,7 +101,7 @@ class FilterChips extends Component {
               onRemove={this.handleRemove}
               onClick={openFilters}
             >
-              <I18n.Price price={piceMin} currency={appConfig.currency} fractions={false} />
+              <I18n.Price price={priceMin} currency={appConfig.currency} fractions={false} />
               &nbsp;&mdash;&nbsp;
               <I18n.Price price={priceMax} currency={appConfig.currency} fractions={false} />
             </Chip>

--- a/themes/theme-ios11/components/FilterBar/components/Content/index.jsx
+++ b/themes/theme-ios11/components/FilterBar/components/Content/index.jsx
@@ -1,14 +1,19 @@
 import React, { Fragment } from 'react';
 import { RouteContext } from '@shopgate/pwa-common/context';
+import { ViewContext } from 'Components/View/context';
 import Consume from '@shopgate/pwa-common/components/Consume';
 import Sort from './components/Sort';
 import FilterButton from './components/FilterButton';
 import FilterChips from './components/FilterChips';
 import styles from './style';
 
-const map = {
+const mapRoute = {
   filters: 'state.filters',
   routeId: 'id',
+};
+
+const mapView = {
+  scrollTop: 'scrollTop',
 };
 
 /**
@@ -21,8 +26,14 @@ const FilterBarContent = () => (
       <Sort />
       <FilterButton />
     </div>
-    <Consume context={RouteContext} props={map}>
-      {({ filters, routeId }) => <FilterChips filters={filters} routeId={routeId} />}
+    <Consume context={RouteContext} props={mapRoute}>
+      {({ filters, routeId }) => (
+        <Consume context={ViewContext} props={mapView}>
+          {({ scrollTop }) => (
+            <FilterChips filters={filters} routeId={routeId} scrollTop={scrollTop} />
+          )}
+        </Consume>
+      )}
     </Consume>
   </Fragment>
 );

--- a/themes/theme-ios11/pages/Category/components/Bar/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Category/components/Bar/__snapshots__/spec.jsx.snap
@@ -489,18 +489,48 @@ exports[`<Bar /> should match snapshot 1`] = `
                     }
                   >
                     <Consumer>
-                      <Connect(FilterChips)
-                        filters={null}
-                        routeId=""
+                      <Consume
+                        context={
+                          Object {
+                            "$$typeof": Symbol(react.context),
+                            "Consumer": Object {
+                              "$$typeof": Symbol(react.context),
+                              "_calculateChangedBits": null,
+                              "_context": [Circular],
+                            },
+                            "Provider": Object {
+                              "$$typeof": Symbol(react.provider),
+                              "_context": [Circular],
+                            },
+                            "_calculateChangedBits": null,
+                            "_currentRenderer": null,
+                            "_currentRenderer2": null,
+                            "_currentValue": undefined,
+                            "_currentValue2": undefined,
+                            "_threadCount": 0,
+                          }
+                        }
+                        props={
+                          Object {
+                            "scrollTop": "scrollTop",
+                          }
+                        }
                       >
-                        <FilterChips
-                          currentPathname="/"
+                        <Connect(FilterChips)
                           filters={null}
-                          openFilters={[Function]}
                           routeId=""
-                          updateFilters={[Function]}
-                        />
-                      </Connect(FilterChips)>
+                          scrollTop={null}
+                        >
+                          <FilterChips
+                            currentPathname="/"
+                            filters={null}
+                            openFilters={[Function]}
+                            routeId=""
+                            scrollTop={null}
+                            updateFilters={[Function]}
+                          />
+                        </Connect(FilterChips)>
+                      </Consume>
                     </Consumer>
                   </Consume>
                 </FilterBarContent>

--- a/themes/theme-ios11/pages/Category/components/Products/actions/getProducts.js
+++ b/themes/theme-ios11/pages/Category/components/Products/actions/getProducts.js
@@ -3,14 +3,16 @@ import fetchCategoryProducts from '@shopgate/pwa-common-commerce/category/action
 
 /**
  * @param {string} categoryId The category id to requests products for.
+ * @param {string} sort The sort order for the products to request.
  * @param {number} offset The offset for the products to request.
  * @return {Function} A redux thunk.
  */
-const getProducts = (categoryId, offset) => (dispatch, getState) => {
+const getProducts = (categoryId, sort, offset) => (dispatch, getState) => {
   const filters = getActiveFilters(getState());
 
   dispatch(fetchCategoryProducts({
     categoryId,
+    sort,
     offset,
     filters,
   }));

--- a/themes/theme-ios11/pages/Category/components/Products/connector.js
+++ b/themes/theme-ios11/pages/Category/components/Products/connector.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state, props) => ({
  * @return {Object} The extended component props.
  */
 const mapDispatchToProps = dispatch => ({
-  getProducts: (categoryId, offset) => dispatch(getProducts(categoryId, offset)),
+  getProducts: (categoryId, sort, offset) => dispatch(getProducts(categoryId, sort, offset)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/themes/theme-ios11/pages/Category/components/Products/index.jsx
+++ b/themes/theme-ios11/pages/Category/components/Products/index.jsx
@@ -8,6 +8,7 @@ import connect from './connector';
  */
 class CategoryProducts extends PureComponent {
   static propTypes = {
+    sort: PropTypes.string.isRequired,
     categoryId: PropTypes.string,
     getProducts: PropTypes.func,
     hash: PropTypes.string,
@@ -24,7 +25,11 @@ class CategoryProducts extends PureComponent {
   };
 
   fetchProducts = () => {
-    this.props.getProducts(this.props.categoryId, this.props.products.length);
+    this.props.getProducts(
+      this.props.categoryId,
+      this.props.sort,
+      this.props.products.length
+    );
   }
 
   /**

--- a/themes/theme-ios11/pages/Category/components/ProductsContent/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Category/components/ProductsContent/__snapshots__/spec.jsx.snap
@@ -5,29 +5,31 @@ exports[`<ProductsContent /> should render 1`] = `
   categoryId="1234"
   hasProducts={false}
 >
-  <Portal
-    name="product.list.before"
-    props={
-      Object {
-        "categoryId": "1234",
+  <Consumer>
+    <Portal
+      name="product.list.before"
+      props={
+        Object {
+          "categoryId": "1234",
+        }
       }
-    }
-  />
-  <Portal
-    name="product.list"
-    props={
-      Object {
-        "categoryId": "1234",
+    />
+    <Portal
+      name="product.list"
+      props={
+        Object {
+          "categoryId": "1234",
+        }
       }
-    }
-  />
-  <Portal
-    name="product.list.after"
-    props={
-      Object {
-        "categoryId": "1234",
+    />
+    <Portal
+      name="product.list.after"
+      props={
+        Object {
+          "categoryId": "1234",
+        }
       }
-    }
-  />
+    />
+  </Consumer>
 </ProductsContent>
 `;

--- a/themes/theme-ios11/pages/Category/components/ProductsContent/index.jsx
+++ b/themes/theme-ios11/pages/Category/components/ProductsContent/index.jsx
@@ -1,6 +1,8 @@
 import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Portal from '@shopgate/pwa-common/components/Portal';
+import { DEFAULT_SORT } from '@shopgate/pwa-common/constants/DisplayOptions';
+import { RouteContext } from '@shopgate/pwa-common/context';
 import {
   PRODUCT_LIST,
   PRODUCT_LIST_AFTER,
@@ -26,15 +28,24 @@ class ProductsContent extends PureComponent {
    */
   render() {
     const { categoryId, hasProducts } = this.props;
+    const portalProps = { categoryId };
 
     return (
-      <Fragment>
-        <Portal name={PRODUCT_LIST_BEFORE} props={{ categoryId }} />
-        <Portal name={PRODUCT_LIST} props={{ categoryId }}>
-          {hasProducts && <Products categoryId={categoryId} />}
-        </Portal>
-        <Portal name={PRODUCT_LIST_AFTER} props={{ categoryId }} />
-      </Fragment>
+      <RouteContext.Consumer>
+        {({ state, query }) => (
+          <Fragment>
+            <Portal name={PRODUCT_LIST_BEFORE} props={portalProps} />
+            <Portal name={PRODUCT_LIST} props={portalProps}>
+              {hasProducts && <Products
+                categoryId={categoryId}
+                filters={state.filters}
+                sort={query.sort || DEFAULT_SORT}
+              />}
+            </Portal>
+            <Portal name={PRODUCT_LIST_AFTER} props={portalProps} />
+          </Fragment>
+        )}
+      </RouteContext.Consumer>
     );
   }
 }

--- a/themes/theme-ios11/pages/Search/components/Content/index.jsx
+++ b/themes/theme-ios11/pages/Search/components/Content/index.jsx
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import NoResults from '@shopgate/pwa-ui-shared/NoResults';
 import { DEFAULT_SORT } from '@shopgate/pwa-common/constants/DisplayOptions';
+import { RouteContext } from '@shopgate/pwa-common/context';
 import { BackBar } from 'Components/AppBar/presets';
 import Bar from '../Bar';
 import Products from '../Products';
@@ -37,20 +38,28 @@ class SearchContent extends Component {
     } = this.props;
 
     return (
-      <Fragment>
-        <BackBar
-          title={searchPhrase}
-          {...showFilterBar && { below: <Bar key="below" /> }}
-        />
-        <Products searchPhrase={searchPhrase} sortOrder={DEFAULT_SORT} />
-        {showNoResults && (
-          <NoResults
-            headlineText="search.no_result.heading"
-            bodyText="search.no_result.body"
-            searchPhrase={searchPhrase}
-          />
+      <RouteContext.Consumer>
+        {({ state, query }) => (
+          <Fragment>
+            <BackBar
+              title={searchPhrase}
+              {...showFilterBar && { below: <Bar key="below" /> }}
+            />
+            <Products
+              searchPhrase={searchPhrase}
+              filters={state.filters}
+              sort={query.sort || DEFAULT_SORT}
+            />
+            {showNoResults && (
+              <NoResults
+                headlineText="search.no_result.heading"
+                bodyText="search.no_result.body"
+                searchPhrase={searchPhrase}
+              />
+            )}
+          </Fragment>
         )}
-      </Fragment>
+      </RouteContext.Consumer>
     );
   }
 }

--- a/themes/theme-ios11/pages/Search/components/Products/actions/getProducts.js
+++ b/themes/theme-ios11/pages/Search/components/Products/actions/getProducts.js
@@ -1,0 +1,21 @@
+import { getActiveFilters } from '@shopgate/pwa-common-commerce/filter/selectors';
+import fetchSearchResults from '@shopgate/pwa-common-commerce/search/actions/fetchSearchResults';
+
+/**
+ * @param {string} searchPhrase The search phrase to requests products for.
+ * @param {string} sort The sort order for the products to request.
+ * @param {number} offset The offset for the products to request.
+ * @return {Function} A redux thunk.
+ */
+const getProducts = (searchPhrase, sort, offset) => (dispatch, getState) => {
+  const filters = getActiveFilters(getState(), {});
+
+  dispatch(fetchSearchResults({
+    searchPhrase,
+    offset,
+    filters,
+    sort,
+  }));
+};
+
+export default getProducts;

--- a/themes/theme-ios11/pages/Search/components/Products/connector.js
+++ b/themes/theme-ios11/pages/Search/components/Products/connector.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import { getProductsResult } from '@shopgate/pwa-common-commerce/product/selectors/product';
-import fetchSearchResults from '@shopgate/pwa-common-commerce/search/actions/fetchSearchResults';
+import getProducts from './actions/getProducts';
 
 /**
  * Maps the contents of the state to the component props.
@@ -13,13 +13,14 @@ const mapStateToProps = (state, props) => ({
   ...getProductsResult(state, props),
 });
 
-const mapDispatchToProps = {
-  getProducts: (searchPhrase, offset) => fetchSearchResults({
-    searchPhrase,
-    offset,
-  }),
-};
-
+/**
+ * Connects the dispatch function to a callable function in the props.
+ * @param {Function} dispatch The redux dispatch function.
+ * @return {Object} The extended component props.
+ */
+const mapDispatchToProps = dispatch => ({
+  getProducts: (categoryId, sort, offset) => dispatch(getProducts(categoryId, sort, offset)),
+});
 /**
  * Check to see if the categories have arrived.
  * @param {*} next The next state.

--- a/themes/theme-ios11/pages/Search/components/Products/index.jsx
+++ b/themes/theme-ios11/pages/Search/components/Products/index.jsx
@@ -9,7 +9,9 @@ import connect from './connector';
 class SearchProducts extends PureComponent {
   static propTypes = {
     getProducts: PropTypes.func.isRequired,
+    hash: PropTypes.string.isRequired,
     searchPhrase: PropTypes.string.isRequired,
+    sort: PropTypes.string.isRequired,
     products: PropTypes.arrayOf(PropTypes.shape()),
     totalProductCount: PropTypes.number,
   };
@@ -22,6 +24,7 @@ class SearchProducts extends PureComponent {
   fetchProducts = () => {
     this.props.getProducts(
       this.props.searchPhrase,
+      this.props.sort,
       this.props.products.length
     );
   }
@@ -39,6 +42,7 @@ class SearchProducts extends PureComponent {
         handleGetProducts={this.fetchProducts}
         products={this.props.products}
         totalProductCount={this.props.totalProductCount}
+        requestHash={this.props.hash}
       />
     );
   }

--- a/themes/theme-ios11/providers/View/index.jsx
+++ b/themes/theme-ios11/providers/View/index.jsx
@@ -34,6 +34,7 @@ class ViewProvider extends Component {
       setBottom: this.setBottom,
       setContentRef: this.setContentRef,
       getContentRef: this.getContentRef,
+      scrollTop: this.scrollTop,
     };
   }
 
@@ -62,6 +63,17 @@ class ViewProvider extends Component {
    * @return {Object}
    */
   getContentRef = () => this.state.contentRef;
+
+  /**
+   * Scrolls the content ref to the top.
+   * @param {number} [value=0] A number indicating the new scroll position of the content ref.
+   */
+  scrollTop = (value = 0) => {
+    const { current } = this.state.contentRef;
+    if (current) {
+      current.scrollTop = value;
+    }
+  }
 
   /**
    * @param {string} property The state property to set.


### PR DESCRIPTION
# Description
This ticket is about to fix an issue where product lists in categories or the search page didn't update after filters where removed.
It also introduces a scrollTop method to the ViewContext, which can be used to reset page scroll positions.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Open a category and filter it. When filter chips are removed, the product list updates as expected again.