### PR TITLE
PWA-1984 Implemented the ProductImage shadow setting and Portal for PWA 6.6

### DIFF
--- a/extensions/@shopgate-theme-config/frontend/config-gmd.js
+++ b/extensions/@shopgate-theme-config/frontend/config-gmd.js
@@ -1,6 +1,10 @@
 export default {
   theme: {
-    settings: {},
+    settings: {
+      '@shopgate/engage/product/ProductImage': {
+        showInnerShadow: false,
+      },
+    },
     typography: {
       family: 'Roboto, Arial, sans-serif',
       rootSize: 16,

--- a/extensions/@shopgate-theme-config/frontend/config-ios.js
+++ b/extensions/@shopgate-theme-config/frontend/config-ios.js
@@ -1,6 +1,10 @@
 export default {
   theme: {
-    settings: {},
+    settings: {
+      '@shopgate/engage/product/ProductImage': {
+        showInnerShadow: true,
+      },
+    },
     typography: {
       family: 'system, -apple-system, "SF Pro Display", "Helvetica Neue", "Lucida Grande"',
       rootSize: 17,

--- a/libraries/engage/core/hocs/__mocks__/withWidgetSettings.jsx
+++ b/libraries/engage/core/hocs/__mocks__/withWidgetSettings.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+/**
+ * Mock for the withWidgetSettings HOC.
+ * @param {Function} WrappedComponent The react component to wrap.
+ * @returns {JSX}
+ */
+export function withWidgetSettings(WrappedComponent) {
+  const settings = {
+    mocked: 'widgetSetting',
+  };
+
+  return props => (<WrappedComponent widgetSettings={settings} {...props} />);
+}

--- a/libraries/engage/core/hocs/__tests__/__snapshots__/withWidgetSettings.spec.jsx.snap
+++ b/libraries/engage/core/hocs/__tests__/__snapshots__/withWidgetSettings.spec.jsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`engage > core > hocs > withWidgetSettings should merge add the widget settings to a wrapped component 1`] = `
+<Component
+  widgetSettings={
+    Object {
+      "some": "setting",
+    }
+  }
+/>
+`;

--- a/libraries/engage/core/hocs/__tests__/withWidgetSettings.spec.jsx
+++ b/libraries/engage/core/hocs/__tests__/withWidgetSettings.spec.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { withWidgetSettings } from '../withWidgetSettings';
+import { useWidgetSettings } from '../../hooks/useWidgetSettings';
+
+jest.mock('../../hooks/useWidgetSettings', () => ({
+  useWidgetSettings: jest.fn(),
+}));
+
+/**
+ * A mocked component.
+ * @returns {JSX}
+ */
+const Component = withWidgetSettings(() => (<div />));
+
+const widgetSettings = {
+  some: 'setting',
+};
+
+describe('engage > core > hocs > withWidgetSettings', () => {
+  beforeEach(() => {
+    useWidgetSettings.mockReturnValue(widgetSettings);
+  });
+
+  it('should merge add the widget settings to a wrapped component', () => {
+    const wrapper = shallow(<Component />);
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.prop('widgetSettings')).toEqual(widgetSettings);
+  });
+});

--- a/libraries/engage/core/hocs/withWidgetSettings.jsx
+++ b/libraries/engage/core/hocs/withWidgetSettings.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useWidgetSettings } from '../hooks/useWidgetSettings';
+
+/**
+ * Injects the widget - configuration - settings for a specific widget by its id and
+ * an optional index. into the desired component.  If no index is given it will inject the first
+ * found widget - configuration - settings by widgetId.
+ * @param {Function} WrappedComponent The react component to wrap.
+ * @param {string} widgetId The id of the widget to look for, which must exist in the config.
+ * @param {number|undefined} [index] The optional index of the widget.
+ * @returns {Object}
+ */
+export function withWidgetSettings(WrappedComponent, widgetId, index) {
+  return (props) => {
+    const settings = useWidgetSettings(widgetId, index);
+
+    return (<WrappedComponent widgetSettings={settings} {...props} />);
+  };
+}

--- a/libraries/engage/core/index.js
+++ b/libraries/engage/core/index.js
@@ -243,6 +243,7 @@ export { withTheme } from './hocs/withTheme';
 export { withRoute } from './hocs/withRoute';
 export { withCurrentProduct } from './hocs/withCurrentProduct';
 export { withNavigation } from './hocs/withNavigation';
+export { withWidgetSettings } from './hocs/withWidgetSettings';
 
 // --------------- CONFIG --------------- //
 export { ThemeConfigResolver } from './config/ThemeConfigResolver';

--- a/libraries/engage/product/components/ProductImage/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/product/components/ProductImage/__snapshots__/spec.jsx.snap
@@ -1,30 +1,120 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ProductImage /> should render a placeholder if no src prop is provided 1`] = `
-<div
-  className="css-y5kkpq"
+exports[`<ProductImage /> should apply an inner shadow to the image if turned off via the widget settings 1`] = `
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
 >
   <div
-    className="css-1vq3byi"
-    data-test-id="placeHolder"
+    className="css-3hjqnz"
   >
-    <Placeholder
-      className="css-19rc2oq"
+    <Image
+      alt={null}
+      animating={true}
+      backgroundColor="#f2f2f2"
+      className="css-3hjqnz"
+      forcePlaceholder={false}
+      highestResolutionLoaded={[Function]}
+      onError={[Function]}
+      onLoad={null}
+      ratio={null}
+      resolutions={
+        Array [
+          Object {
+            "blur": 2,
+            "height": 50,
+            "width": 50,
+          },
+          Object {
+            "height": 440,
+            "width": 440,
+          },
+        ]
+      }
+      src="http://placehold.it/300x300"
+      srcmap={null}
+      transition={null}
+      widgetSettings={
+        Object {
+          "showInnerShadow": true,
+        }
+      }
     />
   </div>
-</div>
+</SurroundPortals>
 `;
 
-exports[`<ProductImage /> should render the image without a placeholder 1`] = `
-<Image
+exports[`<ProductImage /> should apply an inner shadow to the placeholder if turned off via the widget settings 1`] = `
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
+>
+  <div
+    className="css-y5kkpq css-3hjqnz"
+  >
+    <div
+      className="css-1vq3byi"
+      data-test-id="placeHolder"
+    >
+      <Placeholder
+        className="css-19rc2oq"
+      />
+    </div>
+  </div>
+</SurroundPortals>
+`;
+
+exports[`<ProductImage /> should not apply an inner shadow to the image if turned off via the app config 1`] = `
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
+>
+  <div
+    className=""
+  >
+    <Image
+      alt={null}
+      animating={true}
+      backgroundColor="#f2f2f2"
+      className=""
+      forcePlaceholder={false}
+      highestResolutionLoaded={[Function]}
+      onError={[Function]}
+      onLoad={null}
+      ratio={null}
+      resolutions={
+        Array [
+          Object {
+            "blur": 2,
+            "height": 50,
+            "width": 50,
+          },
+          Object {
+            "height": 440,
+            "width": 440,
+          },
+        ]
+      }
+      src="http://placehold.it/300x300"
+      srcmap={null}
+      transition={null}
+      widgetSettings={
+        Object {
+          "mocked": "widgetSetting",
+        }
+      }
+    />
+  </div>
+</SurroundPortals>
+`;
+
+exports[`<ProductImage /> should not apply an inner shadow to the image if turned off via the widget settings 1`] = `
+<ProductImage
   alt={null}
   animating={true}
-  backgroundColor="#fff"
   className={null}
   forcePlaceholder={false}
   highestResolutionLoaded={[Function]}
-  onError={[Function]}
-  onLoad={null}
   ratio={null}
   resolutions={
     Array [
@@ -41,6 +131,114 @@ exports[`<ProductImage /> should render the image without a placeholder 1`] = `
   }
   src="http://placehold.it/300x300"
   srcmap={null}
-  transition={null}
+  widgetSettings={
+    Object {
+      "showInnerShadow": false,
+    }
+  }
 />
+`;
+
+exports[`<ProductImage /> should not apply an inner shadow to the placeholder if turned off via the app config 1`] = `
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
+>
+  <div
+    className="css-y5kkpq"
+  >
+    <div
+      className="css-1vq3byi"
+      data-test-id="placeHolder"
+    >
+      <Placeholder
+        className="css-19rc2oq"
+      />
+    </div>
+  </div>
+</SurroundPortals>
+`;
+
+exports[`<ProductImage /> should not apply an inner shadow to the placeholder if turned off via the widget settings 1`] = `
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
+>
+  <div
+    className="css-y5kkpq"
+  >
+    <div
+      className="css-1vq3byi"
+      data-test-id="placeHolder"
+    >
+      <Placeholder
+        className="css-19rc2oq"
+      />
+    </div>
+  </div>
+</SurroundPortals>
+`;
+
+exports[`<ProductImage /> should render a placeholder if no src prop is provided 1`] = `
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
+>
+  <div
+    className="css-y5kkpq css-3hjqnz"
+  >
+    <div
+      className="css-1vq3byi"
+      data-test-id="placeHolder"
+    >
+      <Placeholder
+        className="css-19rc2oq"
+      />
+    </div>
+  </div>
+</SurroundPortals>
+`;
+
+exports[`<ProductImage /> should render the image without a placeholder 1`] = `
+<SurroundPortals
+  portalName="component.product-image"
+  portalProps={null}
+>
+  <div
+    className="css-3hjqnz"
+  >
+    <Image
+      alt={null}
+      animating={true}
+      backgroundColor="#f2f2f2"
+      className="css-3hjqnz"
+      forcePlaceholder={false}
+      highestResolutionLoaded={[Function]}
+      onError={[Function]}
+      onLoad={null}
+      ratio={null}
+      resolutions={
+        Array [
+          Object {
+            "blur": 2,
+            "height": 50,
+            "width": 50,
+          },
+          Object {
+            "height": 440,
+            "width": 440,
+          },
+        ]
+      }
+      src="http://placehold.it/300x300"
+      srcmap={null}
+      transition={null}
+      widgetSettings={
+        Object {
+          "mocked": "widgetSetting",
+        }
+      }
+    />
+  </div>
+</SurroundPortals>
 `;

--- a/libraries/engage/product/components/ProductImage/index.jsx
+++ b/libraries/engage/product/components/ProductImage/index.jsx
@@ -2,8 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import classnames from 'classnames';
-import { themeConfig } from '@shopgate/pwa-common/helpers/config';
-import { Image, PlaceholderIcon } from '../../../components';
+import appConfig, { themeConfig } from '@shopgate/pwa-common/helpers/config';
+import Image from '@shopgate/pwa-common/components/Image';
+import PlaceholderIcon from '@shopgate/pwa-ui-shared/icons/PlaceholderIcon';
+import SurroundPortals from '@shopgate/pwa-common/components/SurroundPortals';
+import { withWidgetSettings } from '../../../core/hocs/withWidgetSettings';
+import { PORTAL_PRODUCT_IMAGE } from '../../../components/constants';
+
 import styles from './style';
 
 const { colors } = themeConfig;
@@ -32,6 +37,7 @@ class ProductImage extends Component {
     })),
     src: PropTypes.string,
     srcmap: PropTypes.arrayOf(PropTypes.string),
+    widgetSettings: PropTypes.shape(),
   };
 
   static defaultProps = {
@@ -54,6 +60,7 @@ class ProductImage extends Component {
     ],
     src: null,
     srcmap: null,
+    widgetSettings: {},
   };
 
   /**
@@ -105,39 +112,44 @@ class ProductImage extends Component {
    * @returns {JSX}
    */
   render() {
+    let { showInnerShadow } = this.props.widgetSettings;
+
+    if (typeof showInnerShadow === 'undefined') {
+      showInnerShadow = !appConfig.hideProductImageShadow;
+    }
+
     if (this.state.showPlaceholder) {
       // Image is not present or could not be loaded, show a placeholder.
       return (
-        <div className={classnames(styles.placeholderContainer, styles.innerShadow)}>
-          <div className={styles.placeholderContent} data-test-id="placeHolder">
-            <PlaceholderIcon className={styles.placeholder} />
+        <SurroundPortals portalName={PORTAL_PRODUCT_IMAGE} >
+          <div className={classnames(styles.placeholderContainer, {
+            [styles.innerShadow]: showInnerShadow,
+          })}
+          >
+            <div className={styles.placeholderContent} data-test-id="placeHolder">
+              <PlaceholderIcon className={styles.placeholder} />
+            </div>
           </div>
-        </div>
-      );
-    }
-
-    if (styles.innerShadow) {
-      return (
-        <div className={styles.innerShadow}>
-          <Image
-            {...this.props}
-            className={styles.innerShadow}
-            backgroundColor={colors.light}
-            onError={this.imageLoadingFailed}
-          />
-        </div>
+        </SurroundPortals>
       );
     }
 
     // Return the actual image.
     return (
-      <Image
-        {...this.props}
-        backgroundColor={colors.light}
-        onError={this.imageLoadingFailed}
-      />
+      <SurroundPortals portalName={PORTAL_PRODUCT_IMAGE}>
+        <div className={showInnerShadow ? styles.innerShadow : ''}>
+          <Image
+            {...this.props}
+            className={showInnerShadow ? styles.innerShadow : ''}
+            backgroundColor={colors.light}
+            onError={this.imageLoadingFailed}
+          />
+        </div>
+      </SurroundPortals>
     );
   }
 }
 
-export default ProductImage;
+export { ProductImage as UnwrappedProductImage };
+
+export default withWidgetSettings(ProductImage, '@shopgate/engage/product/ProductImage');

--- a/libraries/engage/product/components/ProductImage/spec.jsx
+++ b/libraries/engage/product/components/ProductImage/spec.jsx
@@ -1,11 +1,23 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Image, PlaceholderIcon } from '../../../components';
+import Image from '@shopgate/pwa-common/components/Image';
+import PlaceholderIcon from '@shopgate/pwa-ui-shared/icons/PlaceholderIcon';
+import styles from './style';
 import ProductImage from './index';
+
+jest.mock('../../../core/hocs/withWidgetSettings');
+
+let mockHideProductImageShadow;
+jest.mock('@shopgate/pwa-common/helpers/config', () => ({
+  get hideProductImageShadow() { return mockHideProductImageShadow; },
+  themeConfig: {
+    colors: {},
+  },
+}));
 
 describe('<ProductImage />', () => {
   it('should render a placeholder if no src prop is provided', () => {
-    const wrapper = shallow(<ProductImage />);
+    const wrapper = shallow(<ProductImage />).dive();
 
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(Image).length).toBe(0);
@@ -13,10 +25,54 @@ describe('<ProductImage />', () => {
   });
 
   it('should render the image without a placeholder', () => {
-    const wrapper = shallow(<ProductImage src="http://placehold.it/300x300" />);
+    const wrapper = shallow(<ProductImage src="http://placehold.it/300x300" />).dive();
 
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(Image).length).toBe(1);
     expect(wrapper.find(PlaceholderIcon).length).toBe(0);
+  });
+
+  it('should not apply an inner shadow to the placeholder if turned off via the app config', () => {
+    mockHideProductImageShadow = true;
+    const wrapper = shallow(<ProductImage />).dive();
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(`.${styles.innerShadow}`).length).toBe(0);
+  });
+
+  it('should not apply an inner shadow to the image if turned off via the app config', () => {
+    mockHideProductImageShadow = true;
+    const wrapper = shallow(<ProductImage src="http://placehold.it/300x300" />).dive();
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(`.${styles.innerShadow}`).length).toBe(0);
+  });
+
+  it('should not apply an inner shadow to the placeholder if turned off via the widget settings', () => {
+    const wrapper = shallow(<ProductImage widgetSettings={{ showInnerShadow: false }} />).dive();
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(`.${styles.innerShadow}`).length).toBe(0);
+  });
+
+  it('should not apply an inner shadow to the image if turned off via the widget settings', () => {
+    const wrapper = shallow(<ProductImage src="http://placehold.it/300x300" widgetSettings={{ showInnerShadow: false }} />);
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(`.${styles.innerShadow}`).length).toBe(0);
+  });
+
+  it('should apply an inner shadow to the placeholder if turned off via the widget settings', () => {
+    const wrapper = shallow(<ProductImage widgetSettings={{ showInnerShadow: true }} />).dive();
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(`.${styles.innerShadow}`).length).toBe(1);
+  });
+
+  it('should apply an inner shadow to the image if turned off via the widget settings', () => {
+    const wrapper = shallow(<ProductImage src="http://placehold.it/300x300" widgetSettings={{ showInnerShadow: true }} />).dive();
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(`.${styles.innerShadow}`).length).toBe(2);
   });
 });

--- a/libraries/engage/product/components/ProductImage/style.js
+++ b/libraries/engage/product/components/ProductImage/style.js
@@ -1,5 +1,4 @@
 import { css } from 'glamor';
-import { themeName } from '@shopgate/pwa-common/helpers/config';
 
 const placeholderContainer = css({
   position: 'relative',
@@ -31,7 +30,7 @@ const placeholder = css({
   color: 'rgba(0, 0, 0, .05)',
 }).toString();
 
-const innerShadow = themeName.includes('ios') ? css({
+const innerShadow = css({
   position: 'relative',
   overflow: 'hidden',
   ':after': {
@@ -45,7 +44,7 @@ const innerShadow = themeName.includes('ios') ? css({
     boxShadow: 'inset 0 0 20px rgba(0, 0, 0, .05)',
     pointerEvents: 'none',
   },
-}).toString() : null;
+}).toString();
 
 export default {
   placeholderContainer,

--- a/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemImage/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemImage/__snapshots__/spec.jsx.snap
@@ -18,29 +18,10 @@ exports[`<ItemImage /> should render 1`] = `
       }
     }
   >
-    <ProductImage
+    <Component
       alt="FooBar"
-      animating={true}
-      className={null}
-      forcePlaceholder={false}
-      highestResolutionLoaded={[Function]}
       itemProp="image"
-      ratio={null}
-      resolutions={
-        Array [
-          Object {
-            "blur": 2,
-            "height": 50,
-            "width": 50,
-          },
-          Object {
-            "height": 440,
-            "width": 440,
-          },
-        ]
-      }
       src="http://www.google.com"
-      srcmap={null}
     />
   </Portal>
   <Portal

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -333,6 +333,15 @@
         "type": "json",
         "label": "Favorites settings: limits, etc"
       }
+    },
+    "hideProductImageShadow": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": true,
+      "params": {
+        "type": "json",
+        "label": "Toggle inner shadows of product images"
+      }
     }
   }
 }

--- a/themes/theme-gmd/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-gmd/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
@@ -127,68 +127,97 @@ exports[`<ProductCard /> should render as expected 1`] = `
                 onClick={[Function]}
                 role="link"
               >
-                <ProductImage
+                <Component
                   alt="Product Name"
-                  animating={true}
-                  className={null}
-                  forcePlaceholder={false}
-                  highestResolutionLoaded={[Function]}
                   itemProp="image"
-                  ratio={null}
-                  resolutions={
-                    Array [
-                      Object {
-                        "blur": 2,
-                        "height": 50,
-                        "width": 50,
-                      },
-                      Object {
-                        "height": 440,
-                        "width": 440,
-                      },
-                    ]
-                  }
                   src={null}
-                  srcmap={null}
                 >
-                  <div
-                    className="css-y5kkpq"
+                  <ProductImage
+                    alt="Product Name"
+                    animating={true}
+                    className={null}
+                    forcePlaceholder={false}
+                    highestResolutionLoaded={[Function]}
+                    itemProp="image"
+                    ratio={null}
+                    resolutions={
+                      Array [
+                        Object {
+                          "blur": 2,
+                          "height": 50,
+                          "width": 50,
+                        },
+                        Object {
+                          "height": 440,
+                          "width": 440,
+                        },
+                      ]
+                    }
+                    src={null}
+                    srcmap={null}
+                    widgetSettings={
+                      Object {
+                        "mocked": "widgetSetting",
+                      }
+                    }
                   >
-                    <div
-                      className="css-1vq3byi"
-                      data-test-id="placeHolder"
+                    <SurroundPortals
+                      portalName="component.product-image"
+                      portalProps={null}
                     >
-                      <Placeholder
-                        className="css-19rc2oq"
+                      <Portal
+                        name="component.product-image.before"
+                        props={null}
+                      />
+                      <Portal
+                        name="component.product-image"
+                        props={null}
                       >
-                        <Icon
-                          className="css-19rc2oq"
-                          color={null}
-                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                          size="inherit"
-                          viewBox="0 0 24 24"
+                        <div
+                          className="css-y5kkpq css-3hjqnz"
                         >
-                          <svg
-                            className="css-yys9hb css-19rc2oq"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                              }
-                            }
-                            style={
-                              Object {
-                                "fill": null,
-                                "fontSize": "inherit",
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
-                        </Icon>
-                      </Placeholder>
-                    </div>
-                  </div>
-                </ProductImage>
+                          <div
+                            className="css-1vq3byi"
+                            data-test-id="placeHolder"
+                          >
+                            <Placeholder
+                              className="css-19rc2oq"
+                            >
+                              <Icon
+                                className="css-19rc2oq"
+                                color={null}
+                                content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                                size="inherit"
+                                viewBox="0 0 24 24"
+                              >
+                                <svg
+                                  className="css-yys9hb css-19rc2oq"
+                                  dangerouslySetInnerHTML={
+                                    Object {
+                                      "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                                    }
+                                  }
+                                  style={
+                                    Object {
+                                      "fill": null,
+                                      "fontSize": "inherit",
+                                    }
+                                  }
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                />
+                              </Icon>
+                            </Placeholder>
+                          </div>
+                        </div>
+                      </Portal>
+                      <Portal
+                        name="component.product-image.after"
+                        props={null}
+                      />
+                    </SurroundPortals>
+                  </ProductImage>
+                </Component>
                 <ProductCardBadge
                   productId="PR0DUCTID"
                   style={Object {}}

--- a/themes/theme-gmd/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-gmd/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
@@ -61,68 +61,97 @@ exports[`<ProductCardRender /> should not render the discount badge when the is 
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <div
             className={
               Object {
@@ -774,68 +803,97 @@ exports[`<ProductCardRender /> should not render the rating stars when there is 
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <ProductCardBadge
             productId="PR0DUCTID"
             style={Object {}}
@@ -1207,68 +1265,97 @@ exports[`<ProductCardRender /> should render as expected 1`] = `
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <ProductCardBadge
             productId="PR0DUCTID"
             style={Object {}}
@@ -1986,68 +2073,97 @@ exports[`<ProductCardRender /> should render with one row for the product name 1
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <ProductCardBadge
             productId="PR0DUCTID"
             style={Object {}}
@@ -2765,68 +2881,97 @@ exports[`<ProductCardRender /> should render without name 1`] = `
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <ProductCardBadge
             productId="PR0DUCTID"
             style={Object {}}
@@ -3508,68 +3653,97 @@ exports[`<ProductCardRender /> should render without prices 1`] = `
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <div
             className={
               Object {
@@ -4034,68 +4208,97 @@ exports[`<ProductCardRender /> should render without rating 1`] = `
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <ProductCardBadge
             productId="PR0DUCTID"
             style={Object {}}

--- a/themes/theme-gmd/themeApi/ProductCard/components/Render/index.spec.jsx
+++ b/themes/theme-gmd/themeApi/ProductCard/components/Render/index.spec.jsx
@@ -7,6 +7,8 @@ import MockProductImage from '@shopgate/engage/product/components/ProductImage';
 import { mockProductId, mockProduct } from '../../mock';
 import ProductCardRender from './index';
 
+jest.mock('@shopgate/engage/core/hocs/withWidgetSettings');
+
 jest.mock('@shopgate/engage/product', () => ({
   withPriceCalculation: Component => props => <Component {...props} />,
   MapPriceHint: () => null,
@@ -44,7 +46,7 @@ describe('<ProductCardRender />', () => {
   it('should render as expected', () => {
     const wrapper = renderComponent();
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('Portal').length).toBe(6);
+    expect(wrapper.find('Portal').length).toBe(9);
     expect(wrapper.find('Link').prop('href')).toEqual(defaultProps.url);
     expect(wrapper.find('ProductCardBadge').exists()).toBe(true);
     expect(wrapper.find('ProductCardBadge').text()).toEqual(`-${mockProduct.price.discount}%`);

--- a/themes/theme-gmd/themeApi/ProductCard/index.spec.jsx
+++ b/themes/theme-gmd/themeApi/ProductCard/index.spec.jsx
@@ -8,6 +8,8 @@ import mockRenderOptions from '@shopgate/pwa-common/helpers/mocks/mockRenderOpti
 import { mockProductId, mockProduct } from './mock';
 import ProductCard, { ProductCardUnwrapped } from './index';
 
+jest.mock('@shopgate/engage/core/hocs/withWidgetSettings');
+
 /**
  * Creates a state for a mocked store.
  * @param {Object} product A product.

--- a/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemImage/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemImage/__snapshots__/spec.jsx.snap
@@ -18,29 +18,10 @@ exports[`<ItemImage /> should render 1`] = `
       }
     }
   >
-    <ProductImage
+    <Component
       alt="FooBar"
-      animating={true}
-      className={null}
-      forcePlaceholder={false}
-      highestResolutionLoaded={[Function]}
       itemProp="image"
-      ratio={null}
-      resolutions={
-        Array [
-          Object {
-            "blur": 2,
-            "height": 50,
-            "width": 50,
-          },
-          Object {
-            "height": 440,
-            "width": 440,
-          },
-        ]
-      }
       src="http://www.google.com"
-      srcmap={null}
     />
   </Portal>
   <Portal

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -325,10 +325,10 @@
         "label": "Favorites settings: limits, etc"
       }
     },
-    "productImageShadow": {
+    "hideProductImageShadow": {
       "type": "admin",
       "destination": "frontend",
-      "default": true,
+      "default": false,
       "params": {
         "type": "json",
         "label": "Toggle inner shadows of product images"

--- a/themes/theme-ios11/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
@@ -127,68 +127,97 @@ exports[`<ProductCard /> should render as expected 1`] = `
                 onClick={[Function]}
                 role="link"
               >
-                <ProductImage
+                <Component
                   alt="Product Name"
-                  animating={true}
-                  className={null}
-                  forcePlaceholder={false}
-                  highestResolutionLoaded={[Function]}
                   itemProp="image"
-                  ratio={null}
-                  resolutions={
-                    Array [
-                      Object {
-                        "blur": 2,
-                        "height": 50,
-                        "width": 50,
-                      },
-                      Object {
-                        "height": 440,
-                        "width": 440,
-                      },
-                    ]
-                  }
                   src={null}
-                  srcmap={null}
                 >
-                  <div
-                    className="css-y5kkpq"
+                  <ProductImage
+                    alt="Product Name"
+                    animating={true}
+                    className={null}
+                    forcePlaceholder={false}
+                    highestResolutionLoaded={[Function]}
+                    itemProp="image"
+                    ratio={null}
+                    resolutions={
+                      Array [
+                        Object {
+                          "blur": 2,
+                          "height": 50,
+                          "width": 50,
+                        },
+                        Object {
+                          "height": 440,
+                          "width": 440,
+                        },
+                      ]
+                    }
+                    src={null}
+                    srcmap={null}
+                    widgetSettings={
+                      Object {
+                        "mocked": "widgetSetting",
+                      }
+                    }
                   >
-                    <div
-                      className="css-1vq3byi"
-                      data-test-id="placeHolder"
+                    <SurroundPortals
+                      portalName="component.product-image"
+                      portalProps={null}
                     >
-                      <Placeholder
-                        className="css-19rc2oq"
+                      <Portal
+                        name="component.product-image.before"
+                        props={null}
+                      />
+                      <Portal
+                        name="component.product-image"
+                        props={null}
                       >
-                        <Icon
-                          className="css-19rc2oq"
-                          color={null}
-                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                          size="inherit"
-                          viewBox="0 0 24 24"
+                        <div
+                          className="css-y5kkpq css-3hjqnz"
                         >
-                          <svg
-                            className="css-yys9hb css-19rc2oq"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                              }
-                            }
-                            style={
-                              Object {
-                                "fill": null,
-                                "fontSize": "inherit",
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
-                        </Icon>
-                      </Placeholder>
-                    </div>
-                  </div>
-                </ProductImage>
+                          <div
+                            className="css-1vq3byi"
+                            data-test-id="placeHolder"
+                          >
+                            <Placeholder
+                              className="css-19rc2oq"
+                            >
+                              <Icon
+                                className="css-19rc2oq"
+                                color={null}
+                                content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                                size="inherit"
+                                viewBox="0 0 24 24"
+                              >
+                                <svg
+                                  className="css-yys9hb css-19rc2oq"
+                                  dangerouslySetInnerHTML={
+                                    Object {
+                                      "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                                    }
+                                  }
+                                  style={
+                                    Object {
+                                      "fill": null,
+                                      "fontSize": "inherit",
+                                    }
+                                  }
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                />
+                              </Icon>
+                            </Placeholder>
+                          </div>
+                        </div>
+                      </Portal>
+                      <Portal
+                        name="component.product-image.after"
+                        props={null}
+                      />
+                    </SurroundPortals>
+                  </ProductImage>
+                </Component>
                 <ProductCardBadge
                   productId="PR0DUCTID"
                   style={Object {}}

--- a/themes/theme-ios11/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
@@ -61,68 +61,97 @@ exports[`<ProductCardRender /> should not render the discount badge when the is 
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <div
             className={
               Object {
@@ -774,68 +803,97 @@ exports[`<ProductCardRender /> should not render the rating stars when there is 
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <ProductCardBadge
             productId="PR0DUCTID"
             style={Object {}}
@@ -1207,68 +1265,97 @@ exports[`<ProductCardRender /> should render as expected 1`] = `
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <ProductCardBadge
             productId="PR0DUCTID"
             style={Object {}}
@@ -1986,68 +2073,97 @@ exports[`<ProductCardRender /> should render with one row for the product name 1
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <ProductCardBadge
             productId="PR0DUCTID"
             style={Object {}}
@@ -2765,68 +2881,97 @@ exports[`<ProductCardRender /> should render without name 1`] = `
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <ProductCardBadge
             productId="PR0DUCTID"
             style={Object {}}
@@ -3508,68 +3653,97 @@ exports[`<ProductCardRender /> should render without prices 1`] = `
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <div
             className={
               Object {
@@ -4034,68 +4208,97 @@ exports[`<ProductCardRender /> should render without rating 1`] = `
           onClick={[Function]}
           role="link"
         >
-          <ProductImage
+          <Component
             alt="Product Name"
-            animating={true}
-            className={null}
-            forcePlaceholder={false}
-            highestResolutionLoaded={[Function]}
             itemProp="image"
-            ratio={null}
-            resolutions={
-              Array [
-                Object {
-                  "blur": 2,
-                  "height": 50,
-                  "width": 50,
-                },
-                Object {
-                  "height": 440,
-                  "width": 440,
-                },
-              ]
-            }
             src={null}
-            srcmap={null}
           >
-            <div
-              className="css-y5kkpq"
+            <ProductImage
+              alt="Product Name"
+              animating={true}
+              className={null}
+              forcePlaceholder={false}
+              highestResolutionLoaded={[Function]}
+              itemProp="image"
+              ratio={null}
+              resolutions={
+                Array [
+                  Object {
+                    "blur": 2,
+                    "height": 50,
+                    "width": 50,
+                  },
+                  Object {
+                    "height": 440,
+                    "width": 440,
+                  },
+                ]
+              }
+              src={null}
+              srcmap={null}
+              widgetSettings={
+                Object {
+                  "mocked": "widgetSetting",
+                }
+              }
             >
-              <div
-                className="css-1vq3byi"
-                data-test-id="placeHolder"
+              <SurroundPortals
+                portalName="component.product-image"
+                portalProps={null}
               >
-                <Placeholder
-                  className="css-19rc2oq"
+                <Portal
+                  name="component.product-image.before"
+                  props={null}
+                />
+                <Portal
+                  name="component.product-image"
+                  props={null}
                 >
-                  <Icon
-                    className="css-19rc2oq"
-                    color={null}
-                    content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
-                    size="inherit"
-                    viewBox="0 0 24 24"
+                  <div
+                    className="css-y5kkpq css-3hjqnz"
                   >
-                    <svg
-                      className="css-yys9hb css-19rc2oq"
-                      dangerouslySetInnerHTML={
-                        Object {
-                          "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
-                        }
-                      }
-                      style={
-                        Object {
-                          "fill": null,
-                          "fontSize": "inherit",
-                        }
-                      }
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </Icon>
-                </Placeholder>
-              </div>
-            </div>
-          </ProductImage>
+                    <div
+                      className="css-1vq3byi"
+                      data-test-id="placeHolder"
+                    >
+                      <Placeholder
+                        className="css-19rc2oq"
+                      >
+                        <Icon
+                          className="css-19rc2oq"
+                          color={null}
+                          content="<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>"
+                          size="inherit"
+                          viewBox="0 0 24 24"
+                        >
+                          <svg
+                            className="css-yys9hb css-19rc2oq"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "<circle cx=\\"12\\" cy=\\"12\\" r=\\"3.2\\"/><path d=\\"M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z\\"/><path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"/>",
+                              }
+                            }
+                            style={
+                              Object {
+                                "fill": null,
+                                "fontSize": "inherit",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </Icon>
+                      </Placeholder>
+                    </div>
+                  </div>
+                </Portal>
+                <Portal
+                  name="component.product-image.after"
+                  props={null}
+                />
+              </SurroundPortals>
+            </ProductImage>
+          </Component>
           <ProductCardBadge
             productId="PR0DUCTID"
             style={Object {}}

--- a/themes/theme-ios11/themeApi/ProductCard/components/Render/index.spec.jsx
+++ b/themes/theme-ios11/themeApi/ProductCard/components/Render/index.spec.jsx
@@ -7,6 +7,8 @@ import mockRenderOptions from '@shopgate/pwa-common/helpers/mocks/mockRenderOpti
 import { mockProductId, mockProduct } from '../../mock';
 import ProductCardRender from './index';
 
+jest.mock('@shopgate/engage/core/hocs/withWidgetSettings');
+
 jest.mock('@shopgate/engage/product', () => ({
   withPriceCalculation: Component => props => <Component {...props} />,
   MapPriceHint: () => null,
@@ -44,7 +46,7 @@ describe('<ProductCardRender />', () => {
   it('should render as expected', () => {
     const wrapper = renderComponent();
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('Portal').length).toBe(6);
+    expect(wrapper.find('Portal').length).toBe(9);
     expect(wrapper.find('Link').prop('href')).toEqual(defaultProps.url);
     expect(wrapper.find('ProductCardBadge').exists()).toBe(true);
     expect(wrapper.find('ProductCardBadge').text()).toEqual(`-${mockProduct.price.discount}%`);

--- a/themes/theme-ios11/themeApi/ProductCard/index.spec.jsx
+++ b/themes/theme-ios11/themeApi/ProductCard/index.spec.jsx
@@ -8,6 +8,8 @@ import mockRenderOptions from '@shopgate/pwa-common/helpers/mocks/mockRenderOpti
 import { mockProductId, mockProduct } from './mock';
 import ProductCard, { ProductCardUnwrapped } from './index';
 
+jest.mock('@shopgate/engage/core/hocs/withWidgetSettings');
+
 /**
  * Creates a state for a mocked store.
  * @param {Object} product A product.


### PR DESCRIPTION
# Description
This ticket is about to implement the inner shadow setting and Portal for ProductImages into PWA 6.6.0. Since there is now only a single version of the component within the engage package, some refactoring came necessary.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.

