### PR TITLE
Correct handling of concurrent cart requests when adding a coupon with deeplink

### DIFF
--- a/libraries/commerce/cart/subscriptions/index.js
+++ b/libraries/commerce/cart/subscriptions/index.js
@@ -90,6 +90,14 @@ export default function cart(subscribe) {
       pipelines.SHOPGATE_CART_DELETE_COUPONS,
     ]);
 
+    // Push (deeplink) with coupon concurrent to get cart on app start
+    pipelineDependencies.set(pipelines.SHOPGATE_CART_ADD_COUPONS, [
+      pipelines.SHOPGATE_CART_GET_CART,
+    ]);
+    pipelineDependencies.set(pipelines.SHOPGATE_CART_DELETE_COUPONS, [
+      pipelines.SHOPGATE_CART_GET_CART,
+    ]);
+
     /**
      * Reload the cart whenever the WebView becomes visible.
      * This is needed, for example, when the cart is modified from another inAppBrowser tab like a

--- a/libraries/core/commands/registerEvents.js
+++ b/libraries/core/commands/registerEvents.js
@@ -6,7 +6,7 @@ import AppCommand from '../classes/AppCommand';
  * @param {Array} events Events that should be registered.
  */
 export default function registerEvents(events) {
-  const command = new AppCommand();
+  const command = new AppCommand(true, false);
 
   command
     .setCommandName('registerEvents')


### PR DESCRIPTION
# Description

Correct handling of concurrent cart requests when adding a coupon with deeplink or push notification

## Type of change

Please add an "x" into the option that is relevant:

- [ X ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.
