### PR TITLE
Fixed ImageSliderWidget update when the startpage was updated

### DIFF
--- a/extensions/@shopgate-user-privacy/frontend/DeleteAccount/index.jsx
+++ b/extensions/@shopgate-user-privacy/frontend/DeleteAccount/index.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { NavDrawer } from '@shopgate/pwa-ui-material';
 import SecurityIcon from '@shopgate/pwa-ui-shared/icons/SecurityIcon';
 import connect from './connector';
 
@@ -14,6 +13,7 @@ class DeleteAccount extends Component {
 
   static propTypes = {
     deleteAccount: PropTypes.func.isRequired,
+    Item: PropTypes.node.isRequired,
     isShown: PropTypes.bool,
   }
 
@@ -33,7 +33,6 @@ class DeleteAccount extends Component {
    */
   render() {
     const { Item, isShown } = this.props;
-    const { __ } = this.context.i18n();
 
     if (!isShown) {
       return null;

--- a/libraries/common/components/Slider/__snapshots__/spec.jsx.snap
+++ b/libraries/common/components/Slider/__snapshots__/spec.jsx.snap
@@ -83,7 +83,7 @@ exports[`<Slider /> renders with a fraction indicator 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s0"
+                key=".$0_0"
               >
                 <SliderItem
                   key="0"
@@ -98,7 +98,7 @@ exports[`<Slider /> renders with a fraction indicator 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s1"
+                key=".$1_1"
               >
                 <SliderItem
                   key="1"
@@ -113,7 +113,7 @@ exports[`<Slider /> renders with a fraction indicator 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s2"
+                key=".$2_2"
               >
                 <SliderItem
                   key="2"
@@ -219,7 +219,7 @@ exports[`<Slider /> renders with bullet indicators 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s0"
+                key=".$0_0"
               >
                 <SliderItem
                   key="0"
@@ -234,7 +234,7 @@ exports[`<Slider /> renders with bullet indicators 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s1"
+                key=".$1_1"
               >
                 <SliderItem
                   key="1"
@@ -249,7 +249,7 @@ exports[`<Slider /> renders with bullet indicators 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s2"
+                key=".$2_2"
               >
                 <SliderItem
                   key="2"
@@ -338,7 +338,7 @@ exports[`<Slider /> renders with children 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s0"
+                key=".$0_0"
               >
                 <SliderItem
                   key="0"
@@ -353,7 +353,7 @@ exports[`<Slider /> renders with children 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s1"
+                key=".$1_1"
               >
                 <SliderItem
                   key="1"
@@ -368,7 +368,7 @@ exports[`<Slider /> renders with children 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s2"
+                key=".$2_2"
               >
                 <SliderItem
                   key="2"
@@ -456,7 +456,7 @@ exports[`<Slider /> renders with controls 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s0"
+                key=".$0_0"
               >
                 <SliderItem
                   key="0"
@@ -471,7 +471,7 @@ exports[`<Slider /> renders with controls 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s1"
+                key=".$1_1"
               >
                 <SliderItem
                   key="1"
@@ -486,7 +486,7 @@ exports[`<Slider /> renders with controls 1`] = `
               <div
                 className="sg-swiper-slide css-1l9a57c "
                 data-test-id="Slider"
-                key=".$s2"
+                key=".$2_2"
               >
                 <SliderItem
                   key="2"

--- a/libraries/common/components/Slider/index.jsx
+++ b/libraries/common/components/Slider/index.jsx
@@ -279,7 +279,7 @@ class Slider extends Component {
     const hasMultipleChildren = children.length > 1;
 
     const wrappedChildren = this.props.children.map((child, index) => {
-      const key = `s${index}`;
+      const key = child.key ? `${child.key}_${index}` : index;
 
       return (
         <div className={styles.slideWrapper} key={key} data-test-id="Slider">

--- a/libraries/ui-shared/ImageSlider/index.jsx
+++ b/libraries/ui-shared/ImageSlider/index.jsx
@@ -53,8 +53,10 @@ class ImageSlider extends Component {
     const imageSliderItems = [];
 
     React.Children.forEach(this.props.children, (child, index) => {
+      const key = child.key ? `${child.key}_${index}` : index;
+
       imageSliderItems.push((
-        <Slider.Item key={index}>
+        <Slider.Item key={key}>
           {child}
         </Slider.Item>
       ));

--- a/themes/theme-gmd/widgets/ImageSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/widgets/ImageSlider/__snapshots__/spec.jsx.snap
@@ -145,10 +145,10 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
                   <div
                     className="sg-swiper-slide css-1l9a57c "
                     data-test-id="Slider"
-                    key=".$s0"
+                    key=".$cff8d88442d10b88424de77967c68124_0_0"
                   >
                     <SliderItem
-                      key="0"
+                      key="cff8d88442d10b88424de77967c68124_0"
                     >
                       <div
                         className="css-10a4qrv"
@@ -157,7 +157,7 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
                           className="css-63oe3q"
                           data-test-id="withLink"
                           href="http://example.com"
-                          key="si0"
+                          key="cff8d88442d10b88424de77967c68124"
                         >
                           <Link
                             className="css-63oe3q"
@@ -194,10 +194,10 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
                   <div
                     className="sg-swiper-slide css-1l9a57c "
                     data-test-id="Slider"
-                    key=".$s1"
+                    key=".$77387b0455b43e9c56aaeff7c21c7340_1_1"
                   >
                     <SliderItem
-                      key="1"
+                      key="77387b0455b43e9c56aaeff7c21c7340_1"
                     >
                       <div
                         className="css-10a4qrv"
@@ -206,7 +206,7 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
                           className="css-63oe3q"
                           data-test-id="withLink"
                           href="http://other.example.com"
-                          key="si1"
+                          key="77387b0455b43e9c56aaeff7c21c7340"
                         >
                           <Link
                             className="css-63oe3q"
@@ -305,7 +305,7 @@ exports[`<ImageSliderWidget /> should render no slider with just a single image 
         className="css-63oe3q"
         data-test-id="withLink"
         href="http://example.com"
-        key=".$si0"
+        key=".$cff8d88442d10b88424de77967c68124"
       >
         <Link
           className="css-63oe3q"
@@ -395,7 +395,7 @@ exports[`<ImageSliderWidget /> should render the images unlinked if no link is s
           }
         }
         data-test-id="withoutLink"
-        key=".$si0"
+        key=".$cff8d88442d10b88424de77967c68124"
         src="http://placehold.it/350x150"
       />
     </ImageSlider>
@@ -556,10 +556,10 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                   <div
                     className="sg-swiper-slide css-1l9a57c "
                     data-test-id="Slider"
-                    key=".$s0"
+                    key=".$cff8d88442d10b88424de77967c68124_0_0"
                   >
                     <SliderItem
-                      key="0"
+                      key="cff8d88442d10b88424de77967c68124_0"
                     >
                       <div
                         className="css-10a4qrv"
@@ -568,7 +568,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                           className="css-63oe3q"
                           data-test-id="withLink"
                           href="http://example.com"
-                          key="si0"
+                          key="cff8d88442d10b88424de77967c68124"
                         >
                           <Link
                             className="css-63oe3q"
@@ -605,10 +605,10 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                   <div
                     className="sg-swiper-slide css-1l9a57c "
                     data-test-id="Slider"
-                    key=".$s1"
+                    key=".$cff8d88442d10b88424de77967c68124_1_1"
                   >
                     <SliderItem
-                      key="1"
+                      key="cff8d88442d10b88424de77967c68124_1"
                     >
                       <div
                         className="css-10a4qrv"
@@ -620,7 +620,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                             }
                           }
                           data-test-id="withoutLink"
-                          key="si1"
+                          key="cff8d88442d10b88424de77967c68124"
                           src="http://placehold.it/350x150"
                         />
                       </div>
@@ -629,10 +629,10 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                   <div
                     className="sg-swiper-slide css-1l9a57c "
                     data-test-id="Slider"
-                    key=".$s2"
+                    key=".$cff8d88442d10b88424de77967c68124_2_2"
                   >
                     <SliderItem
-                      key="2"
+                      key="cff8d88442d10b88424de77967c68124_2"
                     >
                       <div
                         className="css-10a4qrv"
@@ -641,7 +641,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                           className="css-63oe3q"
                           data-test-id="withLink"
                           href="http://example.com"
-                          key="si2"
+                          key="cff8d88442d10b88424de77967c68124"
                         >
                           <Link
                             className="css-63oe3q"
@@ -678,10 +678,10 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                   <div
                     className="sg-swiper-slide css-1l9a57c "
                     data-test-id="Slider"
-                    key=".$s3"
+                    key=".$cff8d88442d10b88424de77967c68124_3_3"
                   >
                     <SliderItem
-                      key="3"
+                      key="cff8d88442d10b88424de77967c68124_3"
                     >
                       <div
                         className="css-10a4qrv"
@@ -690,7 +690,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                           className="css-63oe3q"
                           data-test-id="withLink"
                           href="http://example.com"
-                          key="si3"
+                          key="cff8d88442d10b88424de77967c68124"
                         >
                           <Link
                             className="css-63oe3q"
@@ -887,10 +887,10 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                   <div
                     className="sg-swiper-slide css-1l9a57c "
                     data-test-id="Slider"
-                    key=".$s0"
+                    key=".$cff8d88442d10b88424de77967c68124_0_0"
                   >
                     <SliderItem
-                      key="0"
+                      key="cff8d88442d10b88424de77967c68124_0"
                     >
                       <div
                         className="css-10a4qrv"
@@ -899,7 +899,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                           className="css-63oe3q"
                           data-test-id="withLink"
                           href="http://example.com"
-                          key="si0"
+                          key="cff8d88442d10b88424de77967c68124"
                         >
                           <Link
                             className="css-63oe3q"
@@ -936,10 +936,10 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                   <div
                     className="sg-swiper-slide css-1l9a57c "
                     data-test-id="Slider"
-                    key=".$s1"
+                    key=".$cff8d88442d10b88424de77967c68124_1_1"
                   >
                     <SliderItem
-                      key="1"
+                      key="cff8d88442d10b88424de77967c68124_1"
                     >
                       <div
                         className="css-10a4qrv"
@@ -948,7 +948,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                           className="css-63oe3q"
                           data-test-id="withLink"
                           href="http://example.com"
-                          key="si1"
+                          key="cff8d88442d10b88424de77967c68124"
                         >
                           <Link
                             className="css-63oe3q"
@@ -985,10 +985,10 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                   <div
                     className="sg-swiper-slide css-1l9a57c "
                     data-test-id="Slider"
-                    key=".$s2"
+                    key=".$cff8d88442d10b88424de77967c68124_2_2"
                   >
                     <SliderItem
-                      key="2"
+                      key="cff8d88442d10b88424de77967c68124_2"
                     >
                       <div
                         className="css-10a4qrv"
@@ -997,7 +997,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                           className="css-63oe3q"
                           data-test-id="withLink"
                           href="http://example.com"
-                          key="si2"
+                          key="cff8d88442d10b88424de77967c68124"
                         >
                           <Link
                             className="css-63oe3q"

--- a/themes/theme-gmd/widgets/ImageSlider/index.jsx
+++ b/themes/theme-gmd/widgets/ImageSlider/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import CryptoJs from 'crypto-js';
 import Link from '@shopgate/pwa-common/components/Link';
 import ImageSlider from '@shopgate/pwa-ui-shared/ImageSlider';
 import styles from './style';
@@ -17,8 +18,8 @@ const ImageSliderWidget = ({ settings, className }) => (
     interval={settings.delay}
     loop={settings.loop}
   >
-    {settings.images.map((image, index) => {
-      const key = `si${index}`;
+    {settings.images.map((image) => {
+      const key = CryptoJs.MD5(image.image);
 
       if (image.link) {
         return (

--- a/themes/theme-gmd/widgets/ImageSlider/spec.jsx
+++ b/themes/theme-gmd/widgets/ImageSlider/spec.jsx
@@ -57,6 +57,7 @@ describe('<ImageSliderWidget />', () => {
   });
 
   it('should map the correct image settings to the components', () => {
+    expect.assertions(3);
     const settings = {
       ...testSettings,
       images: [
@@ -68,12 +69,10 @@ describe('<ImageSliderWidget />', () => {
     const wrapper = createComponent({ settings });
 
     expect(wrapper).toMatchSnapshot();
-    const images = wrapper.find('Image');
-    let index = 0;
-    images.forEach((image) => {
+    const images = wrapper.find('div.sg-swiper-slide img');
+    images.forEach((image, index) => {
       const imageProps = image.props();
       const imageSettings = settings.images[index];
-      index += 1;
 
       expect(imageProps.src).toBe(imageSettings.image);
     });

--- a/themes/theme-ios11/pages/Product/components/AddToCartBar/components/CartItemsCount/style.js
+++ b/themes/theme-ios11/pages/Product/components/AddToCartBar/components/CartItemsCount/style.js
@@ -2,6 +2,7 @@ import { css } from 'glamor';
 import variables from 'Styles/variables';
 
 export const duration = 200;
+export const durationShort = 50;
 
 export const transition = {
   entering: {

--- a/themes/theme-ios11/widgets/ImageSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/widgets/ImageSlider/__snapshots__/spec.jsx.snap
@@ -165,10 +165,10 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
                     <div
                       className="sg-swiper-slide css-1l9a57c "
                       data-test-id="Slider"
-                      key=".$s0"
+                      key=".$cff8d88442d10b88424de77967c68124_0_0"
                     >
                       <SliderItem
-                        key="0"
+                        key="cff8d88442d10b88424de77967c68124_0"
                       >
                         <div
                           className="css-10a4qrv"
@@ -177,7 +177,7 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
                             className="css-63oe3q"
                             data-test-id="withLink"
                             href="http://example.com"
-                            key="si0"
+                            key="cff8d88442d10b88424de77967c68124"
                           >
                             <Link
                               className="css-63oe3q"
@@ -214,10 +214,10 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
                     <div
                       className="sg-swiper-slide css-1l9a57c "
                       data-test-id="Slider"
-                      key=".$s1"
+                      key=".$77387b0455b43e9c56aaeff7c21c7340_1_1"
                     >
                       <SliderItem
-                        key="1"
+                        key="77387b0455b43e9c56aaeff7c21c7340_1"
                       >
                         <div
                           className="css-10a4qrv"
@@ -226,7 +226,7 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
                             className="css-63oe3q"
                             data-test-id="withLink"
                             href="http://other.example.com"
-                            key="si1"
+                            key="77387b0455b43e9c56aaeff7c21c7340"
                           >
                             <Link
                               className="css-63oe3q"
@@ -342,7 +342,7 @@ exports[`<ImageSliderWidget /> should render no slider with just a single image 
           className="css-63oe3q"
           data-test-id="withLink"
           href="http://example.com"
-          key=".$si0"
+          key=".$cff8d88442d10b88424de77967c68124"
         >
           <Link
             className="css-63oe3q"
@@ -449,7 +449,7 @@ exports[`<ImageSliderWidget /> should render the images unlinked if no link is s
             }
           }
           data-test-id="withoutLink"
-          key=".$si0"
+          key=".$cff8d88442d10b88424de77967c68124"
           src="http://placehold.it/350x150"
         />
       </ImageSlider>
@@ -639,10 +639,10 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                     <div
                       className="sg-swiper-slide css-1l9a57c "
                       data-test-id="Slider"
-                      key=".$s0"
+                      key=".$cff8d88442d10b88424de77967c68124_0_0"
                     >
                       <SliderItem
-                        key="0"
+                        key="cff8d88442d10b88424de77967c68124_0"
                       >
                         <div
                           className="css-10a4qrv"
@@ -651,7 +651,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                             className="css-63oe3q"
                             data-test-id="withLink"
                             href="http://example.com"
-                            key="si0"
+                            key="cff8d88442d10b88424de77967c68124"
                           >
                             <Link
                               className="css-63oe3q"
@@ -688,10 +688,10 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                     <div
                       className="sg-swiper-slide css-1l9a57c "
                       data-test-id="Slider"
-                      key=".$s1"
+                      key=".$cff8d88442d10b88424de77967c68124_1_1"
                     >
                       <SliderItem
-                        key="1"
+                        key="cff8d88442d10b88424de77967c68124_1"
                       >
                         <div
                           className="css-10a4qrv"
@@ -703,7 +703,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                               }
                             }
                             data-test-id="withoutLink"
-                            key="si1"
+                            key="cff8d88442d10b88424de77967c68124"
                             src="http://placehold.it/350x150"
                           />
                         </div>
@@ -712,10 +712,10 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                     <div
                       className="sg-swiper-slide css-1l9a57c "
                       data-test-id="Slider"
-                      key=".$s2"
+                      key=".$cff8d88442d10b88424de77967c68124_2_2"
                     >
                       <SliderItem
-                        key="2"
+                        key="cff8d88442d10b88424de77967c68124_2"
                       >
                         <div
                           className="css-10a4qrv"
@@ -724,7 +724,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                             className="css-63oe3q"
                             data-test-id="withLink"
                             href="http://example.com"
-                            key="si2"
+                            key="cff8d88442d10b88424de77967c68124"
                           >
                             <Link
                               className="css-63oe3q"
@@ -761,10 +761,10 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                     <div
                       className="sg-swiper-slide css-1l9a57c "
                       data-test-id="Slider"
-                      key=".$s3"
+                      key=".$cff8d88442d10b88424de77967c68124_3_3"
                     >
                       <SliderItem
-                        key="3"
+                        key="cff8d88442d10b88424de77967c68124_3"
                       >
                         <div
                           className="css-10a4qrv"
@@ -773,7 +773,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
                             className="css-63oe3q"
                             data-test-id="withLink"
                             href="http://example.com"
-                            key="si3"
+                            key="cff8d88442d10b88424de77967c68124"
                           >
                             <Link
                               className="css-63oe3q"
@@ -995,10 +995,10 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                     <div
                       className="sg-swiper-slide css-1l9a57c "
                       data-test-id="Slider"
-                      key=".$s0"
+                      key=".$cff8d88442d10b88424de77967c68124_0_0"
                     >
                       <SliderItem
-                        key="0"
+                        key="cff8d88442d10b88424de77967c68124_0"
                       >
                         <div
                           className="css-10a4qrv"
@@ -1007,7 +1007,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                             className="css-63oe3q"
                             data-test-id="withLink"
                             href="http://example.com"
-                            key="si0"
+                            key="cff8d88442d10b88424de77967c68124"
                           >
                             <Link
                               className="css-63oe3q"
@@ -1044,10 +1044,10 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                     <div
                       className="sg-swiper-slide css-1l9a57c "
                       data-test-id="Slider"
-                      key=".$s1"
+                      key=".$cff8d88442d10b88424de77967c68124_1_1"
                     >
                       <SliderItem
-                        key="1"
+                        key="cff8d88442d10b88424de77967c68124_1"
                       >
                         <div
                           className="css-10a4qrv"
@@ -1056,7 +1056,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                             className="css-63oe3q"
                             data-test-id="withLink"
                             href="http://example.com"
-                            key="si1"
+                            key="cff8d88442d10b88424de77967c68124"
                           >
                             <Link
                               className="css-63oe3q"
@@ -1093,10 +1093,10 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                     <div
                       className="sg-swiper-slide css-1l9a57c "
                       data-test-id="Slider"
-                      key=".$s2"
+                      key=".$cff8d88442d10b88424de77967c68124_2_2"
                     >
                       <SliderItem
-                        key="2"
+                        key="cff8d88442d10b88424de77967c68124_2"
                       >
                         <div
                           className="css-10a4qrv"
@@ -1105,7 +1105,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
                             className="css-63oe3q"
                             data-test-id="withLink"
                             href="http://example.com"
-                            key="si2"
+                            key="cff8d88442d10b88424de77967c68124"
                           >
                             <Link
                               className="css-63oe3q"

--- a/themes/theme-ios11/widgets/ImageSlider/index.jsx
+++ b/themes/theme-ios11/widgets/ImageSlider/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import CryptoJs from 'crypto-js';
 import shouldUpdate from 'recompose/shouldUpdate';
 import Link from '@shopgate/pwa-common/components/Link';
 import ImageSlider from '@shopgate/pwa-ui-shared/ImageSlider';
@@ -18,8 +19,8 @@ const ImageSliderWidget = ({ settings, className }) => (
     interval={settings.delay}
     loop={settings.loop}
   >
-    {settings.images.map((image, index) => {
-      const key = `si${index}`;
+    {settings.images.map((image) => {
+      const key = CryptoJs.MD5(image.image);
 
       if (image.link) {
         return (

--- a/themes/theme-ios11/widgets/ImageSlider/spec.jsx
+++ b/themes/theme-ios11/widgets/ImageSlider/spec.jsx
@@ -57,6 +57,7 @@ describe('<ImageSliderWidget />', () => {
   });
 
   it('should map the correct image settings to the components', () => {
+    expect.assertions(3);
     const settings = {
       ...testSettings,
       images: [
@@ -68,12 +69,10 @@ describe('<ImageSliderWidget />', () => {
     const wrapper = createComponent({ settings });
 
     expect(wrapper).toMatchSnapshot();
-    const images = wrapper.find('Image');
-    let index = 0;
-    images.forEach((image) => {
+    const images = wrapper.find('div.sg-swiper-slide img');
+    images.forEach((image, index) => {
       const imageProps = image.props();
       const imageSettings = settings.images[index];
-      index += 1;
 
       expect(imageProps.src).toBe(imageSettings.image);
     });


### PR DESCRIPTION
# Description
This ticket is about to fix and issue with the ImageSliderWidget which didn't update properly, when the related page config was updated.
This issue caused broken images on a persisted startpage, when the image URLs where outdated.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
- configure an ImageSliderWidget on your startpage with at least two images
- open the PWA startpage
- change the configuration / order of the widget
- reload the PWA startpage
The startpage should reflect the updated widget configuration after the `getPageConfig` for the startpage came in.