### PR TITLE
Fixed incorrect price display on the product detail page when options are involved.

### DIFF
--- a/libraries/commerce/product/selectors/options.js
+++ b/libraries/commerce/product/selectors/options.js
@@ -65,7 +65,9 @@ const getOptionItems = createSelector(
         label: value.label,
         currency,
         value: value.id,
-        price: value.unitPriceModifier,
+        // Price modifier and difference are equal, when nothing is selected.
+        priceModifier: value.unitPriceModifier,
+        priceDifference: value.unitPriceModifier,
       };
     }
 
@@ -77,7 +79,10 @@ const getOptionItems = createSelector(
       label: value.label,
       currency,
       value: value.id,
-      price: (value.unitPriceModifier - siblingPrice),
+      // Price which affects the unit price.
+      priceModifier: value.unitPriceModifier,
+      // Difference to the currently selected sibling.
+      priceDifference: (value.unitPriceModifier - siblingPrice),
     };
   })
 );

--- a/libraries/commerce/product/selectors/options.js
+++ b/libraries/commerce/product/selectors/options.js
@@ -66,7 +66,7 @@ const getOptionItems = createSelector(
         currency,
         value: value.id,
         // Price modifier and difference are equal, when nothing is selected.
-        priceModifier: value.unitPriceModifier,
+        price: value.unitPriceModifier,
         priceDifference: value.unitPriceModifier,
       };
     }
@@ -80,7 +80,7 @@ const getOptionItems = createSelector(
       currency,
       value: value.id,
       // Price which affects the unit price.
-      priceModifier: value.unitPriceModifier,
+      price: value.unitPriceModifier,
       // Difference to the currently selected sibling.
       priceDifference: (value.unitPriceModifier - siblingPrice),
     };

--- a/libraries/commerce/product/selectors/price.spec.js
+++ b/libraries/commerce/product/selectors/price.spec.js
@@ -136,11 +136,11 @@ describe('Product.Price selectors', () => {
 
       // Peak into the calculated relative additional price differences.
       // Price modifiers stay constant, because they're absolute.
-      // Modifiers and difference is equal when nothing is selected, yet
+      // Price modifier and difference is equal when nothing is selected, yet
       const availableOptions = getProductOptions(state, props);
-      expect(availableOptions[0].items[0].priceModifier).toBe(5);
+      expect(availableOptions[0].items[0].price).toBe(5);
       expect(availableOptions[0].items[0].priceDifference).toBe(5);
-      expect(availableOptions[0].items[1].priceModifier).toBe(4);
+      expect(availableOptions[0].items[1].price).toBe(4);
       expect(availableOptions[0].items[1].priceDifference).toBe(4);
     });
 
@@ -162,10 +162,11 @@ describe('Product.Price selectors', () => {
 
       // Peak into the calculated relative additional price differences.
       // Price modifiers stay constant, because they're absolute.
+      // Price modifiers stay constant, because they're absolute.
       const availableOptions = getProductOptions(state, props);
-      expect(availableOptions[0].items[0].priceModifier).toBe(5);
+      expect(availableOptions[0].items[0].price).toBe(5);
       expect(availableOptions[0].items[0].priceDifference).toBe(0);
-      expect(availableOptions[0].items[1].priceModifier).toBe(4);
+      expect(availableOptions[0].items[1].price).toBe(4);
       expect(availableOptions[0].items[1].priceDifference).toBe(-1);
       expect(isFullPriceAvailable(state, props)).toBe(true);
     });

--- a/libraries/commerce/product/selectors/price.spec.js
+++ b/libraries/commerce/product/selectors/price.spec.js
@@ -134,10 +134,14 @@ describe('Product.Price selectors', () => {
       // Product options are now available.
       expect(getRawProductOptions(state, props).length).toBe(1);
 
-      // Peak into the calculated relative additional prices.
+      // Peak into the calculated relative additional price differences.
+      // Price modifiers stay constant, because they're absolute.
+      // Modifiers and difference is equal when nothing is selected, yet
       const availableOptions = getProductOptions(state, props);
-      expect(availableOptions[0].items[0].price).toBe(5);
-      expect(availableOptions[0].items[1].price).toBe(4);
+      expect(availableOptions[0].items[0].priceModifier).toBe(5);
+      expect(availableOptions[0].items[0].priceDifference).toBe(5);
+      expect(availableOptions[0].items[1].priceModifier).toBe(4);
+      expect(availableOptions[0].items[1].priceDifference).toBe(4);
     });
 
     it('Step 3: Select the option', () => {
@@ -156,10 +160,13 @@ describe('Product.Price selectors', () => {
       expect(getProductPriceAddition(state, props)).toBe(5);
       expect(getProductTotalPrice(state, props)).toBe(15.52);
 
-      // Peak into the calculated relative additional prices.
+      // Peak into the calculated relative additional price differences.
+      // Price modifiers stay constant, because they're absolute.
       const availableOptions = getProductOptions(state, props);
-      expect(availableOptions[0].items[0].price).toBe(0);
-      expect(availableOptions[0].items[1].price).toBe(-1);
+      expect(availableOptions[0].items[0].priceModifier).toBe(5);
+      expect(availableOptions[0].items[0].priceDifference).toBe(0);
+      expect(availableOptions[0].items[1].priceModifier).toBe(4);
+      expect(availableOptions[0].items[1].priceDifference).toBe(-1);
       expect(isFullPriceAvailable(state, props)).toBe(true);
     });
 

--- a/themes/theme-gmd/pages/Product/components/Options/components/Option/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Options/components/Option/index.jsx
@@ -25,12 +25,16 @@ const Option = ({
           items={items.map(item => ({
             ...item,
             rightComponent: (
-              <PriceDifference className={styles} currency={currency} difference={item.price} />
+              <PriceDifference
+                className={styles}
+                currency={currency}
+                difference={item.priceDifference}
+              />
             ),
           }))}
           placeholder={<I18n.Text string="product.pick_an_attribute" params={[label]} />}
           value={value}
-          onChange={val => onChange(id, val, items.find(item => item.value === val).price)}
+          onChange={val => onChange(id, val, items.find(item => item.value === val).priceModifier)}
         />
       </div>
     )}

--- a/themes/theme-gmd/pages/Product/components/Options/components/Option/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Options/components/Option/index.jsx
@@ -34,7 +34,7 @@ const Option = ({
           }))}
           placeholder={<I18n.Text string="product.pick_an_attribute" params={[label]} />}
           value={value}
-          onChange={val => onChange(id, val, items.find(item => item.value === val).priceModifier)}
+          onChange={val => onChange(id, val, items.find(item => item.value === val).price)}
         />
       </div>
     )}

--- a/themes/theme-ios11/pages/Product/components/Options/components/Option/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Options/components/Option/index.jsx
@@ -24,12 +24,15 @@ const Option = ({
           items={items.map(item => ({
             ...item,
             rightComponent: (
-              <PriceDifference currency={currency} difference={item.price} />
+              <PriceDifference
+                currency={currency}
+                difference={item.priceDifference}
+              />
             ),
           }))}
           placeholder={<I18n.Text string="product.pick_an_attribute" params={[label]} />}
           value={value}
-          onChange={val => onChange(id, val, items.find(item => item.value === val).price)}
+          onChange={val => onChange(id, val, items.find(item => item.value === val).priceModifier)}
         />
       </div>
     )}

--- a/themes/theme-ios11/pages/Product/components/Options/components/Option/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Options/components/Option/index.jsx
@@ -32,7 +32,7 @@ const Option = ({
           }))}
           placeholder={<I18n.Text string="product.pick_an_attribute" params={[label]} />}
           value={value}
-          onChange={val => onChange(id, val, items.find(item => item.value === val).priceModifier)}
+          onChange={val => onChange(id, val, items.find(item => item.value === val).price)}
         />
       </div>
     )}


### PR DESCRIPTION
# Description

Fixed incorrect price display on the PDP when options are involved.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Open PDP of a product which has options. Switch to an option with a difference price and than switch back to the previous option. The price should change back to what it was before changing the option for the first time.
