### PR TITLE
Renamed the theme-ios11 setting to hide image shadows

### DIFF
--- a/themes/theme-ios11/components/ProductImage/index.jsx
+++ b/themes/theme-ios11/components/ProductImage/index.jsx
@@ -106,7 +106,7 @@ class ProductImage extends Component {
    * @returns {JSX}
    */
   render() {
-    const addInnerShadow = appConfig.productImageShadow;
+    const addInnerShadow = !appConfig.hideProductImageShadow;
 
     if (this.state.showPlaceholder) {
       const wrapperClasses = classNames(styles.placeholderContainer, {

--- a/themes/theme-ios11/components/ProductImage/spec.jsx
+++ b/themes/theme-ios11/components/ProductImage/spec.jsx
@@ -5,9 +5,9 @@ import Placeholder from '@shopgate/pwa-ui-shared/icons/PlaceholderIcon';
 import styles from './style';
 import ProductImage from './index';
 
-let mockProductImageShadow;
+let mockHideProductImageShadow;
 jest.mock('@shopgate/pwa-common/helpers/config', () => ({
-  get productImageShadow() { return mockProductImageShadow; },
+  get hideProductImageShadow() { return mockHideProductImageShadow; },
   themeConfig: {
     colors: {
       light: '#fff',
@@ -18,7 +18,7 @@ jest.mock('@shopgate/pwa-common/helpers/config', () => ({
 describe('<ProductImage />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockProductImageShadow = true;
+    mockHideProductImageShadow = false;
   });
 
   it('should render a placeholder if no src prop is provided', () => {
@@ -40,7 +40,7 @@ describe('<ProductImage />', () => {
   });
 
   it('should not apply an inner shadow to the placeholder if turned off via the app config', () => {
-    mockProductImageShadow = false;
+    mockHideProductImageShadow = true;
     const wrapper = shallow(<ProductImage />);
 
     expect(wrapper).toMatchSnapshot();
@@ -48,7 +48,7 @@ describe('<ProductImage />', () => {
   });
 
   it('should not apply an inner shadow to the image if turned off via the app config', () => {
-    mockProductImageShadow = false;
+    mockHideProductImageShadow = true;
     const wrapper = shallow(<ProductImage src="http://placehold.it/300x300" />);
 
     expect(wrapper).toMatchSnapshot();

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -322,10 +322,10 @@
         "label": "Favorites settings: limits, etc"
       }
     },
-    "productImageShadow": {
+    "hideProductImageShadow": {
       "type": "admin",
       "destination": "frontend",
-      "default": true,
+      "default": false,
       "params": {
         "type": "json",
         "label": "Toggle inner shadows of product images"

--- a/themes/theme-ios11/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
@@ -163,7 +163,7 @@ exports[`<ProductCard /> should render as expected 1`] = `
                       props={null}
                     >
                       <div
-                        className="css-y5kkpq"
+                        className="css-y5kkpq css-3hjqnz"
                       >
                         <div
                           className="css-1vq3byi"

--- a/themes/theme-ios11/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
@@ -97,7 +97,7 @@ exports[`<ProductCardRender /> should not render the discount badge when the is 
                 props={null}
               >
                 <div
-                  className="css-y5kkpq"
+                  className="css-y5kkpq css-3hjqnz"
                 >
                   <div
                     className="css-1vq3byi"
@@ -809,7 +809,7 @@ exports[`<ProductCardRender /> should not render the rating stars when there is 
                 props={null}
               >
                 <div
-                  className="css-y5kkpq"
+                  className="css-y5kkpq css-3hjqnz"
                 >
                   <div
                     className="css-1vq3byi"
@@ -1241,7 +1241,7 @@ exports[`<ProductCardRender /> should render as expected 1`] = `
                 props={null}
               >
                 <div
-                  className="css-y5kkpq"
+                  className="css-y5kkpq css-3hjqnz"
                 >
                   <div
                     className="css-1vq3byi"
@@ -2019,7 +2019,7 @@ exports[`<ProductCardRender /> should render with one row for the product name 1
                 props={null}
               >
                 <div
-                  className="css-y5kkpq"
+                  className="css-y5kkpq css-3hjqnz"
                 >
                   <div
                     className="css-1vq3byi"
@@ -2797,7 +2797,7 @@ exports[`<ProductCardRender /> should render without name 1`] = `
                 props={null}
               >
                 <div
-                  className="css-y5kkpq"
+                  className="css-y5kkpq css-3hjqnz"
                 >
                   <div
                     className="css-1vq3byi"
@@ -3539,7 +3539,7 @@ exports[`<ProductCardRender /> should render without prices 1`] = `
                 props={null}
               >
                 <div
-                  className="css-y5kkpq"
+                  className="css-y5kkpq css-3hjqnz"
                 >
                   <div
                     className="css-1vq3byi"
@@ -4076,7 +4076,7 @@ exports[`<ProductCardRender /> should render without rating 1`] = `
                 props={null}
               >
                 <div
-                  className="css-y5kkpq"
+                  className="css-y5kkpq css-3hjqnz"
                 >
                   <div
                     className="css-1vq3byi"


### PR DESCRIPTION
# Description
This ticket is about to rename the `productImageShadow` setting of the iOS theme. This became necessary due to a bug within the config service, which prevents falsy custom values.
The new name is `hideProductImageShadow`.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.
