### PR TITLE
Small refactoring of the changelog builder script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,11 +6,11 @@ Please include a summary of the change. Please also include relevant motivation 
 
 Please add an "x" into the option that is relevant:
 
-- [  ] Bug Fix :bug: (non-breaking change which fixes an issue)
-- [  ] Enhancement :rocket: (non-breaking change which adds functionality)
-- [  ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
-- [  ] Polish :nail_care: (Just some cleanups)
-- [  ] Internal :house: Only relates to internal processes.
+- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
+- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
+- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Polish :nail_care: (Just some cleanups)
+- [ ] Internal :house: Only relates to internal processes.
 
 ## How to test it
 

--- a/scripts/build-changelog.js
+++ b/scripts/build-changelog.js
@@ -123,7 +123,7 @@ class Changelog extends LernaChangelog {
    */
   toCommitInfos(commits) {
     // Filter ot prerelease tags from commits
-    const ci = LernaChangelog.prototype.toCommitInfos.call(this, commits);
+    const ci = super.toCommitInfos(commits);
     return ci.map(commit => ({
       ...commit,
       tags: commit.tags ? commit.tags.filter(tag => !tag.includes('-')) : undefined,
@@ -137,8 +137,8 @@ class Changelog extends LernaChangelog {
    * @return {Promise<Object[]>}
    */
   async listReleases(from, to) {
+    const releases = await super.listReleases(from, to);
     const min = parseVersion(from);
-    const releases = await LernaChangelog.prototype.listReleases.call(this, from, to);
     return releases.filter((release) => {
       // Always treat unreleased as "higher"
       if (release.name === '___unreleased___') {


### PR DESCRIPTION
# Description

Small refactoring of the changelog builder script and changed PR template a bit.

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [x] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.
