### PR TITLE
Added portuguese translations to the privacy extension

### DIFF
--- a/extensions/@shopgate-user-privacy/frontend/locale/pt-PT.json
+++ b/extensions/@shopgate-user-privacy/frontend/locale/pt-PT.json
@@ -1,0 +1,8 @@
+{
+  "user": {
+    "delete_account": "Deletar minha conta",
+    "delete_account_success": "Recebemos o seu pedido de eliminação da sua conta.",
+    "delete_account_error": "Ocorreu um erro inesperado. Por favor, tente novamente mais tarde.",
+    "delete_account_confirm": "Pressione Confirmar para excluir todos os dados da conta. Esta operação não pode ser desfeita."
+  }
+}


### PR DESCRIPTION
# Description
This ticket adds missing portuguese translations for the @shopgate/user-privacy extension.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
