### PR TITLE
Fixed the possibility of adding spaces to the end of a search term 

### DIFF
--- a/themes/theme-gmd/components/Search/index.jsx
+++ b/themes/theme-gmd/components/Search/index.jsx
@@ -91,7 +91,7 @@ class Search extends Component {
    */
   fetchSuggestions = debounce((query) => {
     if (query.length > SUGGESTIONS_MIN) {
-      this.props.fetchSuggestions(query);
+      this.props.fetchSuggestions(query.trim());
     }
   }, 200, { maxWait: 400 });
 

--- a/themes/theme-gmd/components/Search/index.jsx
+++ b/themes/theme-gmd/components/Search/index.jsx
@@ -81,7 +81,7 @@ class Search extends Component {
    * @param {Event} event The event.
    */
   update = (event) => {
-    const query = event.target.value.trim();
+    const query = event.target.value;
     this.fetchSuggestions(query);
     this.setState({ query });
   };


### PR DESCRIPTION
# Description
This ticket fixes a bug, that discouraged the user from adding spaces to the end of a search term within the GMD theme.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.