### PR TITLE
Fixed an issue where product sliders widgets didn't update on state updates

### DIFF
--- a/themes/theme-gmd/widgets/ProductSlider/connector.js
+++ b/themes/theme-gmd/widgets/ProductSlider/connector.js
@@ -35,7 +35,7 @@ const areStatePropsEqual = (next, prev) => {
     return false;
   }
 
-  if (!prev.products.length && next.products.length) {
+  if (prev.products.length !== next.products.length) {
     return false;
   }
 

--- a/themes/theme-ios11/widgets/ProductSlider/connector.js
+++ b/themes/theme-ios11/widgets/ProductSlider/connector.js
@@ -35,7 +35,7 @@ const areStatePropsEqual = (next, prev) => {
     return false;
   }
 
-  if (!prev.products.length && next.products.length) {
+  if (prev.products.length !== next.products.length) {
     return false;
   }
 


### PR DESCRIPTION
# Description
This ticket is about to fix an issue where the product slider widget didn't update when the product list from its connector was updated.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
