### PR TITLE
Enable parent product cart button when it has variants to select

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ coverage
 dist
 node_modules
 InlineTransitionGroup
+/themes/**/e2e

--- a/libraries/commerce/product/selectors/product.js
+++ b/libraries/commerce/product/selectors/product.js
@@ -493,3 +493,21 @@ export const isBaseProduct = createSelector(
     );
   }
 );
+
+/**
+ * Indicates whether a product has variants
+ * @param {Object} state The current application state.
+ * @param {string} productId A product id.
+ * @return {boolean|null}
+ */
+export const hasProductVariants = createSelector(
+  getProductById,
+  (product) => {
+    if (!product.productData || product.isFetching) {
+      return null;
+    }
+
+    const { productData: { flags: { hasVariants } = {} } } = product;
+    return hasVariants;
+  }
+);

--- a/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/__snapshots__/spec.jsx.snap
@@ -20,6 +20,7 @@ exports[`<CTAButtons /> should render buttons 1`] = `
       active={null}
       addToCart={[Function]}
       favoritesOnce={false}
+      hasVariants={true}
       isBaseProduct={true}
       isOrderable={true}
       onRippleComplete={[Function]}

--- a/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/connector.js
+++ b/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/connector.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import addToCart from '@shopgate/pwa-common-commerce/cart/actions/addProductsToCart';
-import { isBaseProduct, isOrderable } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import { isBaseProduct, isOrderable, hasProductVariants } from '@shopgate/pwa-common-commerce/product/selectors/product';
 import showModal from '@shopgate/pwa-common/actions/modal/showModal';
 import { MODAL_VARIANT_SELECT } from '@shopgate/pwa-ui-shared/Dialog/constants';
 
@@ -14,6 +14,7 @@ import { MODAL_VARIANT_SELECT } from '@shopgate/pwa-ui-shared/Dialog/constants';
 const mapStateToProps = (state, { productId }) => ({
   isBaseProduct: isBaseProduct(state, productId),
   isOrderable: isOrderable(state, productId),
+  hasVariants: hasProductVariants(state, productId),
 });
 
 /**

--- a/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/index.jsx
+++ b/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/index.jsx
@@ -50,7 +50,7 @@ const CTAButtons = props => (
         handleAddToCart: () => handleAddToCart(props),
         isLoading: false,
         isBaseProduct: props.isBaseProduct,
-        isDisabled: !props.isOrderable,
+        isDisabled: !props.isOrderable && !props.hasVariants,
         noShadow: false,
         productId: props.productId,
       }}
@@ -59,7 +59,7 @@ const CTAButtons = props => (
         className={styles.cartButton}
         handleAddToCart={() => handleAddToCart(props)}
         isLoading={false}
-        isDisabled={!props.isOrderable}
+        isDisabled={!props.isOrderable && !props.hasVariants}
         isOrderable={!props.isBaseProduct && props.isOrderable}
       />
     </Portal>
@@ -73,6 +73,7 @@ CTAButtons.propTypes = {
   active: PropTypes.bool,
   addToCart: PropTypes.func,
   favoritesOnce: PropTypes.bool,
+  hasVariants: PropTypes.bool,
   isBaseProduct: PropTypes.bool,
   isOrderable: PropTypes.bool,
   onRippleComplete: PropTypes.func,
@@ -86,6 +87,7 @@ CTAButtons.defaultProps = {
   favoritesOnce: false,
   isBaseProduct: true,
   isOrderable: true,
+  hasVariants: false,
   onRippleComplete: () => {},
   removeThrottle: null,
   showVariantModal: () => {},

--- a/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/connector.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/connector.js
@@ -9,6 +9,7 @@ import {
   isProductPageLoading,
   isProductPageOrderable,
 } from '@shopgate/pwa-common-commerce/product/selectors/page';
+import { hasCurrentProductVariants } from '@shopgate/pwa-common-commerce/product/selectors/variants';
 
 /**
  * Maps the contents of the state to the component props.
@@ -20,7 +21,7 @@ const mapStateToProps = state => ({
   productId: getCurrentProductId(state),
   isLoading: isProductPageLoading(state),
   isOrderable: isProductPageOrderable(state),
-  isDisabled: !isProductOrderable(state),
+  isDisabled: !isProductOrderable(state) && !hasCurrentProductVariants(state),
 });
 
 /**

--- a/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/__snapshots__/spec.jsx.snap
@@ -20,6 +20,7 @@ exports[`<CTAButtons /> should render buttons 1`] = `
       active={null}
       addToCart={[Function]}
       favoritesOnce={false}
+      hasVariants={false}
       isBaseProduct={true}
       isOrderable={true}
       onRippleComplete={[Function]}

--- a/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/connector.js
+++ b/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/connector.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import addToCart from '@shopgate/pwa-common-commerce/cart/actions/addProductsToCart';
-import { isBaseProduct, isOrderable } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import { hasProductVariants, isBaseProduct, isOrderable } from '@shopgate/pwa-common-commerce/product/selectors/product';
 import showModal from '@shopgate/pwa-common/actions/modal/showModal';
 import { MODAL_VARIANT_SELECT } from '@shopgate/pwa-ui-shared/Dialog/constants';
 
@@ -14,6 +14,7 @@ import { MODAL_VARIANT_SELECT } from '@shopgate/pwa-ui-shared/Dialog/constants';
 const mapStateToProps = (state, { productId }) => ({
   isBaseProduct: isBaseProduct(state, productId),
   isOrderable: isOrderable(state, productId),
+  hasVariants: hasProductVariants(state, productId),
 });
 
 /**

--- a/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/index.jsx
+++ b/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/index.jsx
@@ -51,7 +51,7 @@ const CTAButtons = props => (
         handleAddToCart: () => handleAddToCart(props),
         isLoading: false,
         isBaseProduct: props.isBaseProduct,
-        isDisabled: !props.isOrderable,
+        isDisabled: !props.isOrderable && !props.hasVariants,
         noShadow: false,
         productId: props.productId,
       }}
@@ -59,7 +59,7 @@ const CTAButtons = props => (
       <AddToCartButton
         handleAddToCart={() => handleAddToCart(props)}
         isLoading={false}
-        isDisabled={!props.isOrderable}
+        isDisabled={!props.isOrderable && !props.hasVariants}
         isOrderable={!props.isBaseProduct && props.isOrderable}
         noShadow
       />
@@ -74,6 +74,7 @@ CTAButtons.propTypes = {
   active: PropTypes.bool,
   addToCart: PropTypes.func,
   favoritesOnce: PropTypes.bool,
+  hasVariants: PropTypes.bool,
   isBaseProduct: PropTypes.bool,
   isOrderable: PropTypes.bool,
   onRippleComplete: PropTypes.func,
@@ -85,6 +86,7 @@ CTAButtons.defaultProps = {
   active: null,
   addToCart: () => {},
   favoritesOnce: false,
+  hasVariants: false,
   isBaseProduct: true,
   isOrderable: true,
   onRippleComplete: () => {},

--- a/themes/theme-ios11/pages/Product/components/AddToCartBar/connector.js
+++ b/themes/theme-ios11/pages/Product/components/AddToCartBar/connector.js
@@ -4,6 +4,7 @@ import {
   isProductPageOrderable,
 } from '@shopgate/pwa-common-commerce/product/selectors/page';
 import { isProductOrderable } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import { hasCurrentProductVariants } from '@shopgate/pwa-common-commerce/product/selectors/variants';
 import { connect } from 'react-redux';
 import {
   selectActionCount,
@@ -13,12 +14,12 @@ import {
 /**
  * Connects the current application state to the component props.
  * @param {Object} state The current application state.
- * @return {[type]} [description]
+ * @return {Object} [description]
  */
 const mapStateToProps = state => ({
   isLoading: isProductPageLoading(state),
   isOrderable: isProductPageOrderable(state),
-  isDisabled: !isProductOrderable(state),
+  isDisabled: !isProductOrderable(state) && !hasCurrentProductVariants(state),
   isVisible: isVisible(state),
   cartProductCount: selectActionCount(state),
 });


### PR DESCRIPTION
# Description

Enable parent product cart button when it has variants to select

## Type of change

Please add an "x" into the option that is relevant:

- [ X ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.
