### PR TITLE
Fixed broken cart layout at long availability texts

### DIFF
--- a/libraries/ui-shared/ProductProperties/__snapshots__/index.spec.jsx.snap
+++ b/libraries/ui-shared/ProductProperties/__snapshots__/index.spec.jsx.snap
@@ -44,3 +44,76 @@ exports[`<ProductProperties /> should render as expected when properties are pas
   </ul>
 </Properties>
 `;
+
+exports[`<ProductProperties /> should use the ellipsis component when the lineClamp prop is passed  1`] = `
+<Properties
+  lineClamp={2}
+  properties={
+    Array [
+      Object {
+        "label": "Label One",
+        "value": "Value One",
+      },
+      Object {
+        "label": "Label Two",
+        "value": "Value Two",
+      },
+    ]
+  }
+>
+  <ul>
+    <li
+      key="Label One-Value One"
+    >
+      <Ellipsis
+        className=""
+        ellipsis="..."
+        rows={2}
+      >
+        <Dotdotdot
+          clamp={2}
+          className=""
+          ellipsis="..."
+          tagName="div"
+          truncationChar="…"
+          useNativeClamp={true}
+        >
+          <div
+            className=""
+          >
+            Label One
+            : 
+            Value One
+          </div>
+        </Dotdotdot>
+      </Ellipsis>
+    </li>
+    <li
+      key="Label Two-Value Two"
+    >
+      <Ellipsis
+        className=""
+        ellipsis="..."
+        rows={2}
+      >
+        <Dotdotdot
+          clamp={2}
+          className=""
+          ellipsis="..."
+          tagName="div"
+          truncationChar="…"
+          useNativeClamp={true}
+        >
+          <div
+            className=""
+          >
+            Label Two
+            : 
+            Value Two
+          </div>
+        </Dotdotdot>
+      </Ellipsis>
+    </li>
+  </ul>
+</Properties>
+`;

--- a/libraries/ui-shared/ProductProperties/__snapshots__/index.spec.jsx.snap
+++ b/libraries/ui-shared/ProductProperties/__snapshots__/index.spec.jsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ProductProperties /> should not render when an empty list of properties is passed 1`] = `
+<Properties
+  lineClamp={null}
+  properties={Array []}
+/>
+`;
+
+exports[`<ProductProperties /> should not render when no properties are passed 1`] = `
+<Properties
+  lineClamp={null}
+  properties={Array []}
+/>
+`;
+
+exports[`<ProductProperties /> should render as expected when properties are passed 1`] = `
+<Properties
+  lineClamp={null}
+  properties={
+    Array [
+      Object {
+        "label": "Label One",
+        "value": "Value One",
+      },
+      Object {
+        "label": "Label Two",
+        "value": "Value Two",
+      },
+    ]
+  }
+>
+  <ul>
+    <li
+      key="Label One-Value One"
+    >
+      Label One: Value One
+    </li>
+    <li
+      key="Label Two-Value Two"
+    >
+      Label Two: Value Two
+    </li>
+  </ul>
+</Properties>
+`;

--- a/libraries/ui-shared/ProductProperties/index.jsx
+++ b/libraries/ui-shared/ProductProperties/index.jsx
@@ -7,20 +7,26 @@ import Ellipsis from '@shopgate/pwa-common/components/Ellipsis';
  * @param {Object} props The component props.
  * @returns {JSX}
  */
-const Properties = ({ lineClamp, properties }) => (
-  <ul>
-    {properties.map(({ label, value }) => (
-      <li key={`${label}-${value}`}>
-        {lineClamp &&
-          <Ellipsis rows={lineClamp}>
-            {label}: {value}
-          </Ellipsis>
-        }
-        {!lineClamp && `${label}: ${value}`}
-      </li>
-    ))}
-  </ul>
-);
+const Properties = ({ lineClamp, properties }) => {
+  if (!properties.length) {
+    return null;
+  }
+
+  return (
+    <ul>
+      {properties.map(({ label, value }) => (
+        <li key={`${label}-${value}`}>
+          {lineClamp &&
+            <Ellipsis rows={lineClamp}>
+              {label}: {value}
+            </Ellipsis>
+          }
+          {!lineClamp && `${label}: ${value}`}
+        </li>
+      ))}
+    </ul>
+  );
+};
 
 Properties.propTypes = {
   /** Truncate property value at a specific number of lines */

--- a/libraries/ui-shared/ProductProperties/index.spec.jsx
+++ b/libraries/ui-shared/ProductProperties/index.spec.jsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import Ellipsis from '@shopgate/pwa-common/components/Ellipsis';
 import ProductProperties from './index';
+
+const properties = [{
+  label: 'Label One',
+  value: 'Value One',
+}, {
+  label: 'Label Two',
+  value: 'Value Two',
+}];
 
 describe('<ProductProperties />', () => {
   it('should not render when no properties are passed', () => {
@@ -16,19 +25,33 @@ describe('<ProductProperties />', () => {
   });
 
   it('should render as expected when properties are passed', () => {
-    const properties = [{
-      label: 'Label One',
-      value: 'Value One',
-    }, {
-      label: 'Label Two',
-      value: 'Value Two',
-    }];
+    expect.assertions(5);
 
     const wrapper = mount(<ProductProperties properties={properties} />);
     expect(wrapper).toMatchSnapshot();
-    const list = wrapper.find('li');
-    expect(list.length).toBe(2);
-    expect(list.at(0).text()).toBe(`${properties[0].label}: ${properties[0].value}`);
-    expect(list.at(1).text()).toBe(`${properties[1].label}: ${properties[1].value}`);
+    expect(wrapper.find(Ellipsis).exists()).toBe(false);
+
+    const listElements = wrapper.find('li');
+    expect(listElements.length).toBe(2);
+
+    listElements.forEach((el, index) => {
+      expect(listElements.at(index).text()).toBe(`${properties[index].label}: ${properties[index].value}`);
+    });
+  });
+
+  it('should use the ellipsis component when the lineClamp prop is passed ', () => {
+    expect.assertions(6);
+
+    const lineClamp = 2;
+    const wrapper = mount(<ProductProperties properties={properties} lineClamp={lineClamp} />);
+    expect(wrapper).toMatchSnapshot();
+
+    const listElements = wrapper.find(Ellipsis);
+    expect(listElements.length).toBe(2);
+
+    listElements.forEach((el, index) => {
+      expect(el.prop('rows')).toBe(lineClamp);
+      expect(listElements.at(index).text()).toBe(`${properties[index].label}: ${properties[index].value}`);
+    });
   });
 });

--- a/libraries/ui-shared/ProductProperties/index.spec.jsx
+++ b/libraries/ui-shared/ProductProperties/index.spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ProductProperties from './index';
+
+describe('<ProductProperties />', () => {
+  it('should not render when no properties are passed', () => {
+    const wrapper = mount(<ProductProperties />);
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper).toBeEmptyRender();
+  });
+
+  it('should not render when an empty list of properties is passed', () => {
+    const wrapper = mount(<ProductProperties properties={[]} />);
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper).toBeEmptyRender();
+  });
+
+  it('should render as expected when properties are passed', () => {
+    const properties = [{
+      label: 'Label One',
+      value: 'Value One',
+    }, {
+      label: 'Label Two',
+      value: 'Value Two',
+    }];
+
+    const wrapper = mount(<ProductProperties properties={properties} />);
+    expect(wrapper).toMatchSnapshot();
+    const list = wrapper.find('li');
+    expect(list.length).toBe(2);
+    expect(list.at(0).text()).toBe(`${properties[0].label}: ${properties[0].value}`);
+    expect(list.at(1).text()).toBe(`${properties[1].label}: ${properties[1].value}`);
+  });
+});

--- a/themes/theme-gmd/pages/Cart/components/Item/components/Product/components/Layout/style.js
+++ b/themes/theme-gmd/pages/Cart/components/Item/components/Product/components/Layout/style.js
@@ -36,6 +36,7 @@ const info = css({
 
 const priceInfo = css({
   textAlign: 'right',
+  wordBreak: 'break-word',
 }).toString();
 
 const disclaimerSpacer = css({
@@ -44,10 +45,19 @@ const disclaimerSpacer = css({
 
 const price = css({
   marginLeft: '1em',
+  alignSelf: 'flex-end',
 }).toString();
 
 const properties = css({
   wordBreak: 'break-word',
+  alignSelf: 'flex-start',
+  /**
+   * When the properties column has content, apply a max width to the price column
+   * to avoid issues with long availability texts.
+   */
+  [`:not(:empty) + .${price}`]: {
+    maxWidth: '40%',
+  },
 }).toString();
 
 export default {

--- a/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/style.js
+++ b/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/style.js
@@ -36,6 +36,7 @@ const info = css({
 
 const priceInfo = css({
   textAlign: 'right',
+  wordBreak: 'break-word',
 }).toString();
 
 const disclaimerSpacer = css({
@@ -44,10 +45,19 @@ const disclaimerSpacer = css({
 
 const price = css({
   marginLeft: '1em',
+  alignSelf: 'flex-end',
 }).toString();
 
 const properties = css({
   wordBreak: 'break-word',
+  alignSelf: 'flex-start',
+  /**
+   * When the properties column has content, apply a max width to the price column
+   * to avoid issues with long availability texts.
+   */
+  [`:not(:empty) + .${price}`]: {
+    maxWidth: '40%',
+  },
 }).toString();
 
 export default {


### PR DESCRIPTION
# Description
This ticket is about to fix an issue that occurred, when a cart product has "properties" and a long availability text.

Take a look to the screenshots below to compare the old and the modified layout in different situations.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Put a product with attributes and a long availability text to the cart. If you don't have one, your could manipulate the Layout component for the cart item to render such a text.

**Before:**
![bildschirmfoto 2019-02-20 um 09 13 30](https://user-images.githubusercontent.com/13087792/53078995-c21fb300-34f5-11e9-8738-c6f916913741.png)

**After:**
![bildschirmfoto 2019-02-20 um 09 13 37](https://user-images.githubusercontent.com/13087792/53079000-c4820d00-34f5-11e9-89c2-957a0f1cd99b.png)
