### PR TITLE
Removed current route fallback for getProductId selector

### DIFF
--- a/libraries/commerce/product/selectors/product.js
+++ b/libraries/commerce/product/selectors/product.js
@@ -124,6 +124,7 @@ export const getProductId = (state, props) => {
      * To support debugging an error will be logged, if the props are missing at invocation.
      */
     logger.error('getProductId() needs to be called with a props object that includes a productId.');
+    return null;
   }
 
   // Since a variantId can have falsy values, we need an "undefined" check here.

--- a/libraries/commerce/product/selectors/product.js
+++ b/libraries/commerce/product/selectors/product.js
@@ -2,28 +2,11 @@ import { createSelector } from 'reselect';
 import isEqual from 'lodash/isEqual';
 import { getCurrentRoute } from '@shopgate/pwa-common/selectors/router';
 import { logger } from '@shopgate/pwa-core/helpers';
-import { hex2bin } from '@shopgate/pwa-common/helpers/data';
 import { generateResultHash } from '@shopgate/pwa-common/helpers/redux';
 import { DEFAULT_SORT } from '@shopgate/pwa-common/constants/DisplayOptions';
 import { getSortOrder } from '@shopgate/pwa-common/selectors/history';
 import { getActiveFilters } from '../../filter/selectors';
 import { filterProperties } from '../helpers';
-
-/**
- * Retrieves product id from route.
- * @param {Object} state The application state.
- * @returns {string|null} The product id of the current route.
- */
-export const getProductIdFromRoute = createSelector(
-  getCurrentRoute,
-  (route) => {
-    if (!route || !route.params || !route.params.productId) {
-      return null;
-    }
-
-    return hex2bin(route.params.productId);
-  }
-);
 
 /**
  * Retrieves the product state from the store.
@@ -134,8 +117,13 @@ export const getProductId = (state, props) => {
     return null;
   }
 
-  if (!props) {
-    return getProductIdFromRoute(state);
+  if (typeof props === 'undefined') {
+    /**
+     * Before PWA 6.0 some product selectors relied on a "currentProduct" state which doesn't exist
+     * anymore. Their successors require a props object which contains a productId or a variantId.
+     * To support debugging an error will be logged, if the props are missing at invocation.
+     */
+    logger.error('getProductId() needs to be called with a props object that includes a productId.');
   }
 
   // Since a variantId can have falsy values, we need an "undefined" check here.


### PR DESCRIPTION
# Description

Removed current route fallback for getProductId selector again because it caused issues

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.