### PR TITLE
Fix for text hint below text input options with zero rendered price

### DIFF
--- a/themes/theme-gmd/pages/Product/components/Options/components/TextOption/components/OptionInfo/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/Product/components/Options/components/TextOption/components/OptionInfo/__snapshots__/spec.jsx.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<OptionInfo /> should render full info with required and price element 1`] = `
+<Grid
+  className="css-jy6f7q"
+  component="ul"
+  wrap={false}
+>
+  <GridItem
+    className="css-cr41pz"
+    component="li"
+    grow={0}
+    shrink={1}
+  >
+    <Translate
+      className=""
+      params={Object {}}
+      string="common.required"
+    />
+  </GridItem>
+  <GridItem
+    className="css-1bia360"
+    component="li"
+    grow={1}
+    shrink={1}
+  >
+    Label: 
+    <FormatPrice
+      className=""
+      currency="EUR"
+      fractions={true}
+      price={10}
+    />
+  </GridItem>
+</Grid>
+`;
+
+exports[`<OptionInfo /> should render price element 1`] = `
+<Grid
+  className="css-jy6f7q"
+  component="ul"
+  wrap={false}
+>
+  <GridItem
+    className="css-1bia360"
+    component="li"
+    grow={1}
+    shrink={1}
+  >
+    Label: 
+    <FormatPrice
+      className=""
+      currency="EUR"
+      fractions={true}
+      price={10}
+    />
+  </GridItem>
+</Grid>
+`;
+
+exports[`<OptionInfo /> should render required element 1`] = `
+<Grid
+  className="css-jy6f7q"
+  component="ul"
+  wrap={false}
+>
+  <GridItem
+    className="css-cr41pz"
+    component="li"
+    grow={0}
+    shrink={1}
+  >
+    <Translate
+      className=""
+      params={Object {}}
+      string="common.required"
+    />
+  </GridItem>
+</Grid>
+`;

--- a/themes/theme-gmd/pages/Product/components/Options/components/TextOption/components/OptionInfo/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Options/components/TextOption/components/OptionInfo/index.jsx
@@ -17,11 +17,11 @@ const OptionInfo = ({ required, label, price }) => {
   return (
     <Grid className={styles.info}>
       {required &&
-        <Grid.Item grow={0} className={styles.required}>
+        <Grid.Item className={styles.required}>
           <I18n.Text string="common.required" />
         </Grid.Item>
       }
-      {price.price &&
+      {!!price.price &&
         <Grid.Item grow={1} className={styles.price}>
           {`${label}: `}
           <I18n.Price
@@ -36,8 +36,13 @@ const OptionInfo = ({ required, label, price }) => {
 
 OptionInfo.propTypes = {
   label: PropTypes.string.isRequired,
-  price: PropTypes.number.isRequired,
+  price: PropTypes.shape({
+    price: PropTypes.number.isRequired,
+    currency: PropTypes.string.isRequired,
+  }).isRequired,
   required: PropTypes.bool.isRequired,
 };
 
 export default memo(OptionInfo);
+
+export { OptionInfo };

--- a/themes/theme-gmd/pages/Product/components/Options/components/TextOption/components/OptionInfo/spec.jsx
+++ b/themes/theme-gmd/pages/Product/components/Options/components/TextOption/components/OptionInfo/spec.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { OptionInfo } from './index';
+
+describe('<OptionInfo />', () => {
+  const emptyPrice = {
+    price: 0,
+    currency: 'EUR',
+  };
+  const notEmptyPrice = {
+    price: 10,
+    currency: 'EUR',
+  };
+
+  it('should not render when not required and no price', () => {
+    const wrapper = shallow((
+      <OptionInfo required={false} label="" price={emptyPrice} />
+    ));
+    expect(wrapper.type()).toBeNull();
+  });
+  it('should render required element', () => {
+    const wrapper = shallow((
+      <OptionInfo required label="" price={emptyPrice} />
+    ));
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('Translate').prop('string')).toEqual('common.required');
+    expect(wrapper.find('FormatPrice')).toHaveLength(0);
+  });
+  it('should render price element', () => {
+    const wrapper = shallow((
+      <OptionInfo required={false} label="Label" price={notEmptyPrice} />
+    ));
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('Translate')).toHaveLength(0);
+
+    const price = wrapper.find('FormatPrice');
+    expect(price.prop('price')).toEqual(notEmptyPrice.price);
+    expect(price.prop('currency')).toEqual('EUR');
+  });
+  it('should render full info with required and price element', () => {
+    const wrapper = shallow((
+      <OptionInfo required label="Label" price={notEmptyPrice} />
+    ));
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/themes/theme-ios11/pages/Product/components/Options/components/TextOption/components/OptionInfo/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Product/components/Options/components/TextOption/components/OptionInfo/__snapshots__/spec.jsx.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<OptionInfo /> should render full info with required and price element 1`] = `
+<Grid
+  className="css-k4qf09"
+  component="ul"
+  wrap={false}
+>
+  <GridItem
+    className="css-cr41pz"
+    component="li"
+    grow={0}
+    shrink={1}
+  >
+    <Translate
+      className=""
+      params={Object {}}
+      string="common.required"
+    />
+  </GridItem>
+  <GridItem
+    className="css-1bia360"
+    component="li"
+    grow={1}
+    shrink={1}
+  >
+    Label: 
+    <FormatPrice
+      className=""
+      currency="EUR"
+      fractions={true}
+      price={10}
+    />
+  </GridItem>
+</Grid>
+`;
+
+exports[`<OptionInfo /> should render price element 1`] = `
+<Grid
+  className="css-k4qf09"
+  component="ul"
+  wrap={false}
+>
+  <GridItem
+    className="css-1bia360"
+    component="li"
+    grow={1}
+    shrink={1}
+  >
+    Label: 
+    <FormatPrice
+      className=""
+      currency="EUR"
+      fractions={true}
+      price={10}
+    />
+  </GridItem>
+</Grid>
+`;
+
+exports[`<OptionInfo /> should render required element 1`] = `
+<Grid
+  className="css-k4qf09"
+  component="ul"
+  wrap={false}
+>
+  <GridItem
+    className="css-cr41pz"
+    component="li"
+    grow={0}
+    shrink={1}
+  >
+    <Translate
+      className=""
+      params={Object {}}
+      string="common.required"
+    />
+  </GridItem>
+</Grid>
+`;

--- a/themes/theme-ios11/pages/Product/components/Options/components/TextOption/components/OptionInfo/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Options/components/TextOption/components/OptionInfo/index.jsx
@@ -17,11 +17,11 @@ const OptionInfo = ({ required, label, price }) => {
   return (
     <Grid className={styles.info}>
       {required &&
-        <Grid.Item grow={0} className={styles.required}>
+        <Grid.Item className={styles.required}>
           <I18n.Text string="common.required" />
         </Grid.Item>
       }
-      {price.price &&
+      {!!price.price &&
         <Grid.Item grow={1} className={styles.price}>
           {`${label}: `}
           <I18n.Price
@@ -36,8 +36,13 @@ const OptionInfo = ({ required, label, price }) => {
 
 OptionInfo.propTypes = {
   label: PropTypes.string.isRequired,
-  price: PropTypes.number.isRequired,
+  price: PropTypes.shape({
+    price: PropTypes.number.isRequired,
+    currency: PropTypes.string.isRequired,
+  }).isRequired,
   required: PropTypes.bool.isRequired,
 };
 
 export default memo(OptionInfo);
+
+export { OptionInfo };

--- a/themes/theme-ios11/pages/Product/components/Options/components/TextOption/components/OptionInfo/spec.jsx
+++ b/themes/theme-ios11/pages/Product/components/Options/components/TextOption/components/OptionInfo/spec.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { OptionInfo } from './index';
+
+describe('<OptionInfo />', () => {
+  const emptyPrice = {
+    price: 0,
+    currency: 'EUR',
+  };
+  const notEmptyPrice = {
+    price: 10,
+    currency: 'EUR',
+  };
+
+  it('should not render when not required and no price', () => {
+    const wrapper = shallow((
+      <OptionInfo required={false} label="" price={emptyPrice} />
+    ));
+    expect(wrapper.type()).toBeNull();
+  });
+  it('should render required element', () => {
+    const wrapper = shallow((
+      <OptionInfo required label="" price={emptyPrice} />
+    ));
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('Translate').prop('string')).toEqual('common.required');
+    expect(wrapper.find('FormatPrice')).toHaveLength(0);
+  });
+  it('should render price element', () => {
+    const wrapper = shallow((
+      <OptionInfo required={false} label="Label" price={notEmptyPrice} />
+    ));
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('Translate')).toHaveLength(0);
+
+    const price = wrapper.find('FormatPrice');
+    expect(price.prop('price')).toEqual(notEmptyPrice.price);
+    expect(price.prop('currency')).toEqual('EUR');
+  });
+  it('should render full info with required and price element', () => {
+    const wrapper = shallow((
+      <OptionInfo required label="Label" price={notEmptyPrice} />
+    ));
+    expect(wrapper).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
# Description

Fix for text hint below text input options with zero rendered price

## Type of change

Please add an "x" into the option that is relevant:

- [ X ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.
