### PR TITLE
Added more functionality to the changelog builder and generated a missing entry from `v6.4.1`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .idea/
 jsconfig.json
 
+.changelog/
+
 # Logs
 logs
 *.log
@@ -48,8 +50,8 @@ public/
 pipelines/
 trustedPipelines/
 extensions/
-!extensions/@shopgate-product-reviews
 !extensions/@shopgate-tracking-ga-native
+!extensions/@shopgate-product-reviews
 !extensions/@shopgate-user-privacy
 themes/*/config/
 .nyc_output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v6.4.1](https://github.com/shopgate/pwa/compare/v6.4.0...v6.4.1) (2019-04-24)
+
+#### :bug: Bug Fix
+* [#626](https://github.com/shopgate/pwa/pull/626) Fixed an issue with GET parameters inside of coupon deeplinks ([@fkloes](https://github.com/fkloes))
+
 ## [v6.4.0](https://github.com/shopgate/pwa/compare/v6.3.2...v6.4.0) (2019-04-10)
 
 #### :rocket: Enhancement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Changelog
 
-
-
-
-
-
-
-## [v6.4.0](https://github.com/shopgate/theme-gmd/compare/v6.3.2...v6.4.0) (2019-04-10)
+## [v6.4.0](https://github.com/shopgate/pwa/compare/v6.3.2...v6.4.0) (2019-04-10)
 
 #### :rocket: Enhancement
 * [#606](https://github.com/shopgate/pwa/pull/606) Extended the scanner event listeners to register for specific payload formats ([@fkloes](https://github.com/fkloes))
@@ -207,10 +201,10 @@
 * [#429](https://github.com/shopgate/pwa/pull/429) Changed the ViewContent to receive the visible flag as a prop ([@richardgorman](https://github.com/richardgorman))
 
 
-## [v6.0.0](https://github.com/shopgate/pwa/compare/v5.11.0...v6.0.0) (2018-12-04)
+## [v6.0.0](https://github.com/shopgate/pwa/tree/v6.0.0) (2018-12-04)
 
 #### :rocket: Enhancement
-* [#421](https://github.com/shopgate/pwa/pull/421) Add webcheckout register redirect action  ([@alexbridge](https://github.com/alexbridge))
+* [#421](https://github.com/shopgate/pwa/pull/421) Add webcheckout register redirect action ([@alexbridge](https://github.com/alexbridge))
 * [#422](https://github.com/shopgate/pwa/pull/422) Toast messages are hidden ([@richardgorman](https://github.com/richardgorman))
 * [#417](https://github.com/shopgate/pwa/pull/417) Normalise SnackBar usage ([@richardgorman](https://github.com/richardgorman))
 * [#414](https://github.com/shopgate/pwa/pull/414) Correct add to cart bar styles ([@richardgorman](https://github.com/richardgorman))
@@ -349,3 +343,9 @@
 * [#244](https://github.com/shopgate/pwa/pull/244) PWA-875: Implement dynamic redirects ([@fkloes](https://github.com/fkloes))
 * [#230](https://github.com/shopgate/pwa/pull/230) PWA-813: Improved product related selectors ([@fkloes](https://github.com/fkloes))
 * [#207](https://github.com/shopgate/pwa/pull/207) PWA-683 fix favorites route ([@richardgorman](https://github.com/richardgorman))
+
+
+## [Changelog for versions before v6.0.0](https://github.com/shopgate/pwa/blob/v5.X/CHANGELOG.md)
+
+
+## [Changelog for versions before v5.0.0](https://github.com/shopgate/theme-gmd/blob/v4.3.0/CHANGELOG.md)

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ else
 	PRE_RELEASE = true
 endif
 
-# Causes a STABLE release not to update master if not set to true
+# Causes a STABLE release not to update master if not set to false
 UPDATE_MASTER = true
 
 # This causes the Github-API to create draft releases only, without creating tags
@@ -363,7 +363,7 @@ ifeq ("$(STABLE)-$(UPDATE_MASTER)","true-true")
 		git push origin "releases/$(RELEASE_NAME)":master;
 		git status;
 else
-		# PRE-RELEASE (alpha, beta, rc) or STABLE (without changing master branches)
+		# PRE-RELEASE (alpha, beta, rc) or STABLE (without changing master branch)
 		$(call push-subtrees-to-git, releases/$(RELEASE_NAME))
 endif
 
@@ -372,7 +372,7 @@ define build-changelog
 		@echo "| Creating changelog ..."
 		@echo "======================================================================"
 		touch CHANGELOG.md;
-		GITHUB_AUTH=$(GITHUB_AUTH_TOKEN) node ./scripts/build-changelog.js --release-name="$(RELEASE_VERSION)" > CHANGELOG_NEW.md;
+		GITHUB_AUTH=$(GITHUB_AUTH_TOKEN) node ./scripts/build-changelog.js --release-name="$(RELEASE_VERSION)" --tagTo=HEAD --appendPreviousChangelog=true > CHANGELOG_NEW.md;
 		mv CHANGELOG_NEW.md CHANGELOG.md;
 		$(foreach theme, $(THEMES), cp CHANGELOG.md themes/$(theme)/CHANGELOG.md;)
 		# Push the new changelog to GitHub (into the STABLE release branch)


### PR DESCRIPTION
Improved the changelog creation script to allow creating changelog entries between two given tags and added an option to get only the newly created entry, rather than always appending the previous changelog entries. Modified the `Makefile` to account for these changes. Also added the missing changelog entry for PWA version `v6.4.1`.

# Description

Please include a summary of the change. Please also include relevant motivation and context.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Check the missing entry for 6.4.1 to be available now and create an rc or beta version to test changelog creation.