### PR TITLE
Fixed swiper open link actions

### DIFF
--- a/libraries/common/components/Swiper/index.jsx
+++ b/libraries/common/components/Swiper/index.jsx
@@ -32,12 +32,29 @@ function Swiper(props) {
     disabled,
   } = props;
 
+  /** @type {Swiper} swiper An instance of the Swiper. */
   const [swiper, setSwiper] = useState(null);
 
   useEffect(() => {
     if (swiper !== null) {
       swiper.update();
       swiper.on('slideChange', () => onSlideChange(swiper.realIndex));
+      swiper.on('transitionEnd', () => {
+        // In loop mode the Swiper duplicates elements, which are not in the virtual DOM
+        if (loop) {
+          // Skip duplicated elements
+          if (swiper.activeIndex < 1) {
+            swiper.slideToLoop(children.length - 1, 0);
+          } else if (swiper.activeIndex > children.length) {
+            swiper.slideToLoop(0, 0);
+          }
+        }
+      });
+      swiper.on('beforeDestroy', () => {
+        swiper.off('slideChange');
+        swiper.off('transitionEnd');
+        swiper.off('beforeDestroy');
+      });
     }
   }, [swiper]);
 


### PR DESCRIPTION
# Description

Fixed swiper, so that loops function properly by manually switching to the correct react slide, when a duplicated is about to be shown.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [  ] New Feature :rocket: (non-breaking change which adds functionality)
- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [  ] Polish :nail_care: (Just some cleanups)
- [  ] Docs :memo: (Changes in the documentations)
- [  ] Internal :house: Only relates to internal processes.

## How to test it

Open an app which contains a looped swiper with links assigned to the slides. Navigate to the last slide and one slide further to trigger the loop. Tap on the slide and check if the link is opened correctly. Do the same with swiping the other way.