### PR TITLE
Improve error behaviour for tracking core plugin calls

### DIFF
--- a/libraries/common/subscriptions/app.js
+++ b/libraries/common/subscriptions/app.js
@@ -6,7 +6,7 @@ import {
   onload,
 } from '@shopgate/pwa-core';
 import { EVENT_KEYBOARD_WILL_CHANGE } from '@shopgate/pwa-core/constants/AppEvents';
-import { SOURCE_APP, SOURCE_PIPELINE } from '@shopgate/pwa-core/classes/ErrorManager/constants';
+import { SOURCE_APP, SOURCE_PIPELINE } from '@shopgate/pwa-core/constants/ErrorManager';
 import { MODAL_PIPELINE_ERROR } from '@shopgate/pwa-common/constants/ModalTypes';
 import pipelineManager from '@shopgate/pwa-core/classes/PipelineManager';
 import * as errorCodes from '@shopgate/pwa-core/constants/Pipeline';

--- a/libraries/common/subscriptions/error.js
+++ b/libraries/common/subscriptions/error.js
@@ -7,6 +7,8 @@ import {
   addBreadcrumb,
   Severity,
 } from '@sentry/browser';
+import { emitter } from '@shopgate/pwa-core';
+import { SOURCE_TRACKING } from '@shopgate/pwa-core/constants/ErrorManager';
 import {
 // eslint-disable-next-line import/no-named-default
   default as appConfig,
@@ -71,6 +73,15 @@ export default (subscribe) => {
         captureException(error);
       };
     }
+
+    emitter.addListener(SOURCE_TRACKING, (error) => {
+      withScope((scope) => {
+        if (error.context) {
+          scope.setExtra('trackerName', error.context);
+        }
+        captureException(error);
+      });
+    });
   });
 
   subscribe(userDidUpdate$, ({ getState }) => {

--- a/libraries/core/classes/ErrorManager/index.js
+++ b/libraries/core/classes/ErrorManager/index.js
@@ -1,5 +1,5 @@
 import EventEmitter from 'events';
-import { DEFAULT_CONTEXT, SOURCE_PIPELINE } from './constants';
+import { DEFAULT_CONTEXT, SOURCE_PIPELINE } from './../../constants/ErrorManager';
 
 export const emitter = new EventEmitter();
 

--- a/libraries/core/classes/ErrorManager/index.js
+++ b/libraries/core/classes/ErrorManager/index.js
@@ -1,5 +1,5 @@
 import EventEmitter from 'events';
-import { DEFAULT_CONTEXT, SOURCE_PIPELINE } from './../../constants/ErrorManager';
+import { DEFAULT_CONTEXT, SOURCE_PIPELINE } from '../../constants/ErrorManager';
 
 export const emitter = new EventEmitter();
 

--- a/libraries/core/classes/ErrorManager/spec.js
+++ b/libraries/core/classes/ErrorManager/spec.js
@@ -1,5 +1,5 @@
 import errorManager, { emitter } from './';
-import { DEFAULT_CONTEXT } from './../../constants/ErrorManager';
+import { DEFAULT_CONTEXT } from '../../constants/ErrorManager';
 
 describe('ErrorManager', () => {
   beforeEach(() => {

--- a/libraries/core/classes/ErrorManager/spec.js
+++ b/libraries/core/classes/ErrorManager/spec.js
@@ -1,5 +1,5 @@
 import errorManager, { emitter } from './';
-import { DEFAULT_CONTEXT } from './constants';
+import { DEFAULT_CONTEXT } from './../../constants/ErrorManager';
 
 describe('ErrorManager', () => {
   beforeEach(() => {

--- a/libraries/core/classes/PipelineManager/index.js
+++ b/libraries/core/classes/PipelineManager/index.js
@@ -3,7 +3,7 @@ import event from '../Event';
 import errorManager from '../ErrorManager';
 import pipelineDependencies from '../PipelineDependencies';
 import pipelineSequence from '../PipelineSequence';
-import * as errorSources from '../ErrorManager/constants';
+import * as errorSources from '../../constants/ErrorManager';
 import * as errorHandleTypes from '../../constants/ErrorHandleTypes';
 import * as processTypes from '../../constants/ProcessTypes';
 import { ETIMEOUT } from '../../constants/Pipeline';

--- a/libraries/core/constants/ErrorManager.js
+++ b/libraries/core/constants/ErrorManager.js
@@ -1,3 +1,6 @@
 export const DEFAULT_CONTEXT = '*';
 export const SOURCE_APP = 'app';
 export const SOURCE_PIPELINE = 'pipeline';
+export const SOURCE_TRACKING = 'tracking';
+
+export const CODE_TRACKING = 'ETRACKING';

--- a/libraries/tracking-core/core/Core.js
+++ b/libraries/tracking-core/core/Core.js
@@ -1,4 +1,6 @@
 import { logger } from '@shopgate/pwa-core/helpers';
+import errorManager from '@shopgate/pwa-core/classes/ErrorManager';
+import { SOURCE_TRACKING, CODE_TRACKING } from '@shopgate/pwa-core/constants/ErrorManager';
 import { optOut, isOptOut } from '../helpers/optOut';
 import trackingEvents, {
   REMOVE_TRACKER,
@@ -225,7 +227,17 @@ class Core {
         // Pass the unifiedBlacklist to the plugin if the plugin is the unified one
         params[2] = blacklist;
       }
-      entry.callback.apply(this, params);
+      try {
+        entry.callback.apply(this, params);
+      } catch (err) {
+        logger.error(`'SgTrackingCore': Error in plugin [${entry.trackerName}]`, err);
+
+        err.code = CODE_TRACKING;
+        err.source = SOURCE_TRACKING;
+        err.context = entry.trackerName;
+
+        errorManager.queue(err);
+      }
     });
   }
 

--- a/libraries/tracking/subscriptions/setup.js
+++ b/libraries/tracking/subscriptions/setup.js
@@ -3,6 +3,8 @@ import event from '@shopgate/pwa-core/classes/Event';
 import logGroup from '@shopgate/pwa-core/helpers/logGroup';
 import { getWebStorageEntry } from '@shopgate/pwa-core/commands/webStorage';
 import { useBrowserConnector } from '@shopgate/pwa-core/helpers';
+import errorManager from '@shopgate/pwa-core/classes/ErrorManager';
+import { SOURCE_TRACKING, CODE_TRACKING } from '@shopgate/pwa-core/constants/ErrorManager';
 import { defaultClientInformation } from '@shopgate/pwa-core/helpers/version';
 import registerEvents from '@shopgate/pwa-core/commands/registerEvents';
 import { TYPE_PHONE, OS_ALL } from '@shopgate/pwa-common/constants/Device';
@@ -75,6 +77,11 @@ export default function setup(subscribe) {
       logGroup('Tracking %c: Could not setup plugins', {
         error,
       }, '#ED0422');
+
+      error.code = CODE_TRACKING;
+      error.source = SOURCE_TRACKING;
+      error.context = 'trackingPlugins';
+      errorManager.queue(error);
     }
 
     core.registerFinished();


### PR DESCRIPTION
# Description

Improve error behaviour for tracking core plugin calls

## Type of change

Please add an "x" into the option that is relevant:

- [  ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [x] Internal :house: Only relates to internal processes.
