### PR TITLE
Improved extensibility of the ProductImage component

### DIFF
--- a/libraries/engage/components/constants.js
+++ b/libraries/engage/components/constants.js
@@ -1,0 +1,1 @@
+export const PORTAL_PRODUCT_IMAGE = 'component.product-image';

--- a/themes/theme-gmd/components/ProductImage/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/components/ProductImage/__snapshots__/spec.jsx.snap
@@ -1,46 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ProductImage /> should render a placeholder if no src prop is provided 1`] = `
-<div
-  className="css-y5kkpq"
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
 >
   <div
-    className="css-1vq3byi"
-    data-test-id="placeHolder"
+    className="css-y5kkpq"
   >
-    <Placeholder
-      className="css-19rc2oq"
-    />
+    <div
+      className="css-1vq3byi"
+      data-test-id="placeHolder"
+    >
+      <Placeholder
+        className="css-19rc2oq"
+      />
+    </div>
   </div>
-</div>
+</SurroundPortals>
 `;
 
 exports[`<ProductImage /> should render the image without a placeholder 1`] = `
-<Image
-  alt={null}
-  animating={true}
-  backgroundColor="#fff"
-  className={null}
-  forcePlaceholder={false}
-  highestResolutionLoaded={[Function]}
-  onError={[Function]}
-  onLoad={null}
-  ratio={null}
-  resolutions={
-    Array [
-      Object {
-        "blur": 2,
-        "height": 50,
-        "width": 50,
-      },
-      Object {
-        "height": 440,
-        "width": 440,
-      },
-    ]
-  }
-  src="http://placehold.it/300x300"
-  srcmap={null}
-  transition={null}
-/>
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
+>
+  <Image
+    alt={null}
+    animating={true}
+    backgroundColor="#fff"
+    className={null}
+    forcePlaceholder={false}
+    highestResolutionLoaded={[Function]}
+    onError={[Function]}
+    onLoad={null}
+    ratio={null}
+    resolutions={
+      Array [
+        Object {
+          "blur": 2,
+          "height": 50,
+          "width": 50,
+        },
+        Object {
+          "height": 440,
+          "width": 440,
+        },
+      ]
+    }
+    src="http://placehold.it/300x300"
+    srcmap={null}
+    transition={null}
+  />
+</SurroundPortals>
 `;

--- a/themes/theme-gmd/components/ProductImage/index.jsx
+++ b/themes/theme-gmd/components/ProductImage/index.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import Image from '@shopgate/pwa-common/components/Image';
 import Placeholder from '@shopgate/pwa-ui-shared/icons/PlaceholderIcon';
+import SurroundPortals from '@shopgate/pwa-common/components/SurroundPortals';
+import { PORTAL_PRODUCT_IMAGE } from '@shopgate/engage/components/constants';
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 import styles from './style';
 
@@ -108,17 +110,21 @@ class ProductImage extends Component {
     if (this.state.showPlaceholder) {
       // Image is not present or could not be loaded, show a placeholder.
       return (
-        <div className={styles.placeholderContainer}>
-          <div className={styles.placeholderContent} data-test-id="placeHolder">
-            <Placeholder className={styles.placeholder} />
+        <SurroundPortals portalName={PORTAL_PRODUCT_IMAGE} >
+          <div className={styles.placeholderContainer}>
+            <div className={styles.placeholderContent} data-test-id="placeHolder">
+              <Placeholder className={styles.placeholder} />
+            </div>
           </div>
-        </div>
+        </SurroundPortals>
       );
     }
 
     // Return the actual image.
     return (
-      <Image {...this.props} backgroundColor={colors.light} onError={this.imageLoadingFailed} />
+      <SurroundPortals portalName={PORTAL_PRODUCT_IMAGE}>
+        <Image {...this.props} backgroundColor={colors.light} onError={this.imageLoadingFailed} />
+      </SurroundPortals>
     );
   }
 }

--- a/themes/theme-gmd/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-gmd/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
@@ -151,43 +151,61 @@ exports[`<ProductCard /> should render as expected 1`] = `
                   src={null}
                   srcmap={null}
                 >
-                  <div
-                    className="css-y5kkpq"
+                  <SurroundPortals
+                    portalName="component.product-image"
+                    portalProps={null}
                   >
-                    <div
-                      className="css-1vq3byi"
-                      data-test-id="placeHolder"
+                    <Portal
+                      name="component.product-image.before"
+                      props={null}
+                    />
+                    <Portal
+                      name="component.product-image"
+                      props={null}
                     >
-                      <Placeholder
-                        className="css-19rc2oq"
+                      <div
+                        className="css-y5kkpq"
                       >
-                        <Icon
-                          className="css-19rc2oq"
-                          color={null}
-                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                          size="inherit"
-                          viewBox="0 0 24 24"
+                        <div
+                          className="css-1vq3byi"
+                          data-test-id="placeHolder"
                         >
-                          <svg
-                            className="css-yys9hb css-19rc2oq"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                              }
-                            }
-                            style={
-                              Object {
-                                "fill": null,
-                                "fontSize": "inherit",
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
-                        </Icon>
-                      </Placeholder>
-                    </div>
-                  </div>
+                          <Placeholder
+                            className="css-19rc2oq"
+                          >
+                            <Icon
+                              className="css-19rc2oq"
+                              color={null}
+                              content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                              size="inherit"
+                              viewBox="0 0 24 24"
+                            >
+                              <svg
+                                className="css-yys9hb css-19rc2oq"
+                                dangerouslySetInnerHTML={
+                                  Object {
+                                    "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                                  }
+                                }
+                                style={
+                                  Object {
+                                    "fill": null,
+                                    "fontSize": "inherit",
+                                  }
+                                }
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              />
+                            </Icon>
+                          </Placeholder>
+                        </div>
+                      </div>
+                    </Portal>
+                    <Portal
+                      name="component.product-image.after"
+                      props={null}
+                    />
+                  </SurroundPortals>
                 </ProductImage>
                 <ProductCardBadge
                   productId="PR0DUCTID"

--- a/themes/theme-gmd/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-gmd/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
@@ -85,43 +85,61 @@ exports[`<ProductCardRender /> should not render the discount badge when the is 
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <div
             className={
@@ -780,43 +798,61 @@ exports[`<ProductCardRender /> should not render the rating stars when there is 
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <ProductCardBadge
             productId="PR0DUCTID"
@@ -1195,43 +1231,61 @@ exports[`<ProductCardRender /> should render as expected 1`] = `
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <ProductCardBadge
             productId="PR0DUCTID"
@@ -1956,43 +2010,61 @@ exports[`<ProductCardRender /> should render with one row for the product name 1
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <ProductCardBadge
             productId="PR0DUCTID"
@@ -2717,43 +2789,61 @@ exports[`<ProductCardRender /> should render without name 1`] = `
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <ProductCardBadge
             productId="PR0DUCTID"
@@ -3442,43 +3532,61 @@ exports[`<ProductCardRender /> should render without prices 1`] = `
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <div
             className={
@@ -3962,43 +4070,61 @@ exports[`<ProductCardRender /> should render without rating 1`] = `
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <ProductCardBadge
             productId="PR0DUCTID"

--- a/themes/theme-gmd/themeApi/ProductCard/components/Render/index.spec.jsx
+++ b/themes/theme-gmd/themeApi/ProductCard/components/Render/index.spec.jsx
@@ -36,7 +36,7 @@ describe('<ProductCardRender />', () => {
   it('should render as expected', () => {
     const wrapper = renderComponent();
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('Portal').length).toBe(6);
+    expect(wrapper.find('Portal').length).toBe(9);
     expect(wrapper.find('Link').prop('href')).toEqual(defaultProps.url);
     expect(wrapper.find('ProductCardBadge').exists()).toBe(true);
     expect(wrapper.find('ProductCardBadge').text()).toEqual(`-${mockProduct.price.discount}%`);

--- a/themes/theme-ios11/components/ProductImage/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/components/ProductImage/__snapshots__/spec.jsx.snap
@@ -1,50 +1,119 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ProductImage /> should render a placeholder if no src prop is provided 1`] = `
-<div
-  className="css-y5kkpq css-3hjqnz"
+exports[`<ProductImage /> should not apply an inner shadow to the image if turned off via the app config 1`] = `
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
 >
   <div
-    className="css-1vq3byi"
-    data-test-id="placeHolder"
+    className=""
   >
-    <Placeholder
-      className="css-19rc2oq"
+    <Image
+      alt={null}
+      animating={true}
+      backgroundColor="#fff"
+      className=""
+      forcePlaceholder={false}
+      highestResolutionLoaded={[Function]}
+      onError={[Function]}
+      onLoad={null}
+      ratio={null}
+      resolutions={
+        Array [
+          Object {
+            "blur": 2,
+            "height": 50,
+            "width": 50,
+          },
+          Object {
+            "height": 440,
+            "width": 440,
+          },
+        ]
+      }
+      src="http://placehold.it/300x300"
+      srcmap={null}
+      transition={null}
     />
   </div>
-</div>
+</SurroundPortals>
+`;
+
+exports[`<ProductImage /> should not apply an inner shadow to the placeholder if turned off via the app config 1`] = `
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
+>
+  <div
+    className="css-y5kkpq"
+  >
+    <div
+      className="css-1vq3byi"
+      data-test-id="placeHolder"
+    >
+      <Placeholder
+        className="css-19rc2oq"
+      />
+    </div>
+  </div>
+</SurroundPortals>
+`;
+
+exports[`<ProductImage /> should render a placeholder if no src prop is provided 1`] = `
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
+>
+  <div
+    className="css-y5kkpq css-3hjqnz"
+  >
+    <div
+      className="css-1vq3byi"
+      data-test-id="placeHolder"
+    >
+      <Placeholder
+        className="css-19rc2oq"
+      />
+    </div>
+  </div>
+</SurroundPortals>
 `;
 
 exports[`<ProductImage /> should render the image without a placeholder 1`] = `
-<div
-  className="css-3hjqnz"
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
 >
-  <Image
-    alt={null}
-    animating={true}
-    backgroundColor="#fff"
+  <div
     className="css-3hjqnz"
-    forcePlaceholder={false}
-    highestResolutionLoaded={[Function]}
-    onError={[Function]}
-    onLoad={null}
-    ratio={null}
-    resolutions={
-      Array [
-        Object {
-          "blur": 2,
-          "height": 50,
-          "width": 50,
-        },
-        Object {
-          "height": 440,
-          "width": 440,
-        },
-      ]
-    }
-    src="http://placehold.it/300x300"
-    srcmap={null}
-    transition={null}
-  />
-</div>
+  >
+    <Image
+      alt={null}
+      animating={true}
+      backgroundColor="#fff"
+      className="css-3hjqnz"
+      forcePlaceholder={false}
+      highestResolutionLoaded={[Function]}
+      onError={[Function]}
+      onLoad={null}
+      ratio={null}
+      resolutions={
+        Array [
+          Object {
+            "blur": 2,
+            "height": 50,
+            "width": 50,
+          },
+          Object {
+            "height": 440,
+            "width": 440,
+          },
+        ]
+      }
+      src="http://placehold.it/300x300"
+      srcmap={null}
+      transition={null}
+    />
+  </div>
+</SurroundPortals>
 `;

--- a/themes/theme-ios11/components/ProductImage/index.jsx
+++ b/themes/theme-ios11/components/ProductImage/index.jsx
@@ -1,9 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import classNames from 'classnames';
 import Image from '@shopgate/pwa-common/components/Image';
 import Placeholder from '@shopgate/pwa-ui-shared/icons/PlaceholderIcon';
-import { themeConfig } from '@shopgate/pwa-common/helpers/config';
+import appConfig, { themeConfig } from '@shopgate/pwa-common/helpers/config';
+import SurroundPortals from '@shopgate/pwa-common/components/SurroundPortals';
+import { PORTAL_PRODUCT_IMAGE } from '@shopgate/engage/components/constants';
 import styles from './style';
 
 const { colors } = themeConfig;
@@ -103,27 +106,38 @@ class ProductImage extends Component {
    * @returns {JSX}
    */
   render() {
+    const addInnerShadow = appConfig.productImageShadow;
+
     if (this.state.showPlaceholder) {
+      const wrapperClasses = classNames(styles.placeholderContainer, {
+        [styles.innerShadow]: addInnerShadow,
+      });
+
       // Image is not present or could not be loaded, show a placeholder.
       return (
-        <div className={`${styles.placeholderContainer} ${styles.innerShadow}`}>
-          <div className={styles.placeholderContent} data-test-id="placeHolder">
-            <Placeholder className={styles.placeholder} />
+        <SurroundPortals portalName={PORTAL_PRODUCT_IMAGE} >
+          <div className={wrapperClasses}>
+            <div className={styles.placeholderContent} data-test-id="placeHolder">
+              <Placeholder className={styles.placeholder} />
+            </div>
           </div>
-        </div>
+        </SurroundPortals>
       );
     }
 
     // Return the actual image.
     return (
-      <div className={styles.innerShadow}>
-        <Image
-          {...this.props}
-          className={styles.innerShadow}
-          backgroundColor={colors.light}
-          onError={this.imageLoadingFailed}
-        />
-      </div>
+      <SurroundPortals portalName={PORTAL_PRODUCT_IMAGE}>
+        <div className={addInnerShadow ? styles.innerShadow : ''}>
+          <Image
+            {...this.props}
+            className={addInnerShadow ? styles.innerShadow : ''}
+            backgroundColor={colors.light}
+            onError={this.imageLoadingFailed}
+          />
+        </div>
+      </SurroundPortals>
+
     );
   }
 }

--- a/themes/theme-ios11/components/ProductImage/spec.jsx
+++ b/themes/theme-ios11/components/ProductImage/spec.jsx
@@ -2,15 +2,32 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import Image from '@shopgate/pwa-common/components/Image';
 import Placeholder from '@shopgate/pwa-ui-shared/icons/PlaceholderIcon';
+import styles from './style';
 import ProductImage from './index';
 
+let mockProductImageShadow;
+jest.mock('@shopgate/pwa-common/helpers/config', () => ({
+  get productImageShadow() { return mockProductImageShadow; },
+  themeConfig: {
+    colors: {
+      light: '#fff',
+    },
+  },
+}));
+
 describe('<ProductImage />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProductImageShadow = true;
+  });
+
   it('should render a placeholder if no src prop is provided', () => {
     const wrapper = shallow(<ProductImage />);
 
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(Image).length).toBe(0);
     expect(wrapper.find(Placeholder).length).toBe(1);
+    expect(wrapper.find(`.${styles.innerShadow}`).length).toBe(1);
   });
 
   it('should render the image without a placeholder', () => {
@@ -19,5 +36,22 @@ describe('<ProductImage />', () => {
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(Image).length).toBe(1);
     expect(wrapper.find(Placeholder).length).toBe(0);
+    expect(wrapper.find(`.${styles.innerShadow}`).length).toBe(2);
+  });
+
+  it('should not apply an inner shadow to the placeholder if turned off via the app config', () => {
+    mockProductImageShadow = false;
+    const wrapper = shallow(<ProductImage />);
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(`.${styles.innerShadow}`).length).toBe(0);
+  });
+
+  it('should not apply an inner shadow to the image if turned off via the app config', () => {
+    mockProductImageShadow = false;
+    const wrapper = shallow(<ProductImage src="http://placehold.it/300x300" />);
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(`.${styles.innerShadow}`).length).toBe(0);
   });
 });

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -321,6 +321,15 @@
         "type": "json",
         "label": "Favorites settings: limits, etc"
       }
+    },
+    "productImageShadow": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": true,
+      "params": {
+        "type": "json",
+        "label": "Toggle inner shadows of product images"
+      }
     }
   }
 }

--- a/themes/theme-ios11/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
@@ -150,43 +150,61 @@ exports[`<ProductCard /> should render as expected 1`] = `
                   src={null}
                   srcmap={null}
                 >
-                  <div
-                    className="css-y5kkpq css-3hjqnz"
+                  <SurroundPortals
+                    portalName="component.product-image"
+                    portalProps={null}
                   >
-                    <div
-                      className="css-1vq3byi"
-                      data-test-id="placeHolder"
+                    <Portal
+                      name="component.product-image.before"
+                      props={null}
+                    />
+                    <Portal
+                      name="component.product-image"
+                      props={null}
                     >
-                      <Placeholder
-                        className="css-19rc2oq"
+                      <div
+                        className="css-y5kkpq"
                       >
-                        <Icon
-                          className="css-19rc2oq"
-                          color={null}
-                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                          size="inherit"
-                          viewBox="0 0 24 24"
+                        <div
+                          className="css-1vq3byi"
+                          data-test-id="placeHolder"
                         >
-                          <svg
-                            className="css-yys9hb css-19rc2oq"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                              }
-                            }
-                            style={
-                              Object {
-                                "fill": null,
-                                "fontSize": "inherit",
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
-                        </Icon>
-                      </Placeholder>
-                    </div>
-                  </div>
+                          <Placeholder
+                            className="css-19rc2oq"
+                          >
+                            <Icon
+                              className="css-19rc2oq"
+                              color={null}
+                              content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                              size="inherit"
+                              viewBox="0 0 24 24"
+                            >
+                              <svg
+                                className="css-yys9hb css-19rc2oq"
+                                dangerouslySetInnerHTML={
+                                  Object {
+                                    "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                                  }
+                                }
+                                style={
+                                  Object {
+                                    "fill": null,
+                                    "fontSize": "inherit",
+                                  }
+                                }
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              />
+                            </Icon>
+                          </Placeholder>
+                        </div>
+                      </div>
+                    </Portal>
+                    <Portal
+                      name="component.product-image.after"
+                      props={null}
+                    />
+                  </SurroundPortals>
                 </ProductImage>
                 <ProductCardBadge
                   productId="PR0DUCTID"

--- a/themes/theme-ios11/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
@@ -84,43 +84,61 @@ exports[`<ProductCardRender /> should not render the discount badge when the is 
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq css-3hjqnz"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <div
             className={
@@ -778,43 +796,61 @@ exports[`<ProductCardRender /> should not render the rating stars when there is 
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq css-3hjqnz"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <ProductCardBadge
             productId="PR0DUCTID"
@@ -1192,43 +1228,61 @@ exports[`<ProductCardRender /> should render as expected 1`] = `
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq css-3hjqnz"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <ProductCardBadge
             productId="PR0DUCTID"
@@ -1952,43 +2006,61 @@ exports[`<ProductCardRender /> should render with one row for the product name 1
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq css-3hjqnz"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <ProductCardBadge
             productId="PR0DUCTID"
@@ -2712,43 +2784,61 @@ exports[`<ProductCardRender /> should render without name 1`] = `
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq css-3hjqnz"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <ProductCardBadge
             productId="PR0DUCTID"
@@ -3436,43 +3526,61 @@ exports[`<ProductCardRender /> should render without prices 1`] = `
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq css-3hjqnz"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <div
             className={
@@ -3955,43 +4063,61 @@ exports[`<ProductCardRender /> should render without rating 1`] = `
             src={null}
             srcmap={null}
           >
-            <div
-              className="css-y5kkpq css-3hjqnz"
+            <SurroundPortals
+              portalName="component.product-image"
+              portalProps={null}
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <Portal
+                name="component.product-image.before"
+                props={null}
+              />
+              <Portal
+                name="component.product-image"
+                props={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <div
+                  className="css-y5kkpq"
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-1vq3byi"
+                    data-test-id="placeHolder"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
+                    <Placeholder
+                      className="css-19rc2oq"
+                    >
+                      <Icon
+                        className="css-19rc2oq"
+                        color={null}
+                        content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                        size="inherit"
+                        viewBox="0 0 24 24"
+                      >
+                        <svg
+                          className="css-yys9hb css-19rc2oq"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                            }
+                          }
+                          style={
+                            Object {
+                              "fill": null,
+                              "fontSize": "inherit",
+                            }
+                          }
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </Icon>
+                    </Placeholder>
+                  </div>
+                </div>
+              </Portal>
+              <Portal
+                name="component.product-image.after"
+                props={null}
+              />
+            </SurroundPortals>
           </ProductImage>
           <ProductCardBadge
             productId="PR0DUCTID"

--- a/themes/theme-ios11/themeApi/ProductCard/components/Render/index.spec.jsx
+++ b/themes/theme-ios11/themeApi/ProductCard/components/Render/index.spec.jsx
@@ -36,7 +36,7 @@ describe('<ProductCardRender />', () => {
   it('should render as expected', () => {
     const wrapper = renderComponent();
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('Portal').length).toBe(6);
+    expect(wrapper.find('Portal').length).toBe(9);
     expect(wrapper.find('Link').prop('href')).toEqual(defaultProps.url);
     expect(wrapper.find('ProductCardBadge').exists()).toBe(true);
     expect(wrapper.find('ProductCardBadge').text()).toEqual(`-${mockProduct.price.discount}%`);


### PR DESCRIPTION
# Description
This ticket is about to add portals to the ProductImage component. It also introduces a new config setting to turn off inner shadows of product images within the iOS 11 theme.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
