### PR TITLE
Fixed wrapping "goto cart" button label within the iOS theme in pt-PT

### DIFF
--- a/themes/theme-ios11/locale/pt-PT.json
+++ b/themes/theme-ios11/locale/pt-PT.json
@@ -60,7 +60,7 @@
     "tax_disclaimer": "* Incl. IVA mais custos de envio, se aplicável",
     "item_added": "{count, plural, =0 {# nenhum item adicionado} =1 {{count} item adicionado} other {{count} itens adicionados}}",
     "add_to_cart": "Adicionar ao carrinho",
-    "go_to_cart": "Ir para o carrinho",
+    "go_to_cart": "Carrinho",
     "no_more_found": "O item: \"{name}\" não está mais disponível."
   },
   "category": {


### PR DESCRIPTION
# Description
This contains an update for the pt-PT language file. It shortens the label for the "goto cart" button, so that it will not wrap anymore when the PaymentBar animates after the user has added a product to the cart.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
