### PR TITLE
Always render RATING_* portals on PDP

### DIFF
--- a/themes/theme-gmd/pages/Product/components/Header/components/Rating/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Rating/index.jsx
@@ -39,24 +39,20 @@ const scrollToRating = () => {
  * @param {Object} props The component props.
  * @return {JSX}
  */
-const Rating = ({ rating }) => {
-  if (!appConfig.hasReviews || !rating || !rating.count) {
-    return null;
-  }
-
-  return (
-    <Fragment>
-      <Portal name={PRODUCT_RATING_BEFORE} />
-      <Portal name={PRODUCT_RATING}>
+const Rating = ({ rating }) => (
+  <Fragment>
+    <Portal name={PRODUCT_RATING_BEFORE} />
+    <Portal name={PRODUCT_RATING}>
+      {appConfig.hasReviews && rating && rating.count &&
         <div className={container} onClick={scrollToRating} role="link" aria-hidden>
           <RatingStars value={rating.average} display="big" />
           <RatingCount count={rating.count} prominent />
         </div>
-      </Portal>
-      <Portal name={PRODUCT_RATING_AFTER} />
-    </Fragment>
-  );
-};
+      }
+    </Portal>
+    <Portal name={PRODUCT_RATING_AFTER} />
+  </Fragment>
+);
 
 Rating.propTypes = {
   rating: PropTypes.shape(),

--- a/themes/theme-ios11/pages/Product/components/Header/components/Rating/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Rating/index.jsx
@@ -39,24 +39,20 @@ const scrollToRating = () => {
  * @param {Object} props The component props.
  * @return {JSX}
  */
-const Rating = ({ rating }) => {
-  if (!appConfig.hasReviews || !rating || !rating.count) {
-    return null;
-  }
-
-  return (
-    <Fragment>
-      <Portal name={PRODUCT_RATING_BEFORE} />
-      <Portal name={PRODUCT_RATING}>
+const Rating = ({ rating }) => (
+  <Fragment>
+    <Portal name={PRODUCT_RATING_BEFORE} />
+    <Portal name={PRODUCT_RATING}>
+      {appConfig.hasReviews && rating && rating.count &&
         <div className={container} onClick={scrollToRating} role="link" aria-hidden>
           <RatingStars value={rating.average} display="big" />
           <RatingCount count={rating.count} prominent />
         </div>
-      </Portal>
-      <Portal name={PRODUCT_RATING_AFTER} />
-    </Fragment>
-  );
-};
+      }
+    </Portal>
+    <Portal name={PRODUCT_RATING_AFTER} />
+  </Fragment>
+);
 
 Rating.propTypes = {
   rating: PropTypes.shape(),


### PR DESCRIPTION
# Description

Always render RATING_* portals on PDP

## Type of change

Please add an "x" into the option that is relevant:

- [  ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ X  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.
