### PR TITLE
Improved PWA pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "e2e:gmd": "make e2e-gmd",
     "e2e:ios11": "make e2e-ios11",
     "e2e:checkout": "make e2e-checkout",
-    "start-cloud": "sgconnect backend start & sgconnect frontend start"
+    "start-cloud": "sgconnect backend start & sgconnect frontend start",
+    "lint-staged": "lint-staged"
   },
   "husky": {
     "hooks": {
@@ -30,7 +31,11 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx}": ["eslint --quiet --ext .js --ext .jsx --ignore-pattern '/extensions/*' ."]
+    "linters": {
+      "*.{js,jsx,json}": [
+        "eslint"
+      ]
+    }
   },
   "devDependencies": {
     "coveralls": "^3.0.1",


### PR DESCRIPTION
# Description
This ticket is about to improve the PWA mono repository pre-commit hook. It now only lints staged files, instead of running ESLint for the whole project.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [x] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.