### PR TITLE
Make start page content load after window load event

### DIFF
--- a/libraries/core/commands/hideSplashScreen.js
+++ b/libraries/core/commands/hideSplashScreen.js
@@ -4,7 +4,7 @@ import AppCommand from '../classes/AppCommand';
  * Sends hideSplashScreen command to the app.
  */
 export default function hideSplashScreen() {
-  const command = new AppCommand();
+  const command = new AppCommand(true, false);
 
   command
     .setCommandName('hideSplashScreen')

--- a/libraries/core/commands/onload.js
+++ b/libraries/core/commands/onload.js
@@ -10,7 +10,7 @@ export default function onload() {
     return;
   }
 
-  const command = new AppCommand();
+  const command = new AppCommand(true, false);
 
   command
     .setCommandName('onload')

--- a/themes/theme-gmd/pages/StartPage/index.jsx
+++ b/themes/theme-gmd/pages/StartPage/index.jsx
@@ -1,15 +1,44 @@
-import React from 'react';
+import React, { Component } from 'react';
 import View from 'Components/View';
 import { PAGE_ID_INDEX } from '@shopgate/pwa-common/constants/PageIDs';
 import PageContent from '../Page/components/Content';
 
+let windowLoaded = false;
+
 /**
  * @returns {JSX}
  */
-const StartPage = () => (
-  <View>
-    <PageContent pageId={PAGE_ID_INDEX} />
-  </View>
-);
+class StartPage extends Component {
+  state = { content: windowLoaded };
+
+  /**
+   * Component did mount callback
+   */
+  componentDidMount() {
+    if (!windowLoaded) {
+      window.addEventListener('load', this.onWindowLoad);
+    }
+  }
+
+  /**
+   * Listener for window.load event
+   */
+  onWindowLoad = () => {
+    // With small timeout to let window commit loaded state
+    setTimeout(() => this.setState({ content: true }), 50);
+    windowLoaded = true;
+  }
+
+  /**
+   * @returns {JSX}
+   */
+  render() {
+    return (
+      <View>
+        {this.state.content && <PageContent pageId={PAGE_ID_INDEX} />}
+      </View>
+    );
+  }
+}
 
 export default StartPage;

--- a/themes/theme-ios11/pages/StartPage/index.jsx
+++ b/themes/theme-ios11/pages/StartPage/index.jsx
@@ -1,15 +1,44 @@
-import React from 'react';
+import React, { Component } from 'react';
 import View from 'Components/View';
 import { PAGE_ID_INDEX } from '@shopgate/pwa-common/constants/PageIDs';
 import PageContent from '../Page/components/Content';
 
+let windowLoaded = false;
+
 /**
  * @returns {JSX}
  */
-const StartPage = () => (
-  <View>
-    <PageContent pageId={PAGE_ID_INDEX} />
-  </View>
-);
+class StartPage extends Component {
+  state = { content: windowLoaded };
+
+  /**
+   * Component did mount callback
+   */
+  componentDidMount() {
+    if (!windowLoaded) {
+      window.addEventListener('load', this.onWindowLoad);
+    }
+  }
+
+  /**
+   * Listener for window.load event
+   */
+  onWindowLoad = () => {
+    // With small timeout to let window commit loaded state
+    setTimeout(() => this.setState({ content: true }), 50);
+    windowLoaded = true;
+  }
+
+  /**
+   * @returns {JSX}
+   */
+  render() {
+    return (
+      <View>
+        {this.state.content && <PageContent pageId={PAGE_ID_INDEX} />}
+      </View>
+    );
+  }
+}
 
 export default StartPage;


### PR DESCRIPTION
# Description

Make start page content load after window load event to prevent view blocking by long resources, like images, etc

## Type of change

Please add an "x" into the option that is relevant:

- [ X ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.
