### PR TITLE
Added support for long product names

### DIFF
--- a/libraries/commerce/product/selectors/product.js
+++ b/libraries/commerce/product/selectors/product.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import isEqual from 'lodash/isEqual';
-import { getCurrentRoute } from '@shopgate/pwa-common/selectors/router';
+import { getCurrentState } from '@shopgate/pwa-common/selectors/router';
 import { logger } from '@shopgate/pwa-core/helpers';
 import { generateResultHash } from '@shopgate/pwa-common/helpers/redux';
 import { DEFAULT_SORT } from '@shopgate/pwa-common/constants/DisplayOptions';
@@ -185,38 +185,21 @@ export const getProduct = createSelector(
 );
 
 /**
- * Retrieves the product name from the current route.
- * @param {Object} state The current application state.
- * @param {Object} props The component props.
- * @return {string|null}
- */
-export const getProductRouteName = createSelector(
-  getCurrentRoute,
-  (route) => {
-    if (!route || !route.state || !route.state.title) {
-      return null;
-    }
-
-    return route.state.title;
-  }
-);
-
-/**
  * Retrieves the product name.
  * @param {Object} state The current application state.
  * @param {Object} props The component props.
  * @return {string|null}
  */
 export const getProductName = createSelector(
-  getProductRouteName,
+  getCurrentState,
   getProduct,
-  (routeName, product) => {
-    if (routeName) {
-      return routeName;
-    }
-
+  (routeState, product) => {
     if (!product) {
-      return null;
+      if (!routeState || !routeState.title) {
+        return null;
+      }
+
+      return routeState.title;
     }
 
     return product.name;
@@ -230,15 +213,15 @@ export const getProductName = createSelector(
  * @return {string|null}
  */
 export const getProductLongName = createSelector(
-  getProductRouteName,
+  getCurrentState,
   getProduct,
-  (routeName, product) => {
-    if (routeName) {
-      return routeName;
-    }
-
+  (routeState, product) => {
     if (!product) {
-      return null;
+      if (!routeState || !routeState.title) {
+        return null;
+      }
+
+      return routeState.title;
     }
 
     if (!product.longName) {

--- a/libraries/commerce/product/selectors/product.js
+++ b/libraries/commerce/product/selectors/product.js
@@ -185,20 +185,67 @@ export const getProduct = createSelector(
 );
 
 /**
+ * Retrieves the product name from the current route.
+ * @param {Object} state The current application state.
+ * @param {Object} props The component props.
+ * @return {string|null}
+ */
+export const getProductRouteName = createSelector(
+  getCurrentRoute,
+  (route) => {
+    if (!route || !route.state || !route.state.title) {
+      return null;
+    }
+
+    return route.state.title;
+  }
+);
+
+/**
  * Retrieves the product name.
  * @param {Object} state The current application state.
  * @param {Object} props The component props.
  * @return {string|null}
  */
 export const getProductName = createSelector(
-  getCurrentRoute,
+  getProductRouteName,
   getProduct,
-  (route, product) => {
-    if (route && route.state && route.state.title) {
-      return route.state.title;
+  (routeName, product) => {
+    if (routeName) {
+      return routeName;
     }
 
-    return product ? product.name : null;
+    if (!product) {
+      return null;
+    }
+
+    return product.name;
+  }
+);
+
+/**
+ * Retrieves the product long name.
+ * @param {Object} state The current application state.
+ * @param {Object} props The component props.
+ * @return {string|null}
+ */
+export const getProductLongName = createSelector(
+  getProductRouteName,
+  getProduct,
+  (routeName, product) => {
+    if (routeName) {
+      return routeName;
+    }
+
+    if (!product) {
+      return null;
+    }
+
+    if (!product.longName) {
+      return product.name;
+    }
+
+    return product.longName;
   }
 );
 

--- a/libraries/commerce/product/selectors/product.mock.js
+++ b/libraries/commerce/product/selectors/product.mock.js
@@ -90,6 +90,7 @@ export const mockedProductsById = {
         hasVariants: false,
       },
       name: 'Fancy Product',
+      longName: 'Fancy Long Product Name',
       manufacturer: 'ACME',
       price: {
         currency: 'EUR',
@@ -126,6 +127,12 @@ export const mockedProductsById = {
       metadata: {
         some: 'metadata',
       },
+    },
+  },
+  product_7: {
+    isFetching: false,
+    productData: {
+      name: 'Short product name',
     },
   },
   // Taken from the original getKnownRelatives() selector test for variants.

--- a/libraries/commerce/product/selectors/product.spec.js
+++ b/libraries/commerce/product/selectors/product.spec.js
@@ -32,6 +32,7 @@ import {
   isVariantSelected,
   getProduct,
   getProductName,
+  getProductLongName,
   getProductRating,
   getProductManufacturer,
   getProductStock,
@@ -306,6 +307,25 @@ describe('Product selectors', () => {
         it('should return the property as expected', () => {
           expect(selector(mockedState, { productId })).toEqual(productData[property]);
         });
+      });
+    });
+
+    describe('getProductLongName()', () => {
+      it('should return the property as expected', () => {
+        const id = 'product_5';
+        const mockProductData = mockedProductsById[id].productData;
+        expect(getProductLongName(mockedState, { productId: id }))
+          .toEqual(mockProductData.longName);
+      });
+
+      it('should return the short name if long is not available', () => {
+        const id = 'product_7';
+        const mockProductData = mockedProductsById[id].productData;
+        expect(getProductLongName(mockedState, { productId: id })).toEqual(mockProductData.name);
+      });
+
+      it('should return null if no data is available', () => {
+        expect(getProductLongName(mockedState, { productId: 'product_4' })).toEqual(null);
       });
     });
 

--- a/themes/theme-gmd/pages/Product/components/AppBar/connector.js
+++ b/themes/theme-gmd/pages/Product/components/AppBar/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { getProductName } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import { getProductLongName } from '@shopgate/engage/product';
 
 /**
  * Maps the contents of the state to the component props.
@@ -8,7 +8,7 @@ import { getProductName } from '@shopgate/pwa-common-commerce/product/selectors/
  * @return {Object} The extended component props.
  */
 const mapStateToProps = (state, props) => ({
-  title: getProductName(state, props),
+  title: getProductLongName(state, props),
 });
 
 export default connect(mapStateToProps);

--- a/themes/theme-gmd/pages/Product/components/Header/components/Name/connector.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Name/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { getProductName } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import { getProductLongName } from '@shopgate/engage/product';
 
 /**
  * Maps the contents of the state to the component props.
@@ -8,7 +8,7 @@ import { getProductName } from '@shopgate/pwa-common-commerce/product/selectors/
  * @return {Object} The extended component props.
  */
 const mapStateToProps = (state, props) => ({
-  name: getProductName(state, props),
+  name: getProductLongName(state, props),
 });
 
 /**

--- a/themes/theme-ios11/pages/Product/components/AppBar/connector.js
+++ b/themes/theme-ios11/pages/Product/components/AppBar/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { getProductName } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import { getProductLongName } from '@shopgate/engage/product';
 
 /**
  * Maps the contents of the state to the component props.
@@ -8,7 +8,7 @@ import { getProductName } from '@shopgate/pwa-common-commerce/product/selectors/
  * @return {Object} The extended component props.
  */
 const mapStateToProps = (state, props) => ({
-  title: getProductName(state, props),
+  title: getProductLongName(state, props),
 });
 
 export default connect(mapStateToProps);

--- a/themes/theme-ios11/pages/Product/components/Header/components/Name/connector.js
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Name/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { getProductName } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import { getProductLongName } from '@shopgate/engage/product';
 
 /**
  * Maps the contents of the state to the component props.
@@ -8,7 +8,7 @@ import { getProductName } from '@shopgate/pwa-common-commerce/product/selectors/
  * @return {Object} The extended component props.
  */
 const mapStateToProps = (state, props) => ({
-  name: getProductName(state, props),
+  name: getProductLongName(state, props),
 });
 
 /**


### PR DESCRIPTION
# Description

This ticket is about adding support for long product names that will come up in the next generation of the Catalog Services (Catalog 2.0).

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.