### PR TITLE
Fixed missing focus and contrast colors

### DIFF
--- a/libraries/common/helpers/config/theme.js
+++ b/libraries/common/helpers/config/theme.js
@@ -29,6 +29,11 @@ export function getThemeConfig(appConfig) {
     colors: {
       ...globals.colors,
       ...colors,
+      /**
+       * The SDK creates some colors dynamically and populates them via the THEME_CONFIG.
+       * To avoid breaking changes, those colors also needs to be added for now.
+       */
+      ...oldTheme.colors,
     },
     variables: {
       ...(oldTheme.variables || {}),

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -218,6 +218,7 @@
               "cta": "#fa5400",
               "ctaContrast": "#fff",
               "darkGray": "#eaeaea",
+              "focus": "#fa5400",
               "shade3": "#9a9a9a",
               "shade4": "#b5b5b5",
               "shade5": "#ccc",

--- a/themes/theme-gmd/theme-config.js
+++ b/themes/theme-gmd/theme-config.js
@@ -1,4 +1,22 @@
+const appConfig = require('./config/app.json');
+
+const { theme: { styles: { globals: { colors } = {} } = {} } = {} } = appConfig;
+const {
+  light, dark, primary, accent,
+} = colors;
+
+/**
+ * Currently the SDK uses the theme-config to autogenerate some dynamic color properties like
+ * primaryContrast or accentContrast. To avoid breaking of this system, the required colors
+ * are taken from the app-config and injected here.
+ */
 module.exports = {
+  colors: {
+    primary,
+    accent,
+    light,
+    dark,
+  },
   variables: {
     gap: {
       xsmall: 4,

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -209,6 +209,7 @@
               "cta": "#fa5400",
               "ctaContrast": "#fff",
               "darkGray": "#eaeaea",
+              "focus": "#fa5400",
               "shade3": "#9a9a9a",
               "shade4": "#b5b5b5",
               "shade5": "#ccc",

--- a/themes/theme-ios11/theme-config.js
+++ b/themes/theme-ios11/theme-config.js
@@ -1,4 +1,22 @@
+const appConfig = require('./config/app.json');
+
+const { theme: { styles: { globals: { colors } = {} } = {} } = {} } = appConfig;
+const {
+  light, dark, primary, accent,
+} = colors;
+
+/**
+ * Currently the SDK uses the theme-config to autogenerate some dynamic color properties like
+ * primaryContrast or accentContrast. To avoid breaking of this system, the required colors
+ * are taken from the app-config and injected here.
+ */
 module.exports = {
+  colors: {
+    primary,
+    accent,
+    light,
+    dark,
+  },
   variables: {
     blur: {
       backdropFilter: 'blur(20px)',


### PR DESCRIPTION
# Description
When the colors where moved from the theme-config the extension-config, we where not aware that the SDK uses them to create some additional colors dynamically (`primaryContrast`, `accentContrast` and `focus`).
Those colors are based on the `primary` and the `accent` color, which can be configured by SIs. Since there are already a lot of shops with custom colors, this ticket brings the relevant colors back to the theme-config. But they are now imported from the app-config which will be only relevant place with colors in the future.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Goto the login form and focus an input. The line below the input should have the primary color.
