### PR TITLE
Fix displaying unit price on product details page for product without variants

### DIFF
--- a/themes/theme-gmd/pages/Product/components/Header/components/Price/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Price/__snapshots__/spec.jsx.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Price /> should not pass unitPriceMin for non variants 1`] = `
+<PlaceholderLabel
+  className="css-q720h0"
+  ready={true}
+  style={null}
+>
+  <Price
+    className="css-1051jlf"
+    currency="USD"
+    discounted={false}
+    fractions={true}
+    taxDisclaimer={true}
+    unitPrice={90.5}
+    unitPriceMin={0}
+  />
+</PlaceholderLabel>
+`;
+
+exports[`<Price /> should pass unitPriceMin for variants 1`] = `
+<PlaceholderLabel
+  className="css-q720h0"
+  ready={true}
+  style={null}
+>
+  <Price
+    className="css-1051jlf"
+    currency="USD"
+    discounted={false}
+    fractions={true}
+    taxDisclaimer={true}
+    unitPrice={90.5}
+    unitPriceMin={80.5}
+  />
+</PlaceholderLabel>
+`;
+
+exports[`<Price /> should render portals 1`] = `
+<Fragment>
+  <Portal
+    name="product.price.before"
+    props={null}
+  />
+  <Portal
+    name="product.price"
+    props={
+      Object {
+        "price": Object {
+          "currency": "USD",
+          "discount": 0,
+          "unitPrice": 90.5,
+          "unitPriceMin": 80.5,
+        },
+      }
+    }
+  >
+    <Consumer>
+      <Component />
+    </Consumer>
+  </Portal>
+  <Portal
+    name="product.price.after"
+    props={null}
+  />
+</Fragment>
+`;

--- a/themes/theme-gmd/pages/Product/components/Header/components/Price/connector.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Price/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { getProductPriceData } from '@shopgate/pwa-common-commerce/product';
+import { getProductPriceData, hasProductVariants } from '@shopgate/pwa-common-commerce/product';
 
 /**
  * Maps the contents of the state to the component props.
@@ -9,6 +9,7 @@ import { getProductPriceData } from '@shopgate/pwa-common-commerce/product';
  */
 const mapStateToProps = (state, props) => ({
   price: getProductPriceData(state, props),
+  hasProductVariants: hasProductVariants(state, props),
 });
 
 /**

--- a/themes/theme-gmd/pages/Product/components/Header/components/Price/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Price/index.jsx
@@ -35,7 +35,7 @@ const getTotalPrice = (price, additions) => {
  * @param {Object} props The component props.
  * @return {JSX}
  */
-const Price = ({ price }) => (
+const Price = ({ price, hasProductVariants }) => (
   <Fragment>
     <Portal name={PRODUCT_PRICE_BEFORE} />
     <Portal name={PRODUCT_PRICE} props={{ price }}>
@@ -49,7 +49,7 @@ const Price = ({ price }) => (
                 discounted={!!price.discount}
                 taxDisclaimer
                 unitPrice={getTotalPrice(price.unitPrice, optionsPrices)}
-                unitPriceMin={!optionsPrices ? price.unitPriceMin : 0}
+                unitPriceMin={hasProductVariants ? price.unitPriceMin : 0}
               />
             )}
           </PlaceholderLabel>
@@ -61,10 +61,12 @@ const Price = ({ price }) => (
 );
 
 Price.propTypes = {
+  hasProductVariants: PropTypes.bool,
   price: PropTypes.shape(),
 };
 
 Price.defaultProps = {
+  hasProductVariants: false,
   price: null,
 };
 

--- a/themes/theme-gmd/pages/Product/components/Header/components/Price/spec.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Price/spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Price from './index';
+
+jest.mock('../../../../context', () => ({
+  ProductContext: {
+    Consumer: ({ children }) => children({}),
+  },
+}));
+jest.mock('./connector', () => cmp => cmp);
+
+describe('<Price />', () => {
+  const price = {
+    unitPrice: 90.5,
+    unitPriceMin: 80.5,
+    discount: 0,
+    currency: 'USD',
+  };
+
+  it('should render portals', () => {
+    const wrapper = shallow(<Price price={price} hasProductVariants />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should pass unitPriceMin for variants', () => {
+    const wrapper = shallow(<Price price={price} hasProductVariants />)
+      .find('Consumer').dive();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should not pass unitPriceMin for non variants', () => {
+    const wrapper = shallow(<Price price={price} hasProductVariants={false} />)
+      .find('Consumer').dive();
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+

--- a/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import pure from 'recompose/pure';
+import { MapPriceHint, OrderQuantityHint, EffectivityDates } from '@shopgate/engage/product';
 import Grid from '@shopgate/pwa-common/components/Grid';
 import Portal from '@shopgate/pwa-common/components/Portal';
 import {
@@ -10,7 +11,6 @@ import {
   PRODUCT_INFO_ROW1,
   PRODUCT_INFO_ROW2,
 } from '@shopgate/pwa-common-commerce/product/constants/Portals';
-import { MapPriceHint, OrderQuantityHint, EffectivityDates } from '@shopgate/engage/product';
 import Manufacturer from '../Manufacturer';
 import Shipping from '../Shipping';
 import Availability from '../Availability';

--- a/themes/theme-gmd/pages/Product/components/Header/components/Tiers/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Tiers/__snapshots__/spec.jsx.snap
@@ -1,35 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tiers /> Rendering Rendering with data should render tier prices when tier prices are available 1`] = `
-<Tiers
-  price={
-    Object {
-      "currency": "USD",
-      "tiers": Array [
-        Object {
-          "from": 1,
-          "to": 10,
-          "unitPrice": 99.99,
-        },
-        Object {
-          "from": 11,
-          "to": 9999,
-          "unitPrice": 80,
-        },
-      ],
-    }
-  }
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
->
+exports[`<Tiers /> Rendering with data should render tier prices when tier prices are available 1`] = `
+<Fragment>
   <Portal
     name="product.tiers.before"
     props={null}
@@ -42,20 +14,25 @@ exports[`<Tiers /> Rendering Rendering with data should render tier prices when 
       className="css-ipvvc7"
     >
       <pure(Tier)
-        key="1_10_99.99"
+        key="1_2_92.5"
         price={
           Object {
             "currency": "USD",
             "tiers": Array [
               Object {
                 "from": 1,
-                "to": 10,
-                "unitPrice": 99.99,
+                "to": 2,
+                "unitPrice": 92.5,
               },
               Object {
-                "from": 11,
-                "to": 9999,
-                "unitPrice": 80,
+                "from": 3,
+                "to": 5,
+                "unitPrice": 77.5,
+              },
+              Object {
+                "from": 6,
+                "to": null,
+                "unitPrice": 68.5,
               },
             ],
           }
@@ -63,208 +40,80 @@ exports[`<Tiers /> Rendering Rendering with data should render tier prices when 
         tier={
           Object {
             "from": 1,
-            "to": 10,
-            "unitPrice": 99.99,
+            "to": 2,
+            "unitPrice": 92.5,
           }
         }
-      >
-        <Tier
-          price={
-            Object {
-              "currency": "USD",
-              "tiers": Array [
-                Object {
-                  "from": 1,
-                  "to": 10,
-                  "unitPrice": 99.99,
-                },
-                Object {
-                  "from": 11,
-                  "to": 9999,
-                  "unitPrice": 80,
-                },
-              ],
-            }
-          }
-          tier={
-            Object {
-              "from": 1,
-              "to": 10,
-              "unitPrice": 99.99,
-            }
-          }
-        >
-          <Translate
-            className="css-z8ikop"
-            key="1"
-            params={
-              Object {
-                "from": 1,
-              }
-            }
-            role="text"
-            string="price.tier.range"
-          >
-            <span
-              className="css-z8ikop"
-              role="text"
-            >
-              price.tier.range
-            </span>
-          </Translate>
-        </Tier>
-      </pure(Tier)>
+      />
       <pure(Tier)
-        key="11_9999_80"
+        key="3_5_77.5"
         price={
           Object {
             "currency": "USD",
             "tiers": Array [
               Object {
                 "from": 1,
-                "to": 10,
-                "unitPrice": 99.99,
+                "to": 2,
+                "unitPrice": 92.5,
               },
               Object {
-                "from": 11,
-                "to": 9999,
-                "unitPrice": 80,
+                "from": 3,
+                "to": 5,
+                "unitPrice": 77.5,
+              },
+              Object {
+                "from": 6,
+                "to": null,
+                "unitPrice": 68.5,
               },
             ],
           }
         }
         tier={
           Object {
-            "from": 11,
-            "to": 9999,
-            "unitPrice": 80,
+            "from": 3,
+            "to": 5,
+            "unitPrice": 77.5,
           }
         }
-      >
-        <Tier
-          price={
-            Object {
-              "currency": "USD",
-              "tiers": Array [
-                Object {
-                  "from": 1,
-                  "to": 10,
-                  "unitPrice": 99.99,
-                },
-                Object {
-                  "from": 11,
-                  "to": 9999,
-                  "unitPrice": 80,
-                },
-              ],
-            }
-          }
-          tier={
-            Object {
-              "from": 11,
-              "to": 9999,
-              "unitPrice": 80,
-            }
-          }
-        >
-          <Translate
-            className="css-z8ikop"
-            key="11"
-            params={
+      />
+      <pure(Tier)
+        key="6__68.5"
+        price={
+          Object {
+            "currency": "USD",
+            "tiers": Array [
               Object {
-                "from": 11,
-              }
-            }
-            role="text"
-            string="price.tier.range"
-          >
-            <span
-              className="css-z8ikop"
-              role="text"
-            >
-              price.tier.range
-            </span>
-          </Translate>
-        </Tier>
-      </pure(Tier)>
+                "from": 1,
+                "to": 2,
+                "unitPrice": 92.5,
+              },
+              Object {
+                "from": 3,
+                "to": 5,
+                "unitPrice": 77.5,
+              },
+              Object {
+                "from": 6,
+                "to": null,
+                "unitPrice": 68.5,
+              },
+            ],
+          }
+        }
+        tier={
+          Object {
+            "from": 6,
+            "to": null,
+            "unitPrice": 68.5,
+          }
+        }
+      />
     </div>
   </Portal>
   <Portal
     name="product.tiers.after"
     props={null}
   />
-</Tiers>
-`;
-
-exports[`<Tiers /> Rendering Rendering without data should render nothing when price data are not available ({}) 1`] = `
-<Tiers
-  price={Object {}}
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
-/>
-`;
-
-exports[`<Tiers /> Rendering Rendering without data should render nothing when price data are not available (null) 1`] = `
-<Tiers
-  price={null}
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
-/>
-`;
-
-exports[`<Tiers /> Rendering Rendering without data should render nothing when tier prices are empty ([]) 1`] = `
-<Tiers
-  price={
-    Object {
-      "currency": "USD",
-      "tiers": Array [],
-    }
-  }
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
-/>
-`;
-
-exports[`<Tiers /> Rendering Rendering without data should render nothing when tier prices are not available (field missing) 1`] = `
-<Tiers
-  price={
-    Object {
-      "currency": "USD",
-    }
-  }
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
-/>
+</Fragment>
 `;

--- a/themes/theme-gmd/pages/Product/components/Header/components/Tiers/components/Tier/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Tiers/components/Tier/__snapshots__/spec.jsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Tier /> Rendering with data should render tier prices when tier prices are available 1`] = `
+<Translate
+  className="css-z8ikop"
+  key="3"
+  params={
+    Object {
+      "from": 3,
+    }
+  }
+  role="text"
+  string="price.tier.range"
+>
+  <FormatPrice
+    className="css-ud99sa"
+    currency="USD"
+    forKey="price"
+    fractions={true}
+    price={77.5}
+  />
+</Translate>
+`;

--- a/themes/theme-gmd/pages/Product/components/Header/components/Tiers/components/Tier/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Tiers/components/Tier/index.jsx
@@ -9,8 +9,8 @@ import styles from '../../style';
  * @returns {JSX}
  */
 const Tier = ({ tier, price }) => {
-  // Skip tier if tier price is equal the product price
-  if (tier.unitPrice === price.totalPrice) {
+  // Skip tier with quantity 1
+  if (tier.from <= 1) {
     return null;
   }
 

--- a/themes/theme-gmd/pages/Product/components/Header/components/Tiers/components/Tier/spec.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Tiers/components/Tier/spec.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Tier from './index';
+
+jest.mock('@shopgate/engage/core/helpers/i18n', () => ({
+  i18n: {
+    text: input => input,
+  },
+}));
+
+describe('<Tier />', () => {
+  describe('Rendering with data', () => {
+    it('should render tier prices when tier prices are available', () => {
+      const price = {
+        tiers: [
+          {
+            from: 1,
+            to: 2,
+            unitPrice: 92.5,
+          },
+          {
+            from: 3,
+            to: 5,
+            unitPrice: 77.5,
+          },
+          {
+            from: 6,
+            to: null,
+            unitPrice: 68.5,
+          },
+        ],
+        currency: 'USD',
+      };
+
+      const tier = {
+        from: 3,
+        to: 5,
+        unitPrice: 77.5,
+      };
+
+      const wrapper = shallow(<Tier price={price} tier={tier} />).dive();
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+
+  describe('Rendering without data', () => {
+    it('should render nothing when tier from is less then 1', () => {
+      const tier = { from: 1 };
+      const wrapper = shallow(<Tier tier={tier} price={{}} />).dive();
+      expect(wrapper).toBeEmptyRender();
+    });
+  });
+});
+

--- a/themes/theme-gmd/pages/Product/components/Header/components/Tiers/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Tiers/index.jsx
@@ -42,5 +42,4 @@ Tiers.defaultProps = {
   price: null,
 };
 
-export { Tiers as TiersUnconnected };
 export default connect(pure(Tiers));

--- a/themes/theme-gmd/pages/Product/components/Header/components/Tiers/spec.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/Tiers/spec.jsx
@@ -1,89 +1,66 @@
 import React from 'react';
-import configureStore from 'redux-mock-store';
-import { mount } from 'enzyme';
-import { TiersUnconnected as Tiers } from './index';
+import { shallow } from 'enzyme';
+import Tiers from './index';
 
-jest.mock('@shopgate/engage/core/helpers/i18n', () => ({
-  i18n: {
-    text: input => input,
-  },
-}));
+jest.mock('./connector', () => cmp => cmp);
 
 describe('<Tiers />', () => {
-  const store = configureStore()({});
+  describe('Rendering with data', () => {
+    it('should render tier prices when tier prices are available', () => {
+      const price = {
+        tiers: [
+          {
+            from: 1,
+            to: 2,
+            unitPrice: 92.5,
+          },
+          {
+            from: 3,
+            to: 5,
+            unitPrice: 77.5,
+          },
+          {
+            from: 6,
+            to: null,
+            unitPrice: 68.5,
+          },
+        ],
+        currency: 'USD',
+      };
 
-  describe('Rendering', () => {
-    describe('Rendering with data', () => {
-      it('should render tier prices when tier prices are available', () => {
-        const price = {
-          tiers: [
-            {
-              from: 1,
-              to: 10,
-              unitPrice: 99.99,
-            },
-            {
-              from: 11,
-              to: 9999,
-              unitPrice: 80,
-            },
-          ],
-          currency: 'USD',
-        };
+      const wrapper = shallow((
+        <Tiers price={price} />
+      )).dive();
 
-        const wrapper = mount((
-          <Tiers price={price} store={store} />
-        ));
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
 
-        expect(wrapper).toMatchSnapshot();
-      });
+  describe('Rendering without data', () => {
+    it('should render nothing when price data are not available ({})', () => {
+      const wrapper = shallow(<Tiers price={{}} />).dive();
+      expect(wrapper).toBeEmptyRender();
     });
 
-    describe('Rendering without data', () => {
-      it('should render nothing when price data are not available ({})', () => {
-        const wrapper = mount((
-          <Tiers price={{}} store={store} />
-        ));
+    it('should render nothing when price data are not available (null)', () => {
+      const wrapper = shallow(<Tiers price={null} />).dive();
+      expect(wrapper).toBeEmptyRender();
+    });
 
-        expect(wrapper).toMatchSnapshot();
-        expect(wrapper.exists()).toBe(true);
-      });
+    it('should render nothing when tier prices are empty ([])', () => {
+      const price = {
+        tiers: [],
+        currency: 'USD',
+      };
 
-      it('should render nothing when price data are not available (null)', () => {
-        const wrapper = mount((
-          <Tiers price={null} store={store} />
-        ));
+      const wrapper = shallow(<Tiers price={price} />).dive();
+      expect(wrapper).toBeEmptyRender();
+    });
 
-        expect(wrapper).toMatchSnapshot();
-        expect(wrapper.exists()).toBe(true);
-      });
-
-      it('should render nothing when tier prices are empty ([])', () => {
-        const price = {
-          tiers: [],
-          currency: 'USD',
-        };
-
-        const wrapper = mount((
-          <Tiers price={price} store={store} />
-        ));
-
-        expect(wrapper).toMatchSnapshot();
-        expect(wrapper.exists()).toBe(true);
-      });
-
-      it('should render nothing when tier prices are not available (field missing)', () => {
-        const price = {
-          currency: 'USD',
-        };
-
-        const wrapper = mount((
-          <Tiers price={price} store={store} />
-        ));
-
-        expect(wrapper).toMatchSnapshot();
-        expect(wrapper.exists()).toBe(true);
-      });
+    it('should render nothing when tier prices are not available (field missing)', () => {
+      const price = { currency: 'USD' };
+      const wrapper = shallow(<Tiers price={price} />).dive();
+      expect(wrapper).toBeEmptyRender();
     });
   });
 });

--- a/themes/theme-ios11/pages/Product/components/Header/components/Price/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Price/__snapshots__/spec.jsx.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Price /> should not pass unitPriceMin for non variants 1`] = `
+<PlaceholderLabel
+  className="css-q720h0"
+  ready={true}
+  style={null}
+>
+  <Price
+    className="css-1051jlf"
+    currency="USD"
+    discounted={false}
+    fractions={true}
+    taxDisclaimer={true}
+    unitPrice={90.5}
+    unitPriceMin={0}
+  />
+</PlaceholderLabel>
+`;
+
+exports[`<Price /> should pass unitPriceMin for variants 1`] = `
+<PlaceholderLabel
+  className="css-q720h0"
+  ready={true}
+  style={null}
+>
+  <Price
+    className="css-1051jlf"
+    currency="USD"
+    discounted={false}
+    fractions={true}
+    taxDisclaimer={true}
+    unitPrice={90.5}
+    unitPriceMin={80.5}
+  />
+</PlaceholderLabel>
+`;
+
+exports[`<Price /> should render portals 1`] = `
+<Fragment>
+  <Portal
+    name="product.price.before"
+    props={null}
+  />
+  <Portal
+    name="product.price"
+    props={
+      Object {
+        "price": Object {
+          "currency": "USD",
+          "discount": 0,
+          "unitPrice": 90.5,
+          "unitPriceMin": 80.5,
+        },
+      }
+    }
+  >
+    <Consumer>
+      <Component />
+    </Consumer>
+  </Portal>
+  <Portal
+    name="product.price.after"
+    props={null}
+  />
+</Fragment>
+`;

--- a/themes/theme-ios11/pages/Product/components/Header/components/Price/connector.js
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Price/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { getProductPriceData } from '@shopgate/pwa-common-commerce/product';
+import { getProductPriceData, hasProductVariants } from '@shopgate/pwa-common-commerce/product';
 
 /**
  * Maps the contents of the state to the component props.
@@ -9,6 +9,7 @@ import { getProductPriceData } from '@shopgate/pwa-common-commerce/product';
  */
 const mapStateToProps = (state, props) => ({
   price: getProductPriceData(state, props),
+  hasProductVariants: hasProductVariants(state, props),
 });
 
 /**

--- a/themes/theme-ios11/pages/Product/components/Header/components/Price/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Price/index.jsx
@@ -33,7 +33,7 @@ const getTotalPrice = (price, additions) => {
  * @param {Object} props The component props.
  * @return {JSX}
  */
-const Price = ({ price }) => (
+const Price = ({ price, hasProductVariants }) => (
   <Fragment>
     <Portal name={PRODUCT_PRICE_BEFORE} />
     <Portal name={PRODUCT_PRICE} props={{ price }}>
@@ -47,7 +47,7 @@ const Price = ({ price }) => (
                 discounted={!!price.discount}
                 taxDisclaimer
                 unitPrice={getTotalPrice(price.unitPrice, optionsPrices)}
-                unitPriceMin={!optionsPrices ? price.unitPriceMin : 0}
+                unitPriceMin={hasProductVariants ? price.unitPriceMin : 0}
               />
             )}
           </PlaceholderLabel>
@@ -59,10 +59,12 @@ const Price = ({ price }) => (
 );
 
 Price.propTypes = {
+  hasProductVariants: PropTypes.bool,
   price: PropTypes.shape(),
 };
 
 Price.defaultProps = {
+  hasProductVariants: false,
   price: null,
 };
 

--- a/themes/theme-ios11/pages/Product/components/Header/components/Price/spec.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Price/spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Price from './index';
+
+jest.mock('../../../../context', () => ({
+  ProductContext: {
+    Consumer: ({ children }) => children({}),
+  },
+}));
+jest.mock('./connector', () => cmp => cmp);
+
+describe('<Price />', () => {
+  const price = {
+    unitPrice: 90.5,
+    unitPriceMin: 80.5,
+    discount: 0,
+    currency: 'USD',
+  };
+
+  it('should render portals', () => {
+    const wrapper = shallow(<Price price={price} hasProductVariants />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should pass unitPriceMin for variants', () => {
+    const wrapper = shallow(<Price price={price} hasProductVariants />)
+      .find('Consumer').dive();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should not pass unitPriceMin for non variants', () => {
+    const wrapper = shallow(<Price price={price} hasProductVariants={false} />)
+      .find('Consumer').dive();
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+

--- a/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -35,7 +35,7 @@ const ProductInfo = ({ productId, options }) => (
           <Portal name={PRODUCT_INFO_ROW1}>
             <div className={styles.productInfo}>
               {/* This feature is currently in BETA testing.
-                It should only be used for approved BETA Client Projects */}
+              It should only be used for approved BETA Client Projects */}
               <MapPriceHint productId={productId} />
             </div>
             <div className={styles.productInfo}>
@@ -46,7 +46,7 @@ const ProductInfo = ({ productId, options }) => (
             </div>
             <div className={styles.productInfo}>
               {/* This feature is currently in BETA testing.
-                It should only be used for approved BETA Client Projects */}
+              It should only be used for approved BETA Client Projects */}
               <OrderQuantityHint productId={productId} />
             </div>
             <div className={styles.productInfo}>

--- a/themes/theme-ios11/pages/Product/components/Header/components/Tiers/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Tiers/__snapshots__/spec.jsx.snap
@@ -1,35 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tiers /> Rendering Rendering with data should render tier prices when tier prices are available 1`] = `
-<Tiers
-  price={
-    Object {
-      "currency": "USD",
-      "tiers": Array [
-        Object {
-          "from": 1,
-          "to": 10,
-          "unitPrice": 99.99,
-        },
-        Object {
-          "from": 11,
-          "to": 9999,
-          "unitPrice": 80,
-        },
-      ],
-    }
-  }
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
->
+exports[`<Tiers /> Rendering with data should render tier prices when tier prices are available 1`] = `
+<Fragment>
   <Portal
     name="product.tiers.before"
     props={null}
@@ -42,20 +14,25 @@ exports[`<Tiers /> Rendering Rendering with data should render tier prices when 
       className="css-ipvvc7"
     >
       <pure(Tier)
-        key="1_10_99.99"
+        key="1_2_92.5"
         price={
           Object {
             "currency": "USD",
             "tiers": Array [
               Object {
                 "from": 1,
-                "to": 10,
-                "unitPrice": 99.99,
+                "to": 2,
+                "unitPrice": 92.5,
               },
               Object {
-                "from": 11,
-                "to": 9999,
-                "unitPrice": 80,
+                "from": 3,
+                "to": 5,
+                "unitPrice": 77.5,
+              },
+              Object {
+                "from": 6,
+                "to": null,
+                "unitPrice": 68.5,
               },
             ],
           }
@@ -63,208 +40,80 @@ exports[`<Tiers /> Rendering Rendering with data should render tier prices when 
         tier={
           Object {
             "from": 1,
-            "to": 10,
-            "unitPrice": 99.99,
+            "to": 2,
+            "unitPrice": 92.5,
           }
         }
-      >
-        <Tier
-          price={
-            Object {
-              "currency": "USD",
-              "tiers": Array [
-                Object {
-                  "from": 1,
-                  "to": 10,
-                  "unitPrice": 99.99,
-                },
-                Object {
-                  "from": 11,
-                  "to": 9999,
-                  "unitPrice": 80,
-                },
-              ],
-            }
-          }
-          tier={
-            Object {
-              "from": 1,
-              "to": 10,
-              "unitPrice": 99.99,
-            }
-          }
-        >
-          <Translate
-            className="css-z8ikop"
-            key="1"
-            params={
-              Object {
-                "from": 1,
-              }
-            }
-            role="text"
-            string="price.tier.range"
-          >
-            <span
-              className="css-z8ikop"
-              role="text"
-            >
-              price.tier.range
-            </span>
-          </Translate>
-        </Tier>
-      </pure(Tier)>
+      />
       <pure(Tier)
-        key="11_9999_80"
+        key="3_5_77.5"
         price={
           Object {
             "currency": "USD",
             "tiers": Array [
               Object {
                 "from": 1,
-                "to": 10,
-                "unitPrice": 99.99,
+                "to": 2,
+                "unitPrice": 92.5,
               },
               Object {
-                "from": 11,
-                "to": 9999,
-                "unitPrice": 80,
+                "from": 3,
+                "to": 5,
+                "unitPrice": 77.5,
+              },
+              Object {
+                "from": 6,
+                "to": null,
+                "unitPrice": 68.5,
               },
             ],
           }
         }
         tier={
           Object {
-            "from": 11,
-            "to": 9999,
-            "unitPrice": 80,
+            "from": 3,
+            "to": 5,
+            "unitPrice": 77.5,
           }
         }
-      >
-        <Tier
-          price={
-            Object {
-              "currency": "USD",
-              "tiers": Array [
-                Object {
-                  "from": 1,
-                  "to": 10,
-                  "unitPrice": 99.99,
-                },
-                Object {
-                  "from": 11,
-                  "to": 9999,
-                  "unitPrice": 80,
-                },
-              ],
-            }
-          }
-          tier={
-            Object {
-              "from": 11,
-              "to": 9999,
-              "unitPrice": 80,
-            }
-          }
-        >
-          <Translate
-            className="css-z8ikop"
-            key="11"
-            params={
+      />
+      <pure(Tier)
+        key="6__68.5"
+        price={
+          Object {
+            "currency": "USD",
+            "tiers": Array [
               Object {
-                "from": 11,
-              }
-            }
-            role="text"
-            string="price.tier.range"
-          >
-            <span
-              className="css-z8ikop"
-              role="text"
-            >
-              price.tier.range
-            </span>
-          </Translate>
-        </Tier>
-      </pure(Tier)>
+                "from": 1,
+                "to": 2,
+                "unitPrice": 92.5,
+              },
+              Object {
+                "from": 3,
+                "to": 5,
+                "unitPrice": 77.5,
+              },
+              Object {
+                "from": 6,
+                "to": null,
+                "unitPrice": 68.5,
+              },
+            ],
+          }
+        }
+        tier={
+          Object {
+            "from": 6,
+            "to": null,
+            "unitPrice": 68.5,
+          }
+        }
+      />
     </div>
   </Portal>
   <Portal
     name="product.tiers.after"
     props={null}
   />
-</Tiers>
-`;
-
-exports[`<Tiers /> Rendering Rendering without data should render nothing when price data are not available ({}) 1`] = `
-<Tiers
-  price={Object {}}
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
-/>
-`;
-
-exports[`<Tiers /> Rendering Rendering without data should render nothing when price data are not available (null) 1`] = `
-<Tiers
-  price={null}
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
-/>
-`;
-
-exports[`<Tiers /> Rendering Rendering without data should render nothing when tier prices are empty ([]) 1`] = `
-<Tiers
-  price={
-    Object {
-      "currency": "USD",
-      "tiers": Array [],
-    }
-  }
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
-/>
-`;
-
-exports[`<Tiers /> Rendering Rendering without data should render nothing when tier prices are not available (field missing) 1`] = `
-<Tiers
-  price={
-    Object {
-      "currency": "USD",
-    }
-  }
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
-/>
+</Fragment>
 `;

--- a/themes/theme-ios11/pages/Product/components/Header/components/Tiers/components/Tier/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Tiers/components/Tier/__snapshots__/spec.jsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Tier /> Rendering with data should render tier prices when tier prices are available 1`] = `
+<Translate
+  className="css-z8ikop"
+  key="3"
+  params={
+    Object {
+      "from": 3,
+    }
+  }
+  role="text"
+  string="price.tier.range"
+>
+  <FormatPrice
+    className="css-ud99sa"
+    currency="USD"
+    forKey="price"
+    fractions={true}
+    price={77.5}
+  />
+</Translate>
+`;

--- a/themes/theme-ios11/pages/Product/components/Header/components/Tiers/components/Tier/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Tiers/components/Tier/index.jsx
@@ -9,8 +9,8 @@ import styles from '../../style';
  * @returns {JSX}
  */
 const Tier = ({ tier, price }) => {
-  // Skip tier if tier price is equal the product price
-  if (tier.unitPrice === price.totalPrice) {
+  // Skip tier with quantity 1
+  if (tier.from <= 1) {
     return null;
   }
 

--- a/themes/theme-ios11/pages/Product/components/Header/components/Tiers/components/Tier/spec.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Tiers/components/Tier/spec.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Tier from './index';
+
+jest.mock('@shopgate/engage/core/helpers/i18n', () => ({
+  i18n: {
+    text: input => input,
+  },
+}));
+
+describe('<Tier />', () => {
+  describe('Rendering with data', () => {
+    it('should render tier prices when tier prices are available', () => {
+      const price = {
+        tiers: [
+          {
+            from: 1,
+            to: 2,
+            unitPrice: 92.5,
+          },
+          {
+            from: 3,
+            to: 5,
+            unitPrice: 77.5,
+          },
+          {
+            from: 6,
+            to: null,
+            unitPrice: 68.5,
+          },
+        ],
+        currency: 'USD',
+      };
+
+      const tier = {
+        from: 3,
+        to: 5,
+        unitPrice: 77.5,
+      };
+
+      const wrapper = shallow(<Tier price={price} tier={tier} />).dive();
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+
+  describe('Rendering without data', () => {
+    it('should render nothing when tier from is less then 1', () => {
+      const tier = { from: 1 };
+      const wrapper = shallow(<Tier tier={tier} price={{}} />).dive();
+      expect(wrapper).toBeEmptyRender();
+    });
+  });
+});
+

--- a/themes/theme-ios11/pages/Product/components/Header/components/Tiers/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Tiers/index.jsx
@@ -42,5 +42,4 @@ Tiers.defaultProps = {
   price: null,
 };
 
-export { Tiers as TiersUnconnected };
 export default connect(pure(Tiers));

--- a/themes/theme-ios11/pages/Product/components/Header/components/Tiers/spec.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/Tiers/spec.jsx
@@ -1,89 +1,66 @@
 import React from 'react';
-import configureStore from 'redux-mock-store';
-import { mount } from 'enzyme';
-import { TiersUnconnected as Tiers } from './index';
+import { shallow } from 'enzyme';
+import Tiers from './index';
 
-jest.mock('@shopgate/engage/core/helpers/i18n', () => ({
-  i18n: {
-    text: input => input,
-  },
-}));
+jest.mock('./connector', () => cmp => cmp);
 
 describe('<Tiers />', () => {
-  const store = configureStore()({});
+  describe('Rendering with data', () => {
+    it('should render tier prices when tier prices are available', () => {
+      const price = {
+        tiers: [
+          {
+            from: 1,
+            to: 2,
+            unitPrice: 92.5,
+          },
+          {
+            from: 3,
+            to: 5,
+            unitPrice: 77.5,
+          },
+          {
+            from: 6,
+            to: null,
+            unitPrice: 68.5,
+          },
+        ],
+        currency: 'USD',
+      };
 
-  describe('Rendering', () => {
-    describe('Rendering with data', () => {
-      it('should render tier prices when tier prices are available', () => {
-        const price = {
-          tiers: [
-            {
-              from: 1,
-              to: 10,
-              unitPrice: 99.99,
-            },
-            {
-              from: 11,
-              to: 9999,
-              unitPrice: 80,
-            },
-          ],
-          currency: 'USD',
-        };
+      const wrapper = shallow((
+        <Tiers price={price} />
+      )).dive();
 
-        const wrapper = mount((
-          <Tiers price={price} store={store} />
-        ));
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
 
-        expect(wrapper).toMatchSnapshot();
-      });
+  describe('Rendering without data', () => {
+    it('should render nothing when price data are not available ({})', () => {
+      const wrapper = shallow(<Tiers price={{}} />).dive();
+      expect(wrapper).toBeEmptyRender();
     });
 
-    describe('Rendering without data', () => {
-      it('should render nothing when price data are not available ({})', () => {
-        const wrapper = mount((
-          <Tiers price={{}} store={store} />
-        ));
+    it('should render nothing when price data are not available (null)', () => {
+      const wrapper = shallow(<Tiers price={null} />).dive();
+      expect(wrapper).toBeEmptyRender();
+    });
 
-        expect(wrapper).toMatchSnapshot();
-        expect(wrapper.exists()).toBe(true);
-      });
+    it('should render nothing when tier prices are empty ([])', () => {
+      const price = {
+        tiers: [],
+        currency: 'USD',
+      };
 
-      it('should render nothing when price data are not available (null)', () => {
-        const wrapper = mount((
-          <Tiers price={null} store={store} />
-        ));
+      const wrapper = shallow(<Tiers price={price} />).dive();
+      expect(wrapper).toBeEmptyRender();
+    });
 
-        expect(wrapper).toMatchSnapshot();
-        expect(wrapper.exists()).toBe(true);
-      });
-
-      it('should render nothing when tier prices are empty ([])', () => {
-        const price = {
-          tiers: [],
-          currency: 'USD',
-        };
-
-        const wrapper = mount((
-          <Tiers price={price} store={store} />
-        ));
-
-        expect(wrapper).toMatchSnapshot();
-        expect(wrapper.exists()).toBe(true);
-      });
-
-      it('should render nothing when tier prices are not available (field missing)', () => {
-        const price = {
-          currency: 'USD',
-        };
-
-        const wrapper = mount((
-          <Tiers price={price} store={store} />
-        ));
-
-        expect(wrapper).toMatchSnapshot();
-        expect(wrapper.exists()).toBe(true);
-      });
+    it('should render nothing when tier prices are not available (field missing)', () => {
+      const price = { currency: 'USD' };
+      const wrapper = shallow(<Tiers price={price} />).dive();
+      expect(wrapper).toBeEmptyRender();
     });
   });
 });


### PR DESCRIPTION
# Description

Fix displaying unit price on product details page for product without variants

## Type of change

Please add an "x" into the option that is relevant:

- [X] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
