### PR TITLE
Fixed save area inset issue at the Footer component

### DIFF
--- a/libraries/ui-shared/Footer/index.jsx
+++ b/libraries/ui-shared/Footer/index.jsx
@@ -8,7 +8,6 @@ import {
 import { getStyle } from '@shopgate/pwa-common/helpers/dom';
 import {
   footer,
-  hasInset,
   withInset,
   updateInsetBackgroundColor,
 } from './style';
@@ -94,7 +93,7 @@ class Footer extends Component {
    * Performs an update of the inset background color.
    */
   performInsetBackgroundUpdate() {
-    if (hasInset() && this.ref.current) {
+    if (this.ref.current) {
       this.ref.current.classList.toggle(withInset, this.hasVisibleContent());
 
       updateInsetBackgroundColor(this.getInsetBackgroundColor(this.ref.current.children));

--- a/libraries/ui-shared/Footer/index.spec.jsx
+++ b/libraries/ui-shared/Footer/index.spec.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import {
-  hasInset,
-  updateInsetBackgroundColor,
-} from './style';
+import { updateInsetBackgroundColor } from './style';
 import Footer from './index';
 
 const mutationConstructorSpy = jest.fn();
@@ -22,7 +19,6 @@ jest.mock('./style', () => {
   const actual = require.requireActual('./style');
   return {
     ...actual,
-    hasInset: jest.fn().mockReturnValue(true),
     updateInsetBackgroundColor: jest.fn(),
   };
 });
@@ -179,14 +175,6 @@ describe('<Footer />', () => {
   });
 
   describe('.performInsetBackgroundUpdate()', () => {
-    it('should do nothing when no inset is set', () => {
-      const wrapper = createComponent();
-      updateInsetBackgroundColor.mockClear();
-      hasInset.mockReturnValueOnce(false);
-      wrapper.instance().performInsetBackgroundUpdate();
-      expect(updateInsetBackgroundColor).not.toHaveBeenCalled();
-    });
-
     it('should do nothing when the ref is empty', () => {
       const wrapper = createComponent();
       wrapper.instance().ref.current = null;

--- a/libraries/ui-shared/Footer/style.js
+++ b/libraries/ui-shared/Footer/style.js
@@ -12,20 +12,6 @@ export const updateInsetBackgroundColor = (color) => {
   }
 };
 
-/**
- * Checks if a bottom inset is set.
- * @returns {boolean}
- */
-export const hasInset = () => {
-  const value = getComputedStyle(document.documentElement).getPropertyValue('--safe-area-inset-bottom');
-
-  if (value) {
-    return value.replace('px', '') > 0;
-  }
-
-  return false;
-};
-
 export const footer = css({
   bottom: 0,
   flexShrink: 1,


### PR DESCRIPTION
# Description
This ticket is about to fix an issue with the Footer component, where the safe-area-inset at the bottom was not applied right from the app start. Instead it came in ~ 1sec delayed and pushed the TabBar up visible.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Open the app with an active iOS 11 theme on an iPhone with a notch. The TabBar should now have the correct height right from the beginning.