### PR TITLE
Onload command is independent of clientInformation

### DIFF
--- a/libraries/core/commands/onload.js
+++ b/libraries/core/commands/onload.js
@@ -10,7 +10,7 @@ export default function onload() {
     return;
   }
 
-  const command = new AppCommand();
+  const command = new AppCommand(true, false);
 
   command
     .setCommandName('onload')


### PR DESCRIPTION
# Description

Onload command is not independent of clientInformation data, which makes the command to actually be sent during the app start. With that change app doesn't wait for a fallback "on load" event (window.onload) in order to consider the web view being loaded.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please refer to internal ticket PWA-2042.
