### PR TITLE
The AppBar in iOS is only rendered when its target container has mounted

### DIFF
--- a/themes/theme-ios11/components/AppBar/presets/DefaultBar/index.jsx
+++ b/themes/theme-ios11/components/AppBar/presets/DefaultBar/index.jsx
@@ -30,13 +30,25 @@ class AppBarDefault extends PureComponent {
     i18n: PropTypes.func,
   };
 
-  target = document.getElementById('AppHeader');
+  state = {
+    target: document.getElementById('AppHeader'),
+  }
+
+  /**
+   * Sets the target if it hasn't been set before.
+   */
+  componentDidMount() {
+    if (!this.state.target) {
+      const target = document.getElementById('AppHeader');
+      this.setState({ target: target || null }); // eslint-disable-line react/no-did-mount-set-state
+    }
+  }
 
   /**
    * @returns {JSX}
    */
   render() {
-    if (!this.props.visible) {
+    if (!this.props.visible || !this.state.target) {
       return null;
     }
 
@@ -58,7 +70,7 @@ class AppBarDefault extends PureComponent {
         </Portal>
         <Portal name={APP_BAR_DEFAULT_AFTER} />
       </Fragment>,
-      this.target
+      this.state.target
     );
   }
 }


### PR DESCRIPTION
# Description

To prevent the AppBar component throwing errors in the development environment, it now waits for its target container to be mounted before it tries to attach itself via a React Portal.

## Type of change

Please add an "x" into the option that is relevant:

- [ x ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.