### PR TITLE
Expire page configs on every app start

### DIFF
--- a/libraries/common/actions/page/fetchPageConfig.js
+++ b/libraries/common/actions/page/fetchPageConfig.js
@@ -7,15 +7,14 @@ import { getPageConfigById } from '../../selectors/page';
 /**
  * Retrieves the config for a page.
  * @param {string} pageId The ID of the page to request.
- * @param {boolean} [force=true] When true, the request will go out without being checked.
  * @return {Function} The dispatched action.
  */
-export default function fetchPageConfig(pageId, force = false) {
+export default function fetchPageConfig(pageId) {
   return (dispatch, getState) => {
     const state = getState();
     const pageConfig = getPageConfigById(state, { pageId });
 
-    if (!force && !shouldFetchData(pageConfig)) {
+    if (!shouldFetchData(pageConfig)) {
       return null;
     }
 

--- a/libraries/common/reducers/page/index.js
+++ b/libraries/common/reducers/page/index.js
@@ -2,6 +2,7 @@ import {
   REQUEST_PAGE_CONFIG,
   RECEIVE_PAGE_CONFIG,
   ERROR_PAGE_CONFIG,
+  APP_WILL_START,
 } from '../../constants/ActionTypes';
 
 /**
@@ -53,6 +54,14 @@ export default function pageReducer(state = {}, action) {
         },
       };
     }
+    case APP_WILL_START: {
+      return Object.keys(state).reduce((newState, pageId) => {
+        // eslint-disable-next-line no-param-reassign
+        newState[pageId].expires = 0;
+        return newState;
+      }, { ...state });
+    }
+
     default:
       return state;
   }

--- a/themes/theme-gmd/pages/StartPage/subscriptions.js
+++ b/themes/theme-gmd/pages/StartPage/subscriptions.js
@@ -2,15 +2,12 @@ import { PAGE_ID_INDEX } from '@shopgate/pwa-common/constants/PageIDs';
 import { fetchPageConfig } from '@shopgate/pwa-common/actions/page';
 import { startPageWillEnter$ } from './streams';
 
-let force = true;
-
 /**
  * Page subscriptions.
  * @param {Function} subscribe The subscribe function.
  */
 export default function page(subscribe) {
   subscribe(startPageWillEnter$, ({ dispatch }) => {
-    dispatch(fetchPageConfig(PAGE_ID_INDEX, force));
-    force = false;
+    dispatch(fetchPageConfig(PAGE_ID_INDEX));
   });
 }

--- a/themes/theme-ios11/pages/StartPage/subscriptions.js
+++ b/themes/theme-ios11/pages/StartPage/subscriptions.js
@@ -2,15 +2,12 @@ import { PAGE_ID_INDEX } from '@shopgate/pwa-common/constants/PageIDs';
 import { fetchPageConfig } from '@shopgate/pwa-common/actions/page';
 import { startPageWillEnter$ } from './streams';
 
-let force = true;
-
 /**
  * Page subscriptions.
  * @param {Function} subscribe The subscribe function.
  */
 export default function page(subscribe) {
   subscribe(startPageWillEnter$, ({ dispatch }) => {
-    dispatch(fetchPageConfig(PAGE_ID_INDEX, force));
-    force = false;
+    dispatch(fetchPageConfig(PAGE_ID_INDEX));
   });
 }


### PR DESCRIPTION
# Description

Expire page configs on every app start

## Type of change

Please add an "x" into the option that is relevant:

- [ X ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.
