### PR TITLE
Added props to the store info section portals of the NavDrawer

### DIFF
--- a/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/ImprintButton/index.jsx
+++ b/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/ImprintButton/index.jsx
@@ -9,6 +9,7 @@ import Portal from '@shopgate/pwa-common/components/Portal';
 import InfoIcon from '@shopgate/pwa-ui-shared/icons/InfoIcon';
 import { NavDrawer } from '@shopgate/pwa-ui-material';
 import { IMPRINT_PATH } from '../../../../constants';
+import portalProps from '../../../../portalProps';
 import connect from '../../../../connector';
 
 const LABEL = 'navigation.about';
@@ -19,8 +20,8 @@ const LABEL = 'navigation.about';
  */
 const ImprintButton = ({ navigate }) => (
   <Fragment>
-    <Portal name={NAV_MENU_IMPRINT_BEFORE} />
-    <Portal name={NAV_MENU_IMPRINT}>
+    <Portal name={NAV_MENU_IMPRINT_BEFORE} props={portalProps} />
+    <Portal name={NAV_MENU_IMPRINT} props={portalProps}>
       <NavDrawer.Item
         label={LABEL}
         icon={InfoIcon}
@@ -28,7 +29,7 @@ const ImprintButton = ({ navigate }) => (
         testId="navDrawerImprintButton"
       />
     </Portal>
-    <Portal name={NAV_MENU_IMPRINT_AFTER} />
+    <Portal name={NAV_MENU_IMPRINT_AFTER} props={portalProps} />
   </Fragment>
 );
 

--- a/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/PaymentButton/index.jsx
+++ b/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/PaymentButton/index.jsx
@@ -9,6 +9,7 @@ import Portal from '@shopgate/pwa-common/components/Portal';
 import CreditCardIcon from '@shopgate/pwa-ui-shared/icons/CreditCardIcon';
 import { NavDrawer } from '@shopgate/pwa-ui-material';
 import { PAYMENT_PATH } from '../../../../constants';
+import portalProps from '../../../../portalProps';
 import connect from '../../../../connector';
 
 const LABEL = 'navigation.payment';
@@ -19,8 +20,8 @@ const LABEL = 'navigation.payment';
  */
 const PaymentButton = ({ navigate }) => (
   <Fragment>
-    <Portal name={NAV_MENU_PAYMENT_BEFORE} />
-    <Portal name={NAV_MENU_PAYMENT}>
+    <Portal name={NAV_MENU_PAYMENT_BEFORE} props={portalProps} />
+    <Portal name={NAV_MENU_PAYMENT} props={portalProps}>
       <NavDrawer.Item
         label={LABEL}
         icon={CreditCardIcon}
@@ -28,7 +29,7 @@ const PaymentButton = ({ navigate }) => (
         testId="navDrawerPaymentButton"
       />
     </Portal>
-    <Portal name={NAV_MENU_PAYMENT_AFTER} />
+    <Portal name={NAV_MENU_PAYMENT_AFTER} props={portalProps} />
   </Fragment>
 );
 

--- a/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/PrivacyButton/index.jsx
+++ b/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/PrivacyButton/index.jsx
@@ -9,6 +9,7 @@ import Portal from '@shopgate/pwa-common/components/Portal';
 import SecurityIcon from '@shopgate/pwa-ui-shared/icons/SecurityIcon';
 import { NavDrawer } from '@shopgate/pwa-ui-material';
 import { PRIVACY_PATH } from '../../../../constants';
+import portalProps from '../../../../portalProps';
 import connect from '../../../../connector';
 
 const LABEL = 'navigation.privacy';
@@ -19,8 +20,8 @@ const LABEL = 'navigation.privacy';
  */
 const PrivacyButton = ({ navigate }) => (
   <Fragment>
-    <Portal name={NAV_MENU_PRIVACY_BEFORE} />
-    <Portal name={NAV_MENU_PRIVACY}>
+    <Portal name={NAV_MENU_PRIVACY_BEFORE} props={portalProps} />
+    <Portal name={NAV_MENU_PRIVACY} props={portalProps}>
       <NavDrawer.Item
         label={LABEL}
         icon={SecurityIcon}
@@ -28,7 +29,7 @@ const PrivacyButton = ({ navigate }) => (
         testId="navDrawerPrivacyButton"
       />
     </Portal>
-    <Portal name={NAV_MENU_PRIVACY_AFTER} />
+    <Portal name={NAV_MENU_PRIVACY_AFTER} props={portalProps} />
   </Fragment>
 );
 

--- a/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/ReturnsButton/index.jsx
+++ b/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/ReturnsButton/index.jsx
@@ -9,6 +9,7 @@ import Portal from '@shopgate/pwa-common/components/Portal';
 import DescriptionIcon from '@shopgate/pwa-ui-shared/icons/DescriptionIcon';
 import { NavDrawer } from '@shopgate/pwa-ui-material';
 import { RETURN_POLICY_PATH } from '../../../../constants';
+import portalProps from '../../../../portalProps';
 import connect from '../../../../connector';
 
 const LABEL = 'navigation.return_policy';
@@ -19,8 +20,8 @@ const LABEL = 'navigation.return_policy';
  */
 const ReturnsButton = ({ navigate }) => (
   <Fragment>
-    <Portal name={NAV_MENU_RETURN_POLICY_BEFORE} />
-    <Portal name={NAV_MENU_RETURN_POLICY}>
+    <Portal name={NAV_MENU_RETURN_POLICY_BEFORE} props={portalProps} />
+    <Portal name={NAV_MENU_RETURN_POLICY} props={portalProps}>
       <NavDrawer.Item
         label={LABEL}
         icon={DescriptionIcon}
@@ -28,7 +29,7 @@ const ReturnsButton = ({ navigate }) => (
         testId="navDrawerReturnsButton"
       />
     </Portal>
-    <Portal name={NAV_MENU_RETURN_POLICY_AFTER} />
+    <Portal name={NAV_MENU_RETURN_POLICY_AFTER} props={portalProps} />
   </Fragment>
 );
 

--- a/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/ShippingButton/index.jsx
+++ b/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/ShippingButton/index.jsx
@@ -9,6 +9,7 @@ import Portal from '@shopgate/pwa-common/components/Portal';
 import LocalShippingIcon from '@shopgate/pwa-ui-shared/icons/LocalShippingIcon';
 import { NavDrawer } from '@shopgate/pwa-ui-material';
 import { SHIPPING_PATH } from '../../../../constants';
+import portalProps from '../../../../portalProps';
 import connect from '../../../../connector';
 
 const LABEL = 'navigation.shipping';
@@ -19,8 +20,8 @@ const LABEL = 'navigation.shipping';
  */
 const ShippingButton = ({ navigate }) => (
   <Fragment>
-    <Portal name={NAV_MENU_SHIPPING_BEFORE} />
-    <Portal name={NAV_MENU_SHIPPING}>
+    <Portal name={NAV_MENU_SHIPPING_BEFORE} props={portalProps} />
+    <Portal name={NAV_MENU_SHIPPING} props={portalProps}>
       <NavDrawer.Item
         label={LABEL}
         icon={LocalShippingIcon}
@@ -28,7 +29,7 @@ const ShippingButton = ({ navigate }) => (
         testId="navDrawerShippingButton"
       />
     </Portal>
-    <Portal name={NAV_MENU_SHIPPING_AFTER} />
+    <Portal name={NAV_MENU_SHIPPING_AFTER} props={portalProps} />
   </Fragment>
 );
 

--- a/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/TermsButton/index.jsx
+++ b/themes/theme-gmd/components/NavDrawer/components/StoreInfo/components/TermsButton/index.jsx
@@ -9,6 +9,7 @@ import Portal from '@shopgate/pwa-common/components/Portal';
 import DescriptionIcon from '@shopgate/pwa-ui-shared/icons/DescriptionIcon';
 import { NavDrawer } from '@shopgate/pwa-ui-material';
 import { TERMS_PATH } from '../../../../constants';
+import portalProps from '../../../../portalProps';
 import connect from '../../../../connector';
 
 const LABEL = 'navigation.terms';
@@ -19,8 +20,8 @@ const LABEL = 'navigation.terms';
  */
 const TermsButton = ({ navigate }) => (
   <Fragment>
-    <Portal name={NAV_MENU_TERMS_BEFORE} />
-    <Portal name={NAV_MENU_TERMS}>
+    <Portal name={NAV_MENU_TERMS_BEFORE} props={portalProps} />
+    <Portal name={NAV_MENU_TERMS} props={portalProps}>
       <NavDrawer.Item
         label={LABEL}
         icon={DescriptionIcon}
@@ -28,7 +29,7 @@ const TermsButton = ({ navigate }) => (
         testId="navDrawerTermsButton"
       />
     </Portal>
-    <Portal name={NAV_MENU_TERMS_AFTER} />
+    <Portal name={NAV_MENU_TERMS_AFTER} props={portalProps} />
   </Fragment>
 );
 

--- a/themes/theme-ios11/pages/More/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/pages/More/__snapshots__/index.spec.jsx.snap
@@ -608,64 +608,99 @@ exports[`<More /> should render as expected when the user is logged in 1`] = `
                   <div
                     data-test-id="userMenu"
                   >
-                    <nav
-                      className={
-                        Object {
-                          "data-css-13ch7sr": "",
-                        }
-                      }
+                    <Section
+                      title="navigation.your_account"
                     >
-                      <Portal
-                        name="nav-menu.logout.before"
-                        props={
+                      <Headline
+                        style={
                           Object {
-                            "Item": [Function],
+                            "margin": "24px 20px 16px",
                           }
                         }
-                      />
-                      <Portal
-                        name="nav-menu.logout"
-                        props={
+                        tag="h2"
+                        text="navigation.your_account"
+                      >
+                        <h2
+                          className="css-18cwfw7"
+                          data-test-id="Headline"
+                          style={
+                            Object {
+                              "margin": "24px 20px 16px",
+                            }
+                          }
+                        >
+                          <Translate
+                            className=""
+                            params={Object {}}
+                            string="navigation.your_account"
+                          >
+                            <span
+                              className=""
+                            >
+                              navigation.your_account
+                            </span>
+                          </Translate>
+                        </h2>
+                      </Headline>
+                      <div
+                        className={
                           Object {
-                            "Item": [Function],
+                            "data-css-13ch7sr": "",
                           }
                         }
                       >
-                        <MoreMenuItem
-                          className="css-1usb1k2"
-                          href={null}
-                          label="navigation.logout"
-                          onClick={[Function]}
-                          testId="logoutButton"
-                        >
-                          <button
-                            className="css-1usb1k2"
-                            data-test-id="logoutButton"
-                            onClick={[Function]}
-                          >
-                            <Translate
-                              className=""
-                              params={Object {}}
-                              string="navigation.logout"
-                            >
-                              <span
-                                className=""
-                              >
-                                navigation.logout
-                              </span>
-                            </Translate>
-                          </button>
-                        </MoreMenuItem>
-                      </Portal>
-                      <Portal
-                        name="nav-menu.logout.after"
-                        props={
-                          Object {
-                            "Item": [Function],
+                        <Portal
+                          name="nav-menu.logout.before"
+                          props={
+                            Object {
+                              "Item": [Function],
+                            }
                           }
-                        }
-                      />
-                    </nav>
+                        />
+                        <Portal
+                          name="nav-menu.logout"
+                          props={
+                            Object {
+                              "Item": [Function],
+                            }
+                          }
+                        >
+                          <MoreMenuItem
+                            className={null}
+                            href={null}
+                            label="navigation.logout"
+                            onClick={[Function]}
+                            testId="logoutButton"
+                          >
+                            <button
+                              className="css-1hj8a57"
+                              data-test-id="logoutButton"
+                              onClick={[Function]}
+                            >
+                              <Translate
+                                className=""
+                                params={Object {}}
+                                string="navigation.logout"
+                              >
+                                <span
+                                  className=""
+                                >
+                                  navigation.logout
+                                </span>
+                              </Translate>
+                            </button>
+                          </MoreMenuItem>
+                        </Portal>
+                        <Portal
+                          name="nav-menu.logout.after"
+                          props={
+                            Object {
+                              "Item": [Function],
+                            }
+                          }
+                        />
+                      </div>
+                    </Section>
                   </div>
                 </Portal>
                 <Portal

--- a/themes/theme-ios11/pages/More/components/UserMenu/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/pages/More/components/UserMenu/__snapshots__/index.spec.jsx.snap
@@ -64,64 +64,99 @@ exports[`<UserMenu /> should render as expected when the user is logged in 1`] =
           <div
             data-test-id="userMenu"
           >
-            <nav
-              className={
-                Object {
-                  "data-css-13ch7sr": "",
-                }
-              }
+            <Section
+              title="navigation.your_account"
             >
-              <Portal
-                name="nav-menu.logout.before"
-                props={
+              <Headline
+                style={
                   Object {
-                    "Item": [Function],
+                    "margin": "24px 20px 16px",
                   }
                 }
-              />
-              <Portal
-                name="nav-menu.logout"
-                props={
+                tag="h2"
+                text="navigation.your_account"
+              >
+                <h2
+                  className="css-18cwfw7"
+                  data-test-id="Headline"
+                  style={
+                    Object {
+                      "margin": "24px 20px 16px",
+                    }
+                  }
+                >
+                  <Translate
+                    className=""
+                    params={Object {}}
+                    string="navigation.your_account"
+                  >
+                    <span
+                      className=""
+                    >
+                      navigation.your_account
+                    </span>
+                  </Translate>
+                </h2>
+              </Headline>
+              <div
+                className={
                   Object {
-                    "Item": [Function],
+                    "data-css-13ch7sr": "",
                   }
                 }
               >
-                <MoreMenuItem
-                  className="css-1usb1k2"
-                  href={null}
-                  label="navigation.logout"
-                  onClick={[MockFunction]}
-                  testId="logoutButton"
-                >
-                  <button
-                    className="css-1usb1k2"
-                    data-test-id="logoutButton"
-                    onClick={[MockFunction]}
-                  >
-                    <Translate
-                      className=""
-                      params={Object {}}
-                      string="navigation.logout"
-                    >
-                      <span
-                        className=""
-                      >
-                        navigation.logout
-                      </span>
-                    </Translate>
-                  </button>
-                </MoreMenuItem>
-              </Portal>
-              <Portal
-                name="nav-menu.logout.after"
-                props={
-                  Object {
-                    "Item": [Function],
+                <Portal
+                  name="nav-menu.logout.before"
+                  props={
+                    Object {
+                      "Item": [Function],
+                    }
                   }
-                }
-              />
-            </nav>
+                />
+                <Portal
+                  name="nav-menu.logout"
+                  props={
+                    Object {
+                      "Item": [Function],
+                    }
+                  }
+                >
+                  <MoreMenuItem
+                    className={null}
+                    href={null}
+                    label="navigation.logout"
+                    onClick={[MockFunction]}
+                    testId="logoutButton"
+                  >
+                    <button
+                      className="css-1hj8a57"
+                      data-test-id="logoutButton"
+                      onClick={[MockFunction]}
+                    >
+                      <Translate
+                        className=""
+                        params={Object {}}
+                        string="navigation.logout"
+                      >
+                        <span
+                          className=""
+                        >
+                          navigation.logout
+                        </span>
+                      </Translate>
+                    </button>
+                  </MoreMenuItem>
+                </Portal>
+                <Portal
+                  name="nav-menu.logout.after"
+                  props={
+                    Object {
+                      "Item": [Function],
+                    }
+                  }
+                />
+              </div>
+            </Section>
           </div>
         </Portal>
         <Portal

--- a/themes/theme-ios11/pages/More/components/UserMenu/components/LoggedIn/index.jsx
+++ b/themes/theme-ios11/pages/More/components/UserMenu/components/LoggedIn/index.jsx
@@ -2,8 +2,8 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Portal from '@shopgate/pwa-common/components/Portal';
 import * as commonPortals from '@shopgate/pwa-common/constants/Portals';
+import Section from '../../../Section';
 import Item from '../../../Item';
-import pageStyles from '../../../../style';
 
 /**
  * @param {Object} props The component props.
@@ -17,18 +17,17 @@ const LoggedIn = ({ logout }) => {
       <Portal name={commonPortals.NAV_MENU_MY_ACCOUNT_BEFORE} props={props} />
       <Portal name={commonPortals.NAV_MENU_MY_ACCOUNT} props={props}>
         <div data-test-id="userMenu">
-          <nav className={pageStyles.list}>
+          <Section title="navigation.your_account">
             <Portal name={commonPortals.NAV_MENU_LOGOUT_BEFORE} props={props} />
             <Portal name={commonPortals.NAV_MENU_LOGOUT} props={props}>
               <Item
                 onClick={logout}
                 label="navigation.logout"
-                className={pageStyles.loggedInListItem.toString()}
                 testId="logoutButton"
               />
             </Portal>
             <Portal name={commonPortals.NAV_MENU_LOGOUT_AFTER} props={props} />
-          </nav>
+          </Section>
         </div>
       </Portal>
       <Portal name={commonPortals.NAV_MENU_MY_ACCOUNT_AFTER} props={props} />

--- a/themes/theme-ios11/pages/More/components/UserMenu/index.spec.jsx
+++ b/themes/theme-ios11/pages/More/components/UserMenu/index.spec.jsx
@@ -22,8 +22,8 @@ describe('<UserMenu />', () => {
 
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('LoggedIn').exists()).toBe(true);
-    expect(wrapper.find('nav MoreMenuItem').text()).toBe('navigation.logout');
-    wrapper.find('nav MoreMenuItem').simulate('click');
+    expect(wrapper.find('MoreMenuItem').text()).toBe('navigation.logout');
+    wrapper.find('MoreMenuItem').simulate('click');
     expect(logoutHandler).toHaveBeenCalledTimes(1);
   });
 

--- a/themes/theme-ios11/pages/More/style.js
+++ b/themes/theme-ios11/pages/More/style.js
@@ -1,21 +1,7 @@
 import { css } from 'glamor';
-import colors from '../../styles/colors';
 
 const list = css({
   margin: '0 20px 8px',
-});
-
-const loggedInListItem = css({
-  '&:first-child': {
-    boxShadow: `0 -4px 0 0 ${colors.darkGray}`,
-  },
-  boxShadow: `0 -1px 0 0 ${colors.darkGray}`,
-  padding: '12px 0',
-  'button&': {
-    outline: 0,
-    textAlign: 'inherit',
-    width: '100%',
-  },
 });
 
 const headline = {
@@ -24,6 +10,5 @@ const headline = {
 
 export default {
   list,
-  loggedInListItem,
   headline,
 };


### PR DESCRIPTION
# Description
This ticket is about to add missing Portal props to the section items of the GMD NavDrawer. They have been forgotten during the latest restructuring of the components.
Additionally it re-adds a headline to the Logout section of the More page on iOS which comes visible when a user is logged in.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [x] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.
