### PR TITLE
Fixed an issue with GET parameters inside of coupon deeplinks

### DIFF
--- a/libraries/commerce/cart/streams/index.js
+++ b/libraries/commerce/cart/streams/index.js
@@ -105,7 +105,7 @@ export const couponActionPushNotification$ = openedLink$
   })
   .map(input => ({
     ...input,
-    code: input.action.options.url.split('/').filter(Boolean)[1],
+    code: input.action.options.url.split('/').filter(Boolean)[1].split('?')[0],
   }));
 
 /**


### PR DESCRIPTION
# Description

This ticket is about to fix an issue with coupon deeplinks, when they contain GET-parameters. Now it's possible to redeem them.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] New Feature :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Docs :memo: (Changes in the documentations)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Call `SGEvent.__call('openDeepLink', [{link: 'shopgate-10006://cart_add_coupon/test?get=parameter'}])` inside of the console. Replace "test" with one coupon from your shop.