### PR TITLE
Sentry.io level / severity is not send correctly for PWA 6.3.1

### DIFF
--- a/libraries/core/classes/ErrorManager/index.js
+++ b/libraries/core/classes/ErrorManager/index.js
@@ -1,5 +1,9 @@
 import EventEmitter from 'events';
-import { DEFAULT_CONTEXT, SOURCE_PIPELINE } from '../../constants/ErrorManager';
+import {
+  DEFAULT_CONTEXT,
+  SOURCE_PIPELINE,
+  DEFAULT_SEVERITY,
+} from '../../constants/ErrorManager';
 
 export const emitter = new EventEmitter();
 
@@ -93,6 +97,7 @@ class ErrorManager {
       message,
       source,
       meta,
+      severity = DEFAULT_SEVERITY,
     } = error;
 
     const id = `${source}-${context}-${code}`;
@@ -107,6 +112,7 @@ class ErrorManager {
         message,
       },
       source,
+      severity,
     });
 
     if (!this.timer) {

--- a/libraries/core/classes/ErrorManager/spec.js
+++ b/libraries/core/classes/ErrorManager/spec.js
@@ -1,5 +1,5 @@
 import errorManager, { emitter } from './';
-import { DEFAULT_CONTEXT } from '../../constants/ErrorManager';
+import { DEFAULT_CONTEXT, DEFAULT_SEVERITY } from '../../constants/ErrorManager';
 
 describe('ErrorManager', () => {
   beforeEach(() => {
@@ -258,6 +258,7 @@ describe('ErrorManager', () => {
       meta: {
         message,
       },
+      severity: DEFAULT_SEVERITY,
     });
   });
 });

--- a/libraries/core/constants/ErrorManager.js
+++ b/libraries/core/constants/ErrorManager.js
@@ -4,3 +4,14 @@ export const SOURCE_PIPELINE = 'pipeline';
 export const SOURCE_TRACKING = 'tracking';
 
 export const CODE_TRACKING = 'ETRACKING';
+
+export const Severity = {
+  Fatal: Symbol('fatal'),
+  Error: Symbol('error'),
+  Critical: Symbol('critical'),
+  Warning: Symbol('warning'),
+  Info: Symbol('info'),
+  Debug: Symbol('debug'),
+};
+
+export const DEFAULT_SEVERITY = Severity.Error;


### PR DESCRIPTION
# Description

Sentry.io level / severity is not send correctly for PWA 6.3.1

## Type of change

Please add an "x" into the option that is relevant:

- [ X ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.
