### PR TITLE
Sliders now render correctly when the slides are updated

### DIFF
--- a/themes/theme-gmd/pages/ProductGallery/components/Content/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/ProductGallery/components/Content/__snapshots__/spec.jsx.snap
@@ -204,11 +204,6 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
                   "prevEl": null,
                 }
               }
-              on={
-                Object {
-                  "slideChange": [Function],
-                }
-              }
               pagination={
                 Object {
                   "bulletActiveClass": "css-hpsgy2",
@@ -494,11 +489,6 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
                 Object {
                   "nextEl": null,
                   "prevEl": null,
-                }
-              }
-              on={
-                Object {
-                  "slideChange": [Function],
                 }
               }
               pagination={

--- a/themes/theme-gmd/widgets/ImageSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/widgets/ImageSlider/__snapshots__/spec.jsx.snap
@@ -179,11 +179,6 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
               "prevEl": null,
             }
           }
-          on={
-            Object {
-              "slideChange": [Function],
-            }
-          }
           pagination={
             Object {
               "bulletActiveClass": "css-hpsgy2",
@@ -603,11 +598,6 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
               "prevEl": null,
             }
           }
-          on={
-            Object {
-              "slideChange": [Function],
-            }
-          }
           pagination={
             Object {
               "bulletActiveClass": "css-hpsgy2",
@@ -883,11 +873,6 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
             Object {
               "nextEl": null,
               "prevEl": null,
-            }
-          }
-          on={
-            Object {
-              "slideChange": [Function],
             }
           }
           pagination={

--- a/themes/theme-ios11/pages/ProductGallery/components/Content/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/ProductGallery/components/Content/__snapshots__/spec.jsx.snap
@@ -203,11 +203,6 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
                   "prevEl": null,
                 }
               }
-              on={
-                Object {
-                  "slideChange": [Function],
-                }
-              }
               pagination={
                 Object {
                   "bulletActiveClass": "css-hpsgy2",
@@ -491,11 +486,6 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
                 Object {
                   "nextEl": null,
                   "prevEl": null,
-                }
-              }
-              on={
-                Object {
-                  "slideChange": [Function],
                 }
               }
               pagination={

--- a/themes/theme-ios11/widgets/ImageSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/widgets/ImageSlider/__snapshots__/spec.jsx.snap
@@ -179,11 +179,6 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
               "prevEl": null,
             }
           }
-          on={
-            Object {
-              "slideChange": [Function],
-            }
-          }
           pagination={
             Object {
               "bulletActiveClass": "css-hpsgy2",
@@ -607,11 +602,6 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
               "prevEl": null,
             }
           }
-          on={
-            Object {
-              "slideChange": [Function],
-            }
-          }
           pagination={
             Object {
               "bulletActiveClass": "css-hpsgy2",
@@ -889,11 +879,6 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
             Object {
               "nextEl": null,
               "prevEl": null,
-            }
-          }
-          on={
-            Object {
-              "slideChange": [Function],
             }
           }
           pagination={


### PR DESCRIPTION
# Description
This ticket fixes an issue where sliders didn't update correctly when they where updated with different slides. The issue was caused by the swiper module which underlies the react-id-swiper module. It duplicates slides to enable looping sliders. Those slides are disconnected from react, so they are not updated when updated slides come in.

As a fix the swiper loop is now recreated when new children come in.

The ticket also fixes an issue where sliders with autoloop stopped after the first loop.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
- create a simple cms page with just one image slider
- open the page directly in the browser
- pick the persisted redux state from the localStorage and manipulate the image urls by changing the hash
- now reload the page

You should now see that the slider is initially rendered with broken images, but updates correctly when the page configuration comes in.
