### PR TITLE
Fixed a slider issue with swiping through zoomed slides

### DIFF
--- a/libraries/commerce/product/subscriptions/index.js
+++ b/libraries/commerce/product/subscriptions/index.js
@@ -11,6 +11,7 @@ import fetchProductOptions from '../actions/fetchProductOptions';
 import { productImageFormats } from '../collections';
 import {
   productWillEnter$,
+  galleryWillEnter$,
   productReceived$,
   cachedProductReceived$,
   productRelationsReceived$,
@@ -40,6 +41,11 @@ function product(subscribe) {
     dispatch(fetchProductProperties(id));
     dispatch(fetchProductImages(id, productImageFormats.getAllUniqueFormats()));
     dispatch(fetchProductShipping(id));
+  });
+
+  subscribe(galleryWillEnter$, ({ action, dispatch }) => {
+    const { productId } = action.route.params;
+    dispatch(fetchProductImages(hex2bin(productId), productImageFormats.getAllUniqueFormats()));
   });
 
   subscribe(processProduct$, ({ action, dispatch }) => {

--- a/libraries/common/components/Swiper/index.jsx
+++ b/libraries/common/components/Swiper/index.jsx
@@ -5,7 +5,7 @@ import cls from 'classnames';
 import IDSwiper from 'react-id-swiper';
 import { Pagination, Navigation, Autoplay, Zoom } from 'swiper/dist/js/swiper.esm';
 import SwiperItem from './components/SwiperItem';
-import { container, innerContainer, bullet, bulletActive } from './styles';
+import { container, innerContainer, zoomFix, bullet, bulletActive } from './styles';
 
 /**
  * The basic swiper component.
@@ -42,55 +42,40 @@ function Swiper(props) {
     // Only update the instance, when it differs from the current one.
     if (instance !== null && instance !== swiper) {
       setSwiper(instance);
-    }
-  };
 
-  /**
-   * Removes all event listeners from the swiper instance.
-   */
-  const removeEventListeners = () => {
-    if (swiper !== null) {
-      swiper.off('slideChange');
-      swiper.off('transitionEnd');
-      swiper.off('beforeDestroy');
+      instance.on('slideChange', () => onSlideChange(instance.realIndex));
+      instance.on('transitionEnd', () => {
+        // In loop mode the Swiper duplicates elements, which are not in the virtual DOM
+        if (loop) {
+          const autoplayRunning = instance.autoplay.running;
+          const previousIndex = instance.activeIndex;
+
+          // Skip duplicated elements
+          if (instance.activeIndex < 1) {
+            instance.slideToLoop(children.length - 1, 0);
+          } else if (instance.activeIndex > children.length) {
+            instance.slideToLoop(0, 0);
+          }
+
+          if (autoplayRunning && instance.activeIndex !== previousIndex) {
+            // Restart the autoplay when it was active before the auto slide.
+            instance.autoplay.start();
+          }
+        }
+      });
     }
   };
 
   useEffect(() => {
     if (swiper !== null) {
-      removeEventListeners();
-
       if (loop) {
         // Recreate the loop on prop updates to avoid duplicated slides from the last slide set.
         swiper.loopCreate();
       }
 
       swiper.update();
-      swiper.on('slideChange', () => onSlideChange(swiper.realIndex));
-      swiper.on('transitionEnd', () => {
-        // In loop mode the Swiper duplicates elements, which are not in the virtual DOM
-        if (loop) {
-          const autoplayRunning = swiper.autoplay.running;
-          const previousIndex = swiper.activeIndex;
-
-          // Skip duplicated elements
-          if (swiper.activeIndex < 1) {
-            swiper.slideToLoop(children.length - 1, 0);
-          } else if (swiper.activeIndex > children.length) {
-            swiper.slideToLoop(0, 0);
-          }
-
-          if (autoplayRunning && swiper.activeIndex !== previousIndex) {
-            // Restart the autoplay when it was active before the auto slide.
-            swiper.autoplay.start();
-          }
-        }
-      });
-      swiper.on('beforeDestroy', () => removeEventListeners());
     }
-
-    return () => removeEventListeners();
-  }, [swiper, children]);
+  }, [children]);
 
   const useFraction = (maxIndicators && maxIndicators < children.length);
   const paginationType = useFraction ? 'fraction' : 'bullets';
@@ -111,7 +96,7 @@ function Swiper(props) {
 
   const params = {
     modules: [Pagination, Navigation, Autoplay, Zoom],
-    containerClass: cls(innerContainer, classNames.container),
+    containerClass: cls(innerContainer, classNames.container, { [zoomFix]: zoom }),
     autoplay: autoPlay ? {
       delay: interval,
     } : false,

--- a/libraries/common/components/Swiper/styles.js
+++ b/libraries/common/components/Swiper/styles.js
@@ -15,6 +15,15 @@ export const innerContainer = css({
   },
 }).toString();
 
+/**
+ * Prevents a visible shrink animation of swiped out slides which where in a zoomed state before.
+ */
+export const zoomFix = css({
+  ' .swiper-slide': {
+    overflow: 'hidden',
+  },
+}).toString();
+
 export const wrapper = css({
   flexShrink: 0,
 });

--- a/themes/theme-gmd/pages/ProductGallery/components/Content/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/ProductGallery/components/Content/__snapshots__/spec.jsx.snap
@@ -85,7 +85,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
               allowSlideNext={true}
               allowSlidePrev={true}
               autoplay={false}
-              containerClass="css-1n5i2c5 css-sa13d4"
+              containerClass="css-1n5i2c5 css-sa13d4 css-qb469q"
               freeMode={false}
               getSwiper={[Function]}
               initialSlide={3}
@@ -230,7 +230,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
               }
             >
               <div
-                className="css-1n5i2c5 css-sa13d4"
+                className="css-1n5i2c5 css-sa13d4 css-qb469q"
               >
                 <div
                   className="swiper-wrapper"
@@ -372,7 +372,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
               allowSlideNext={true}
               allowSlidePrev={true}
               autoplay={false}
-              containerClass="css-1n5i2c5 css-sa13d4"
+              containerClass="css-1n5i2c5 css-sa13d4 css-qb469q"
               freeMode={false}
               getSwiper={[Function]}
               initialSlide={0}
@@ -517,7 +517,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
               }
             >
               <div
-                className="css-1n5i2c5 css-sa13d4"
+                className="css-1n5i2c5 css-sa13d4 css-qb469q"
               >
                 <div
                   className="swiper-wrapper"

--- a/themes/theme-ios11/pages/ProductGallery/components/Content/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/ProductGallery/components/Content/__snapshots__/spec.jsx.snap
@@ -84,7 +84,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
               allowSlideNext={true}
               allowSlidePrev={true}
               autoplay={false}
-              containerClass="css-1n5i2c5 css-sa13d4"
+              containerClass="css-1n5i2c5 css-sa13d4 css-qb469q"
               freeMode={false}
               getSwiper={[Function]}
               initialSlide={3}
@@ -228,7 +228,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
               }
             >
               <div
-                className="css-1n5i2c5 css-sa13d4"
+                className="css-1n5i2c5 css-sa13d4 css-qb469q"
               >
                 <div
                   className="swiper-wrapper"
@@ -369,7 +369,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
               allowSlideNext={true}
               allowSlidePrev={true}
               autoplay={false}
-              containerClass="css-1n5i2c5 css-sa13d4"
+              containerClass="css-1n5i2c5 css-sa13d4 css-qb469q"
               freeMode={false}
               getSwiper={[Function]}
               initialSlide={0}
@@ -513,7 +513,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
               }
             >
               <div
-                className="css-1n5i2c5 css-sa13d4"
+                className="css-1n5i2c5 css-sa13d4 css-qb469q"
               >
                 <div
                   className="swiper-wrapper"


### PR DESCRIPTION
# Description
This ticket is about to fix a slider issue with swiping though zoomed slides. Now swiped out slides should reset to the initial zoom state.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
- open the gallery page of a product with multiple images
- zoom an image via pinch or double tap
- swipe to the next image and back

The previously zoomed image should have the original state.