### PR TITLE
Start page renders immediately when React is ready.

### DIFF
--- a/themes/theme-gmd/pages/StartPage/index.jsx
+++ b/themes/theme-gmd/pages/StartPage/index.jsx
@@ -1,44 +1,15 @@
-import React, { Component } from 'react';
+import React from 'react';
 import View from 'Components/View';
 import { PAGE_ID_INDEX } from '@shopgate/pwa-common/constants/PageIDs';
 import PageContent from '../Page/components/Content';
 
-let windowLoaded = false;
-
 /**
  * @returns {JSX}
  */
-class StartPage extends Component {
-  state = { content: windowLoaded };
-
-  /**
-   * Component did mount callback
-   */
-  componentDidMount() {
-    if (!windowLoaded) {
-      window.addEventListener('load', this.onWindowLoad);
-    }
-  }
-
-  /**
-   * Listener for window.load event
-   */
-  onWindowLoad = () => {
-    // With small timeout to let window commit loaded state
-    setTimeout(() => this.setState({ content: true }), 50);
-    windowLoaded = true;
-  }
-
-  /**
-   * @returns {JSX}
-   */
-  render() {
-    return (
-      <View>
-        {this.state.content && <PageContent pageId={PAGE_ID_INDEX} />}
-      </View>
-    );
-  }
-}
+const StartPage = () => (
+  <View>
+    <PageContent pageId={PAGE_ID_INDEX} />
+  </View>
+);
 
 export default StartPage;

--- a/themes/theme-ios11/pages/StartPage/index.jsx
+++ b/themes/theme-ios11/pages/StartPage/index.jsx
@@ -1,44 +1,15 @@
-import React, { Component } from 'react';
+import React from 'react';
 import View from 'Components/View';
 import { PAGE_ID_INDEX } from '@shopgate/pwa-common/constants/PageIDs';
 import PageContent from '../Page/components/Content';
 
-let windowLoaded = false;
-
 /**
  * @returns {JSX}
  */
-class StartPage extends Component {
-  state = { content: windowLoaded };
-
-  /**
-   * Component did mount callback
-   */
-  componentDidMount() {
-    if (!windowLoaded) {
-      window.addEventListener('load', this.onWindowLoad);
-    }
-  }
-
-  /**
-   * Listener for window.load event
-   */
-  onWindowLoad = () => {
-    // With small timeout to let window commit loaded state
-    setTimeout(() => this.setState({ content: true }), 50);
-    windowLoaded = true;
-  }
-
-  /**
-   * @returns {JSX}
-   */
-  render() {
-    return (
-      <View>
-        {this.state.content && <PageContent pageId={PAGE_ID_INDEX} />}
-      </View>
-    );
-  }
-}
+const StartPage = () => (
+  <View>
+    <PageContent pageId={PAGE_ID_INDEX} />
+  </View>
+);
 
 export default StartPage;


### PR DESCRIPTION
# Description

Start page doesn't wait for `window.onload` event in order to start rendering its content. With previous fix for the `onload` command it's not needed and may impair user experience when there is long running external resource fetching during page loading process.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please refer to internal ticket PWA-2042.
