### PR TITLE
The `font` property in the theme config has been changed to `typography`

### DIFF
--- a/libraries/common/helpers/config/mock.js
+++ b/libraries/common/helpers/config/mock.js
@@ -23,7 +23,7 @@ const colors = {
 };
 
 export const themeConfig = {
-  font: {
+  typography: {
     family: 'Roboto, Arial, sans-serif',
     rootSize: 16,
     lineHeight: 1.5,

--- a/libraries/common/helpers/config/theme.js
+++ b/libraries/common/helpers/config/theme.js
@@ -33,7 +33,7 @@ export function getThemeConfig(appConfig) {
   const oldTheme = process.env.THEME_CONFIG || defaultConfig;
 
   return {
-    font: theme.font,
+    typography: theme.typography,
     colors: {
       ...theme.colors,
       ...colors,

--- a/libraries/common/helpers/config/theme.js
+++ b/libraries/common/helpers/config/theme.js
@@ -5,7 +5,7 @@ import { themeConfig } from './mock';
  * @type {Object}
  */
 const defaultConfig = {
-  font: {},
+  typography: {},
   colors: {},
   variables: {},
 };

--- a/libraries/common/styles/reset/root.js
+++ b/libraries/common/styles/reset/root.js
@@ -1,7 +1,7 @@
 import { css } from 'glamor';
 import { themeConfig } from '../../helpers/config';
 
-const { font } = themeConfig;
+const { typography } = themeConfig;
 
 css.global('*, *:before, *:after', {
   boxSizing: 'border-box',
@@ -23,7 +23,7 @@ css.global('html', {
 });
 
 css.global('body', {
-  font: `${font.rootSize}px/${font.lineHeight} ${font.family}`,
+  font: `${typography.rootSize}px/${typography.lineHeight} ${typography.family}`,
   overflow: 'auto',
   margin: 0,
   WebkitOverflowScrolling: 'touch',

--- a/libraries/ui-material/BaseDialog/style.js
+++ b/libraries/ui-material/BaseDialog/style.js
@@ -20,7 +20,7 @@ const content = css({
 
 const title = css({
   fontSize: '1.25em',
-  lineHeight: themeConfig.font.lineHeight,
+  lineHeight: themeConfig.typography.lineHeight,
   fontWeight: 500,
   paddingBottom: themeConfig.variables.gap.small,
   marginTop: '-.25em',

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -199,7 +199,7 @@
         "label": "The theme configuration for Engage GMD theme."
       },
       "default": {
-        "font": {
+        "typography": {
           "family": "Roboto, Arial, sans-serif",
           "rootSize": 16,
           "lineHeight": 1.5

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -190,7 +190,7 @@
         "label": "The theme configuration for Engage GMD theme."
       },
       "default": {
-        "font": {
+        "typography": {
           "family": "system, -apple-system, \"SF Pro Display\", \"Helvetica Neue\", \"Lucida Grande\"",
           "rootSize": 17,
           "lineHeight": 1.43


### PR DESCRIPTION
# Description

To be prepared for future implementations, the `font` property in the theme config has been renamed tp `typography`.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
