### PR TITLE
Changed approach to inject safe aria insets from glamor to plain JS

### DIFF
--- a/themes/theme-gmd/components/Viewport/style.js
+++ b/themes/theme-gmd/components/Viewport/style.js
@@ -39,7 +39,18 @@ export const updatePageInsets = (pageInsets) => {
    * determine the appropriate value for the css variables which can be used in the Engage css
    * when insets need to be considered.
    */
-  css.insert(`
+
+  const id = 'safe-area-insets';
+  let styleBlock = document.querySelector(`#${id}`);
+
+  if (!styleBlock) {
+    styleBlock = document.createElement('style');
+    styleBlock.setAttribute('type', 'text/css');
+    styleBlock.setAttribute('id', id);
+    document.querySelector('head').appendChild(styleBlock);
+  }
+
+  styleBlock.innerHTML = `
     @supports not (padding: max(0px)) {
       :root {
         --safe-area-inset-top: ${safeAreaInsetTop}px;
@@ -53,7 +64,7 @@ export const updatePageInsets = (pageInsets) => {
         --safe-area-inset-bottom: max(${safeAreaInsetBottom}px, env(safe-area-inset-bottom));
       }
     }
-  `);
+  `;
 };
 
 /**

--- a/themes/theme-ios11/components/Viewport/style.js
+++ b/themes/theme-ios11/components/Viewport/style.js
@@ -40,7 +40,18 @@ export const updatePageInsets = (pageInsets) => {
    * determine the appropriate value for the css variables which can be used in the Engage css
    * when insets need to be considered.
    */
-  css.insert(`
+
+  const id = 'safe-area-insets';
+  let styleBlock = document.querySelector(`#${id}`);
+
+  if (!styleBlock) {
+    styleBlock = document.createElement('style');
+    styleBlock.setAttribute('type', 'text/css');
+    styleBlock.setAttribute('id', id);
+    document.querySelector('head').appendChild(styleBlock);
+  }
+
+  styleBlock.innerHTML = `
     @supports not (padding: max(0px)) {
       :root {
         --safe-area-inset-top: ${safeAreaInsetTop}px;
@@ -54,7 +65,7 @@ export const updatePageInsets = (pageInsets) => {
         --safe-area-inset-bottom: max(${safeAreaInsetBottom}px, env(safe-area-inset-bottom));
       }
     }
-  `);
+  `;
 };
 
 /**


### PR DESCRIPTION
# Description

This change is about fixing an issue when using the safe area insets css variables. Before there was an approach via glamor, where the required @supports declaration were injected with css.insert(). But this didn't seem to work inside of sandbox environments.

Now the css is injected via plain JS.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Within the development environment everything worked as expected. But within sandbox shops the necessary style block was not injected. There is a PWA 6.7.0-alpha.3 version available, which was created from this branch. It's already deployed on sandbox shop_31590.
