### PR TITLE
Fixed an issue with GET parameters inside of coupon deeplinks

### DIFF
--- a/libraries/commerce/cart/subscriptions/index.js
+++ b/libraries/commerce/cart/subscriptions/index.js
@@ -71,7 +71,7 @@ export default function cart(subscribe) {
       const [, , coupon] = action.params.pathname.split('/');
 
       if (coupon) {
-        dispatch(addCouponsToCart([coupon]));
+        dispatch(addCouponsToCart([coupon.split('?')[0]]));
       }
 
       return null;

--- a/libraries/commerce/cart/subscriptions/index.spec.js
+++ b/libraries/commerce/cart/subscriptions/index.spec.js
@@ -46,7 +46,7 @@ describe('Cart subscriptions', () => {
       const coupon = '10PERCENTOFF';
       const action = {
         params: {
-          pathname: `/cart_add_coupon/${coupon}`,
+          pathname: `/cart_add_coupon/${coupon}?get=parameter`,
         },
       };
 


### PR DESCRIPTION
# Description

This ticket is about to fix an issue with coupon deeplinks, when they contain GET-parameters. Now it's possible to redeem them.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Call `SGEvent.__call('openDeepLink', [{link: 'shopgate-10006://cart_add_coupon/test?get=parameter'}])` inside of the console. Replace "test" with one coupon from your shop.