### PR TITLE
Changed getPageConfig and getUser redux actions to fetch... to match the API

### DIFF
--- a/libraries/common/actions/page/fetchPageConfig.js
+++ b/libraries/common/actions/page/fetchPageConfig.js
@@ -1,0 +1,33 @@
+import { PipelineRequest, logger } from '@shopgate/pwa-core';
+import * as pipelines from '../../constants/Pipelines';
+import { shouldFetchData } from '../../helpers/redux';
+import * as actions from '../../action-creators/page';
+import { getPageConfigById } from '../../selectors/page';
+
+/**
+ * Retrieves the config for a page.
+ * @param {string} pageId The ID of the page to request.
+ * @param {boolean} [force=true] When true, the request will go out without being checked.
+ * @return {Function} The dispatched action.
+ */
+export default function fetchPageConfig(pageId, force = false) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const pageConfig = getPageConfigById(state, { pageId });
+
+    if (!force && !shouldFetchData(pageConfig)) {
+      return null;
+    }
+
+    dispatch(actions.requestPageConfig(pageId));
+
+    return new PipelineRequest(pipelines.SHOPGATE_CMS_GET_PAGE_CONFIG)
+      .setInput({ pageId })
+      .dispatch()
+      .then(result => dispatch(actions.receivePageConfig(pageId, result)))
+      .catch((error) => {
+        logger.error(error);
+        dispatch(actions.errorPageConfig(pageId));
+      });
+  };
+}

--- a/libraries/common/actions/page/getPageConfig.js
+++ b/libraries/common/actions/page/getPageConfig.js
@@ -1,33 +1,12 @@
-import { PipelineRequest, logger } from '@shopgate/pwa-core';
-import * as pipelines from '../../constants/Pipelines';
-import { shouldFetchData } from '../../helpers/redux';
-import * as actions from '../../action-creators/page';
-import { getPageConfigById } from '../../selectors/page';
+import { fetchPageConfig } from './fetchPageConfig';
 
 /**
  * Retrieves the config for a page.
  * @param {string} pageId The ID of the page to request.
  * @param {boolean} [force=true] When true, the request will go out without being checked.
  * @return {Function} The dispatched action.
+ * @deprecated
  */
-export default function getPageConfig(pageId, force = false) {
-  return (dispatch, getState) => {
-    const state = getState();
-    const pageConfig = getPageConfigById(state, { pageId });
+const getPageConfig = fetchPageConfig;
 
-    if (!force && !shouldFetchData(pageConfig)) {
-      return null;
-    }
-
-    dispatch(actions.requestPageConfig(pageId));
-
-    return new PipelineRequest(pipelines.SHOPGATE_CMS_GET_PAGE_CONFIG)
-      .setInput({ pageId })
-      .dispatch()
-      .then(result => dispatch(actions.receivePageConfig(pageId, result)))
-      .catch((error) => {
-        logger.error(error);
-        dispatch(actions.errorPageConfig(pageId));
-      });
-  };
-}
+export default getPageConfig;

--- a/libraries/common/actions/page/index.js
+++ b/libraries/common/actions/page/index.js
@@ -1,0 +1,1 @@
+export { default as fetchPageConfig } from './fetchPageConfig';

--- a/libraries/common/actions/user/fetchUser.js
+++ b/libraries/common/actions/user/fetchUser.js
@@ -1,0 +1,41 @@
+import { PipelineRequest, logger, EACCESS } from '@shopgate/pwa-core';
+import * as pipelines from '../../constants/Pipelines';
+import * as actions from '../../action-creators/user';
+import { isUserLoggedIn } from '../../selectors/user';
+
+/**
+ * Get the current user
+ * @return {Function} A redux thunk.
+ */
+export default function fetchUser() {
+  return (dispatch, getState) => {
+    dispatch(actions.requestUser());
+
+    return new PipelineRequest(pipelines.SHOPGATE_USER_GET_USER)
+      .setTrusted()
+      .setErrorBlacklist([EACCESS])
+      .dispatch()
+      .then((user) => {
+        dispatch(actions.receiveUser(user));
+
+        // If the user's login state was incorrectly set false then set to true.
+        if (!isUserLoggedIn(getState())) {
+          dispatch(actions.toggleLoggedIn(true));
+        }
+
+        return user;
+      })
+      .catch((error) => {
+        switch (error.code) {
+          case EACCESS:
+            dispatch(actions.toggleLoggedIn(false));
+            break;
+          default:
+            logger.error(error);
+            break;
+        }
+
+        dispatch(actions.errorUser());
+      });
+  };
+}

--- a/libraries/common/actions/user/getUser.js
+++ b/libraries/common/actions/user/getUser.js
@@ -1,41 +1,9 @@
-import { PipelineRequest, logger, EACCESS } from '@shopgate/pwa-core';
-import * as pipelines from '../../constants/Pipelines';
-import * as actions from '../../action-creators/user';
-import { isUserLoggedIn } from '../../selectors/user';
+import { fetchUser } from './fetchUser';
 
 /**
  * Get the current user
  * @return {Function} A redux thunk.
  */
-export default function getUser() {
-  return (dispatch, getState) => {
-    dispatch(actions.requestUser());
+const getUser = fetchUser;
 
-    return new PipelineRequest(pipelines.SHOPGATE_USER_GET_USER)
-      .setTrusted()
-      .setErrorBlacklist([EACCESS])
-      .dispatch()
-      .then((user) => {
-        dispatch(actions.receiveUser(user));
-
-        // If the user's login state was incorrectly set false then set to true.
-        if (!isUserLoggedIn(getState())) {
-          dispatch(actions.toggleLoggedIn(true));
-        }
-
-        return user;
-      })
-      .catch((error) => {
-        switch (error.code) {
-          case EACCESS:
-            dispatch(actions.toggleLoggedIn(false));
-            break;
-          default:
-            logger.error(error);
-            break;
-        }
-
-        dispatch(actions.errorUser());
-      });
-  };
-}
+export default getUser;

--- a/libraries/common/actions/user/index.js
+++ b/libraries/common/actions/user/index.js
@@ -1,0 +1,1 @@
+export { default as fetchUser } from './fetchUser';

--- a/libraries/common/subscriptions/user.js
+++ b/libraries/common/subscriptions/user.js
@@ -2,7 +2,7 @@ import { getCurrentRoute } from '@shopgate/pwa-common/selectors/router';
 import event from '@shopgate/pwa-core/classes/Event';
 import registerEvents from '@shopgate/pwa-core/commands/registerEvents';
 import { LoadingProvider } from '../providers';
-import getUser from '../actions/user/getUser';
+import { fetchUser } from '../actions/user';
 import { successLogin } from '../action-creators';
 import { historyPush } from '../actions/router';
 import {
@@ -36,7 +36,7 @@ export default function user(subscribe) {
   });
 
   subscribe(userNeedsUpdate$, ({ dispatch }) => {
-    dispatch(getUser());
+    dispatch(fetchUser());
   });
 
   subscribe(userDidLogout$, ({ dispatch }) => {

--- a/themes/theme-gmd/pages/Page/subscriptions.js
+++ b/themes/theme-gmd/pages/Page/subscriptions.js
@@ -1,4 +1,4 @@
-import getPageConfig from '@shopgate/pwa-common/actions/page/getPageConfig';
+import { fetchPageConfig } from '@shopgate/pwa-common/actions/page';
 import { pageWillEnter$ } from './streams';
 
 /**
@@ -7,6 +7,6 @@ import { pageWillEnter$ } from './streams';
  */
 export default function page(subscribe) {
   subscribe(pageWillEnter$, ({ action, dispatch }) => {
-    dispatch(getPageConfig(action.route.params.pageId));
+    dispatch(fetchPageConfig(action.route.params.pageId));
   });
 }

--- a/themes/theme-gmd/pages/StartPage/subscriptions.js
+++ b/themes/theme-gmd/pages/StartPage/subscriptions.js
@@ -1,5 +1,5 @@
 import { PAGE_ID_INDEX } from '@shopgate/pwa-common/constants/PageIDs';
-import getPageConfig from '@shopgate/pwa-common/actions/page/getPageConfig';
+import { fetchPageConfig } from '@shopgate/pwa-common/actions/page';
 import { startPageWillEnter$ } from './streams';
 
 let force = true;
@@ -10,7 +10,7 @@ let force = true;
  */
 export default function page(subscribe) {
   subscribe(startPageWillEnter$, ({ dispatch }) => {
-    dispatch(getPageConfig(PAGE_ID_INDEX, force));
+    dispatch(fetchPageConfig(PAGE_ID_INDEX, force));
     force = false;
   });
 }

--- a/themes/theme-ios11/pages/Page/subscriptions.js
+++ b/themes/theme-ios11/pages/Page/subscriptions.js
@@ -1,4 +1,4 @@
-import getPageConfig from '@shopgate/pwa-common/actions/page/getPageConfig';
+import { fetchPageConfig } from '@shopgate/pwa-common/actions/page';
 import { pageWillEnter$ } from './streams';
 
 /**
@@ -7,6 +7,6 @@ import { pageWillEnter$ } from './streams';
  */
 export default function page(subscribe) {
   subscribe(pageWillEnter$, ({ action, dispatch }) => {
-    dispatch(getPageConfig(action.route.params.pageId));
+    dispatch(fetchPageConfig(action.route.params.pageId));
   });
 }

--- a/themes/theme-ios11/pages/StartPage/subscriptions.js
+++ b/themes/theme-ios11/pages/StartPage/subscriptions.js
@@ -1,5 +1,5 @@
 import { PAGE_ID_INDEX } from '@shopgate/pwa-common/constants/PageIDs';
-import getPageConfig from '@shopgate/pwa-common/actions/page/getPageConfig';
+import { fetchPageConfig } from '@shopgate/pwa-common/actions/page';
 import { startPageWillEnter$ } from './streams';
 
 let force = true;
@@ -10,7 +10,7 @@ let force = true;
  */
 export default function page(subscribe) {
   subscribe(startPageWillEnter$, ({ dispatch }) => {
-    dispatch(getPageConfig(PAGE_ID_INDEX, force));
+    dispatch(fetchPageConfig(PAGE_ID_INDEX, force));
     force = false;
   });
 }


### PR DESCRIPTION
# Description

Those two functions haven't been renamed and were now changed to the new naming convention to match the API.

## Type of change

Please add an "x" into the option that is relevant:

- [  ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ x ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.