### PR TITLE
Added additional translations for user-privacy extension

### DIFF
--- a/extensions/@shopgate-user-privacy/extension-config.json
+++ b/extensions/@shopgate-user-privacy/extension-config.json
@@ -32,6 +32,11 @@
       "type": "translations"
     },
     {
+      "id": "es-ES",
+      "path": "frontend/locale/es-ES.json",
+      "type": "translations"
+    },
+    {
       "id": "de-DE",
       "path": "frontend/locale/de-DE.json",
       "type": "translations"
@@ -39,6 +44,11 @@
     {
       "id": "fr-FR",
       "path": "frontend/locale/fr-FR.json",
+      "type": "translations"
+    },
+    {
+      "id": "it-IT",
+      "path": "frontend/locale/it-IT.json",
       "type": "translations"
     },
     {

--- a/extensions/@shopgate-user-privacy/frontend/locale/es-ES.json
+++ b/extensions/@shopgate-user-privacy/frontend/locale/es-ES.json
@@ -1,0 +1,8 @@
+{
+  "user": {
+    "delete_account": "Eliminar mi cuenta",
+    "delete_account_success": "Hemos recibido la solicitud de eliminar tu cuenta.",
+    "delete_account_error": "Se ha producido un error inesperado. Inténtalo de nuevo más tarde.",
+    "delete_account_confirm": "Pulsa Confirmar para eliminar todos los datos de tu cuenta. Esta operación no se puede deshacer."
+  }
+}

--- a/extensions/@shopgate-user-privacy/frontend/locale/it-IT.json
+++ b/extensions/@shopgate-user-privacy/frontend/locale/it-IT.json
@@ -1,0 +1,8 @@
+{
+  "user": {
+    "delete_account": "Cancella il mio account",
+    "delete_account_success": "Abbiamo ricevuto la tua richiesta di cancellazione dell'account.",
+    "delete_account_error": "Si è verificato un errore imprevisto. Riprova più tardi per favore.",
+    "delete_account_confirm": "Premi Conferma per cancellare tutti i dati dell'account. Questa operazione non può essere annullata."
+  }
+}


### PR DESCRIPTION
# Description

Added spanish and italian translations to the privacy extension.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.
