### PR TITLE
Improve commerce/product/getBaseProductId selector

### DIFF
--- a/libraries/commerce/product/selectors/product.js
+++ b/libraries/commerce/product/selectors/product.js
@@ -389,22 +389,14 @@ export const isBaseProduct = createSelector(
  */
 export const getBaseProductId = createSelector(
   getProduct,
-  (state, props = {}) => props,
-  (product, props) => {
-    if (product) {
-      // First try to determine a baseProductId via a selected product.
-      const { baseProductId = null } = product;
-
-      if (baseProductId !== null) {
-        return baseProductId;
-      }
-
-      return product.id;
+  (product) => {
+    if (!product) {
+      return null;
     }
+    // First try to determine a baseProductId for a selected product
+    const { baseProductId = null } = product;
 
-    const { productId } = props;
-    // Use the productId from the props as fallback.
-    return typeof productId !== 'undefined' ? productId : null;
+    return baseProductId || product.id;
   }
 );
 

--- a/libraries/commerce/product/selectors/product.spec.js
+++ b/libraries/commerce/product/selectors/product.spec.js
@@ -704,23 +704,17 @@ describe('Product selectors', () => {
   });
 
   describe('getBaseProductId()', () => {
-    it('should return null and log an error when no props are passed', () => {
+    it('should return null when props are not given', () => {
       expect(getBaseProductId(mockedState)).toBeNull();
     });
 
-    it('should return the passed productId when no product is not available for the id', () => {
-      const productId = 'unavailable';
-      expect(getBaseProductId(mockedState, { productId })).toBe(productId);
+    it('should return null when product is not found in store', () => {
+      const productId = 'unknown';
+      expect(getBaseProductId(mockedState, { productId })).toBeNull();
     });
 
-    it('should return the id of a base product when no variant is selected yet', () => {
-      const productId = 'product_1';
-      expect(getBaseProductId(mockedState, { productId })).toBe(productId);
-    });
-
-    it('should return the id of a base product when no baseProductId prop is set', () => {
+    it('should return the id of a base product when baseProductId is null', () => {
       const productId = 'product_5';
-      delete mockedState.product.productsById[productId].productData.baseProductId;
       expect(getBaseProductId(mockedState, { productId })).toBe(productId);
     });
 
@@ -729,7 +723,12 @@ describe('Product selectors', () => {
       expect(getBaseProductId(mockedState, { productId })).toBe(productId);
     });
 
-    it('should return the id of a base product when a variant is selected ', () => {
+    it('should return the id of a base product when no variantId is in props', () => {
+      const productId = 'product_1';
+      expect(getBaseProductId(mockedState, { productId })).toBe(productId);
+    });
+
+    it('should return the id of a base product when a variantId is in props', () => {
       const productId = 'product_1';
       const variantId = 'product_2';
       expect(getBaseProductId(mockedState, { productId, variantId })).toBe(productId);


### PR DESCRIPTION
# Description

Improve commerce/product/getBaseProductId selector do not return props default value when product is not yet available in store

## Type of change

Please add an "x" into the option that is relevant:

- [ X ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.