### PR TITLE
Changed shopify-webcheckout url logic to accept a full domain over the alias for the web-login.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## [v6.5.2](https://github.com/shopgate/pwa/compare/...v6.5.2) (2019-06-24)
+## [v6.5.2](https://github.com/shopgate/pwa/compare/v6.5.1...v6.5.2) (2019-06-24)
 
 #### :bug: Bug Fix
 * [#708](https://github.com/shopgate/pwa/pull/708) Portuguese pt-PT locale for user privacy labels ([@alexbridge](https://github.com/alexbridge))
 
 
-## [v6.5.1](https://github.com/shopgate/pwa/compare/...v6.5.1) (2019-06-13)
+## [v6.5.1](https://github.com/shopgate/pwa/compare/v6.5.0...v6.5.1) (2019-06-13)
 
 #### :rocket: Enhancement
 * [#679](https://github.com/shopgate/pwa/pull/679) Added portuguese translations to the privacy extension ([@fkloes](https://github.com/fkloes))

--- a/libraries/webcheckout/selectors/index.js
+++ b/libraries/webcheckout/selectors/index.js
@@ -13,10 +13,23 @@ export const hasShopifyCheckout = () => appConfig.webCheckoutShopify !== null;
 export const getShopifyCheckout = () => appConfig.webCheckoutShopify;
 
 /**
- * Returns the aliased Shopify URL.
+ * Returns the Shopify URL based on the given domain or alias.
  * @returns {string}
  */
-export const getShopifyUrl = () => `https://${getShopifyCheckout().alias}.myshopify.com`;
+export const getShopifyUrl = () => {
+  // Prioritize the "domain" property over alias, if it exists.
+  let url = typeof getShopifyCheckout().domain === 'string'
+    ? getShopifyCheckout().domain.replace(/\/+$/g, '')
+    : `https://${getShopifyCheckout().alias}.myshopify.com`;
+
+  // Add https protocol if none is set, yet.
+  if (!url.match(/^https:\/\/.*/g) && !url.match(/^http:\/\/.*/g)) {
+    // Cut out "://" or "//" from the beginning. E.g.: "//www.myshop.com" or "://www.myshop.com"
+    url = `https://${url.replace(/^[:/]*/g, '')}`;
+  }
+
+  return url;
+};
 
 /**
  * Checks if a configuration for Shopify is available

--- a/themes/theme-gmd/CHANGELOG.md
+++ b/themes/theme-gmd/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## [v6.5.2](https://github.com/shopgate/pwa/compare/...v6.5.2) (2019-06-24)
+## [v6.5.2](https://github.com/shopgate/pwa/compare/v6.5.1...v6.5.2) (2019-06-24)
 
 #### :bug: Bug Fix
 * [#708](https://github.com/shopgate/pwa/pull/708) Portuguese pt-PT locale for user privacy labels ([@alexbridge](https://github.com/alexbridge))
 
 
-## [v6.5.1](https://github.com/shopgate/pwa/compare/...v6.5.1) (2019-06-13)
+## [v6.5.1](https://github.com/shopgate/pwa/compare/v6.5.0...v6.5.1) (2019-06-13)
 
 #### :rocket: Enhancement
 * [#679](https://github.com/shopgate/pwa/pull/679) Added portuguese translations to the privacy extension ([@fkloes](https://github.com/fkloes))

--- a/themes/theme-ios11/CHANGELOG.md
+++ b/themes/theme-ios11/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## [v6.5.2](https://github.com/shopgate/pwa/compare/...v6.5.2) (2019-06-24)
+## [v6.5.2](https://github.com/shopgate/pwa/compare/v6.5.1...v6.5.2) (2019-06-24)
 
 #### :bug: Bug Fix
 * [#708](https://github.com/shopgate/pwa/pull/708) Portuguese pt-PT locale for user privacy labels ([@alexbridge](https://github.com/alexbridge))
 
 
-## [v6.5.1](https://github.com/shopgate/pwa/compare/...v6.5.1) (2019-06-13)
+## [v6.5.1](https://github.com/shopgate/pwa/compare/v6.5.0...v6.5.1) (2019-06-13)
 
 #### :rocket: Enhancement
 * [#679](https://github.com/shopgate/pwa/pull/679) Added portuguese translations to the privacy extension ([@fkloes](https://github.com/fkloes))


### PR DESCRIPTION
# Description

Changed shopify-webcheckout url logic to accept a full domain over the alias for the web-login.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

See ticket comments for test instructions.