### PR TITLE
Make modal window title translatable with parameters

### DIFF
--- a/libraries/ui-ios/BaseDialog/index.jsx
+++ b/libraries/ui-ios/BaseDialog/index.jsx
@@ -7,12 +7,11 @@ import styles from './style';
 
 /**
  * This component renders a basic dialog in Google Material Design.
- * @param {Object} props The component properties.
- * @param {Object} props.children The component children to render in the dialog.
- * @param {Array} props.actions The dialog actions.
- * @param {string} props.actions.label The label of the action.
- * @param {Function} props.actions.action The callback to invoke when the action is triggered.
- * @param {string} props.title The title of the dialog.
+ * @param {Object} children The component children to render in the dialog.
+ * @param {Object[]} actions The dialog actions.
+ * @param {string} actions.label The label of the action.
+ * @param {Function} actions.action The callback to invoke when the action is triggered.
+ * @param {string|ReactElement} title The title of the dialog.
  * @return {JSX} The rendered dialog.
  */
 const BasicDialog = ({ children, actions, title }) => (
@@ -21,7 +20,11 @@ const BasicDialog = ({ children, actions, title }) => (
       {title && ( // Render the title if required.
         <div className={styles.title}>
           <Ellipsis rows={3}>
-            <I18n.Text string={title} />
+            {
+              typeof title === 'string'
+              ? <I18n.Text string={title} />
+              : title
+            }
           </Ellipsis>
         </div>
       )}
@@ -53,7 +56,10 @@ BasicDialog.propTypes = {
     action: PropTypes.func.isRequired,
   })),
   children: PropTypes.node,
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
 };
 
 BasicDialog.defaultProps = {

--- a/libraries/ui-ios/BaseDialog/spec.jsx
+++ b/libraries/ui-ios/BaseDialog/spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Button from '@shopgate/pwa-ui-shared/Button';
-import BasicDialog from './';
+import BasicDialog from './index';
 
 describe('<BasicDialog />', () => {
   const props = {
@@ -43,5 +43,10 @@ describe('<BasicDialog />', () => {
     expect(props.actions[0].action).not.toBeCalled();
     expect(props.actions[1].action).toBeCalled();
     expect(props.actions[2].action).not.toBeCalled();
+  });
+
+  it('should render with node as a title', () => {
+    const wrapper = shallow(<BasicDialog title={<strong>My Title</strong>} />);
+    expect(wrapper.find('strong').text()).toEqual('My Title');
   });
 });

--- a/libraries/ui-material/BaseDialog/index.jsx
+++ b/libraries/ui-material/BaseDialog/index.jsx
@@ -7,12 +7,11 @@ import styles from './style';
 
 /**
  * This component renders a basic dialog in Google Material Design.
- * @param {Object} props The component properties.
- * @param {Object} props.children The component children to render in the dialog.
- * @param {Array} props.actions The dialog actions.
- * @param {string} props.actions.label The label of the action.
- * @param {Function} props.actions.action The callback to invoke when the action is triggered.
- * @param {string} props.title The title of the dialog.
+ * @param {Object} children The component children to render in the dialog.
+ * @param {Object[]} actions The dialog actions.
+ * @param {string} actions.label The label of the action.
+ * @param {Function} actions.action The callback to invoke when the action is triggered.
+ * @param {string|ReactElement} title The title of the dialog.
  * @return {JSX} The rendered dialog.
  */
 const BasicDialog = ({ children, actions, title }) => (
@@ -21,7 +20,11 @@ const BasicDialog = ({ children, actions, title }) => (
       {title && ( // Render the title if required.
         <div className={styles.title}>
           <Ellipsis rows={3}>
-            <I18n.Text string={title} />
+            {
+              typeof title === 'string'
+              ? <I18n.Text string={title} />
+              : title
+            }
           </Ellipsis>
         </div>
       )}
@@ -49,7 +52,10 @@ BasicDialog.propTypes = {
     action: PropTypes.func.isRequired,
   })),
   children: PropTypes.node,
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
 };
 
 BasicDialog.defaultProps = {

--- a/libraries/ui-material/BaseDialog/spec.jsx
+++ b/libraries/ui-material/BaseDialog/spec.jsx
@@ -46,4 +46,9 @@ describe('<BasicDialog />', () => {
     expect(props.actions[1].action).toBeCalled();
     expect(props.actions[2].action).not.toBeCalled();
   });
+
+  it('should render with node as a title', () => {
+    const wrapper = shallow(<BasicDialog title={<strong>My Title</strong>} />);
+    expect(wrapper.find('strong').text()).toEqual('My Title');
+  });
 });

--- a/libraries/ui-shared/Dialog/components/TextMessageDialog/index.jsx
+++ b/libraries/ui-shared/Dialog/components/TextMessageDialog/index.jsx
@@ -21,11 +21,11 @@ TextMessageDialog.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   message: PropTypes.string.isRequired,
   params: I18n.Text.propTypes.params,
-  title: PropTypes.string,
+  title: BasicDialog.propTypes.title,
 };
 
 TextMessageDialog.defaultProps = {
-  title: null,
+  title: BasicDialog.defaultProps.title,
   params: I18n.Text.defaultProps.params,
 };
 

--- a/libraries/ui-shared/Dialog/components/TextMessageDialog/spec.jsx
+++ b/libraries/ui-shared/Dialog/components/TextMessageDialog/spec.jsx
@@ -45,4 +45,17 @@ describe('<TextMessageDialog />', () => {
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.html()).toMatch(actions[0].label);
   });
+
+  it('should pass title through', () => {
+    const customTitle = <div>Title</div>;
+    const wrapper = shallow((
+      <TextMessageDialog
+        title={customTitle}
+        message={message}
+        params={{}}
+        actions={[]}
+      />
+    ));
+    expect(wrapper.find('BasicDialog').prop('title')).toEqual(customTitle);
+  });
 });

--- a/libraries/ui-shared/Dialog/components/VariantSelectModal/index.jsx
+++ b/libraries/ui-shared/Dialog/components/VariantSelectModal/index.jsx
@@ -72,14 +72,14 @@ VariantSelectModal.propTypes = {
   message: PropTypes.string.isRequired,
   navigate: PropTypes.func.isRequired,
   params: PropTypes.shape(),
-  title: PropTypes.string,
+  title: BasicDialog.propTypes.title,
 };
 
 VariantSelectModal.defaultProps = {
   params: {
     productId: null,
   },
-  title: null,
+  title: BasicDialog.defaultProps.title,
 };
 
 export default connect(VariantSelectModal);

--- a/libraries/ui-shared/Dialog/index.jsx
+++ b/libraries/ui-shared/Dialog/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Modal from '@shopgate/pwa-common/components/Modal';
 import Backdrop from '@shopgate/pwa-common/components/Backdrop';
 import { MODAL_PIPELINE_ERROR } from '@shopgate/pwa-common/constants/ModalTypes';
+import I18n from '@shopgate/pwa-common/components/I18n';
 import {
   DIALOG_TEXT_MESSAGE,
   MODAL_VARIANT_SELECT,
@@ -13,6 +14,12 @@ import PipelineErrorDialog from './components/PipelineErrorDialog';
 import TextMessageDialog from './components/TextMessageDialog';
 import BasicDialog from './components/BasicDialog';
 import VariantSelectModal from './components/VariantSelectModal';
+
+const dialogTypes = {
+  [DIALOG_TEXT_MESSAGE]: TextMessageDialog,
+  [MODAL_PIPELINE_ERROR]: PipelineErrorDialog,
+  [MODAL_VARIANT_SELECT]: VariantSelectModal,
+};
 
 /**
  * The main component for rendering dialogs.
@@ -25,7 +32,7 @@ const Dialog = ({ modal, onConfirm, onDismiss }) => {
   // Assemble the actions.
   const actions = [];
   const {
-    confirm, dismiss, title, params, message, type,
+    confirm, dismiss, title, titleParams, message, params, type,
   } = modal;
 
   // Push dismiss action first so the button is rendered first
@@ -53,41 +60,32 @@ const Dialog = ({ modal, onConfirm, onDismiss }) => {
     dialogType = DIALOG_TEXT_MESSAGE;
   }
 
-  switch (dialogType) {
-    case MODAL_PIPELINE_ERROR:
-      return (
-        <Modal>
-          <Backdrop isVisible level={0} />
-          <PipelineErrorDialog actions={actions} title={title} params={params} message={message} />
-        </Modal>
-      );
-    case DIALOG_TEXT_MESSAGE:
-      return (
-        <Modal>
-          <Backdrop isVisible level={0} />
-          <TextMessageDialog actions={actions} title={title} params={params} message={message} />
-        </Modal>
-      );
-    case MODAL_VARIANT_SELECT:
-      return (
-        <Modal>
-          <Backdrop isVisible level={0} />
-          <VariantSelectModal actions={actions} title={title} params={params} message={message} />
-        </Modal>
-      );
-    default:
-      return (
-        <Modal>
-          <Backdrop isVisible level={0} />
-          <BasicDialog actions={actions} title={title} params={params} />
-        </Modal>
-      );
+  let dialogTitle = title;
+  if (titleParams) {
+    dialogTitle = <I18n.Text string={title} params={titleParams} />;
   }
+
+  const dialogProps = {
+    actions,
+    title: dialogTitle,
+    params,
+    message: message || undefined,
+  };
+
+  const DialogComponent = dialogTypes[dialogType] || BasicDialog;
+
+  return (
+    <Modal>
+      <Backdrop isVisible level={0} />
+      <DialogComponent {...dialogProps} />
+    </Modal>
+  );
 };
 
 Dialog.propTypes = {
   modal: PropTypes.shape({
-    title: PropTypes.string,
+    title: BasicDialog.propTypes.title,
+    titleParams: PropTypes.shape(),
     confirm: PropTypes.string,
     dismiss: PropTypes.string,
     message: PropTypes.string,

--- a/libraries/ui-shared/Dialog/spec.jsx
+++ b/libraries/ui-shared/Dialog/spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, ReactWrapper } from 'enzyme';
 import { MODAL_PIPELINE_ERROR } from '@shopgate/pwa-common/constants/ModalTypes';
 import { MODAL_VARIANT_SELECT } from './constants';
 import Dialog from './index';
@@ -64,5 +64,19 @@ describe('<Dialog />', () => {
 
     expect(wrapper.find('DefaultDialog').length).toBe(0);
     expect(wrapper.find('VariantSelectModal').length).toBe(1);
+  });
+
+  it('should convert title into translatable element', () => {
+    const title = 'translate.me';
+    const titleParams = {
+      foo: 'bar',
+    };
+
+    // eslint-disable-next-line extra-rules/no-single-line-objects
+    const wrapper = shallow(<Dialog modal={{ title, titleParams }} />);
+    const i18n = new ReactWrapper(wrapper.find('BasicDialog').prop('title'));
+
+    expect(i18n.prop('string')).toEqual(title);
+    expect(i18n.prop('params')).toEqual(titleParams);
   });
 });


### PR DESCRIPTION
# Description

Make modal window title translatable with parameters.

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [X] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
