### PR TITLE
Fixed broken scrolling on iOS after installation of the app

### DIFF
--- a/themes/theme-ios11/components/View/style.js
+++ b/themes/theme-ios11/components/View/style.js
@@ -4,8 +4,6 @@ import variables from 'Styles/variables';
 
 const container = css({
   background: colors.light,
-  width: '100%',
-  height: '100%',
   zIndex: 1,
 }).toString();
 
@@ -16,7 +14,7 @@ const container = css({
  *                  so that it's really fullscreen (including the notch).
  * @param {boolean} considerPaddingTop Whether to consider the natively set inset
  *                  and compensate it or not.
- * @param {boolean} noScroll Wheather the view should be scrollable or not.
+ * @param {boolean} noScroll Whether the view should be scrollable or not.
  * @return {string} The content style class.
  */
 const content = (
@@ -32,13 +30,13 @@ const content = (
     overflow,
     overflowScrolling: 'touch',
     WebkitOverflowScrolling: 'touch',
-    width: '100%',
-    position: 'absolute',
-    top: isFullscreen ? 0 : `calc(${navHeight}px + var(--safe-area-inset-top))`,
     display: 'flex',
     flexDirection: 'column',
+    position: 'relative',
+    width: '100%',
+    height: isFullscreen ? '100vh' : `calc(100vh - (${navHeight}px + var(--safe-area-inset-top)))`,
+    marginTop: isFullscreen ? 0 : `calc(${navHeight}px + var(--safe-area-inset-top))`,
     paddingBottom: 'calc(var(--tabbar-height) + var(--safe-area-inset-bottom))',
-    bottom: 0,
     ...considerPaddingTop && {
       marginBottom: 'calc(var(--tabbar-height) + var(--safe-area-inset-bottom))',
     },


### PR DESCRIPTION
# Description
This ticket is about to fix in issue that sometimes occurred right after the app installation at the first app start. On the iOS theme sometimes scrolling wasn't possible, when the startpage had a simple widget configuration that didn't require further pipeline requests and the related re-rendering.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
- create a simple startpage with some image and image slider widgets
- deactivate the preloaded state mechanism within `commerce/store/index.js`
- connect to the shop with a deactivated app cache
- start / re-start the app multiple times