### PR TITLE
Fixed broken handling of channel urls

### DIFF
--- a/libraries/common/subscriptions/helpers/handleLinks.js
+++ b/libraries/common/subscriptions/helpers/handleLinks.js
@@ -131,7 +131,7 @@ export const isShopLink = (location) => {
 
 /**
  * Sanitizes a link.
- * @param {string} location The location to sanitzie.
+ * @param {string} location The location to sanitize.
  * @return {string}
  */
 export const sanitizeLink = (location) => {
@@ -283,7 +283,8 @@ export const openNativeLink = (location) => {
  * @param {Object} state The application state.
  */
 export const openLegacyLink = (location, historyAction, state) => {
-  const [route] = location.split('?');
+  // Remove route parameters and query parameters to get the pure route of the legacy link.
+  const route = `/${location.split(/[?/]/)[1]}`;
 
   switch (route) {
     case LEGACY_LINK_ACCOUNT:


### PR DESCRIPTION
# Description
This ticket implements https://github.com/shopgate/pwa/pull/621 for `v6.4.2`. It is about to fix a bug within the handling of legacy channel urls. The `openLegacyLink` link handler wasn't prepared to open legacy links with route parameters.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Configure the "Newsletter" channel within the pages section of the merchant admin. Open it from the NavDrawer on GMD, or the "More" tab on iOS.
