### PR TITLE
Added missing translations strings for a11y

### DIFF
--- a/themes/theme-gmd/locale/es-ES.json
+++ b/themes/theme-gmd/locale/es-ES.json
@@ -60,9 +60,9 @@
     "description_heading": "Sobre",
     "pick_an_attribute": "Elija uno {0}",
     "tax_disclaimer": "* Incl. IVA más gastos de envío si procede",
-    "adding_item": "{count, plural, =1 {Adding {count} item} other {Adding {count} items}}",
-    "pick_option_first": "Pick an option first. {option}",
-    "fill_out_required_input_first": "Fill out the required inputs first.",
+    "adding_item": "{count, plural, =1 {Añadiendo {count} artículo} other {Añadiendo {count} artículos}}",
+    "pick_option_first": "Seleccionar primero una opción. {option}",
+    "fill_out_required_input_first": "Rellenar primero las entradas necesarias.",
     "add_to_cart": "Añadir a la cesta",
     "no_more_found": "El artículo: \"{name}\" ya no está disponible.",
     "quantity": "Cantidad",
@@ -78,12 +78,12 @@
       "showMore": "Mostrar todo"
     },
     "sections": {
-      "information": "Product Information",
-      "options": "Choose Options",
-      "description": "Description",
-      "properties": "Properties",
-      "ratings": "Ratings",
-      "purchase": "Purchase Item"
+      "information": "Información sobre el producto",
+      "options": "Elegir opciones",
+      "description": "Descripción",
+      "properties": "Propiedades",
+      "ratings": "Valoraciones",
+      "purchase": "Comprar artículo"
     }
   },
   "category": {

--- a/themes/theme-gmd/locale/fr-FR.json
+++ b/themes/theme-gmd/locale/fr-FR.json
@@ -60,9 +60,9 @@
     "description_heading": "à propos",
     "pick_an_attribute": "Choisir un {0}",
     "tax_disclaimer": "* Inclus TVA plus frais de livraison éventuels",
-    "adding_item": "{count, plural, =1 {Adding {count} item} other {Adding {count} items}}",
-    "pick_option_first": "Pick an option first. {option}",
-    "fill_out_required_input_first": "Fill out the required inputs first.",
+    "adding_item": "{count, plural, =1 {Ajouter {count} un objet} other {Ajouter {count} des objets}}",
+    "pick_option_first": "Choisissez d'abord une option. {option}",
+    "fill_out_required_input_first": "Remplissez d'abord les entrées requises.",
     "add_to_cart": "Ajouter au panier",
     "no_more_found": "L'article: \"{name}\" n'est plus disponible.",
     "quantity": "Quantité",
@@ -78,12 +78,12 @@
       "showMore": "Afficher tout"
     },
     "sections": {
-      "information": "Product Information",
-      "options": "Choose Options",
+      "information": "Informations du produit",
+      "options": "Choisir les options",
       "description": "Description",
-      "properties": "Properties",
-      "ratings": "Ratings",
-      "purchase": "Purchase Item"
+      "properties": "Propriétés",
+      "ratings": "Evaluations",
+      "purchase": "Acheter l'objet"
     }
   },
   "category": {

--- a/themes/theme-gmd/locale/it-IT.json
+++ b/themes/theme-gmd/locale/it-IT.json
@@ -60,9 +60,9 @@
     "description_heading": "A riguardo",
     "pick_an_attribute": "Seleziona un {0}",
     "tax_disclaimer": "* IVA inclusa più le spese di spedizione, se applicabile",
-    "adding_item": "{count, plural, =1 {Adding {count} item} other {Adding {count} items}}",
-    "pick_option_first": "Pick an option first. {option}",
-    "fill_out_required_input_first": "Fill out the required inputs first.",
+    "adding_item": "{count, plural, =1 {Aggiungendo {count} articolo} other {Aggiungendo {count} di articoli}}",
+    "pick_option_first": "Prima scegli un'opzione. {option}",
+    "fill_out_required_input_first": "Prima inserisci i dati richiesti.",
     "add_to_cart": "Aggiungi al carrello",
     "no_more_found": "L'articolo: \"{name}\" non è più disponibile.",
     "quantity": "Quantità",
@@ -78,12 +78,12 @@
       "showMore": "Mostra tutto"
     },
     "sections": {
-      "information": "Product Information",
-      "options": "Choose Options",
-      "description": "Description",
-      "properties": "Properties",
-      "ratings": "Ratings",
-      "purchase": "Purchase Item"
+      "information": "Informazioni sul prodotto",
+      "options": "Seleziona le opzioni",
+      "description": "Descrizione",
+      "properties": "Caratteristiche",
+      "ratings": "Valutazioni",
+      "purchase": "Acquista articolo"
     }
   },
   "category": {

--- a/themes/theme-gmd/locale/nl-NL.json
+++ b/themes/theme-gmd/locale/nl-NL.json
@@ -60,9 +60,9 @@
     "description_heading": "Over",
     "pick_an_attribute": "Kies een {0}",
     "tax_disclaimer": "* Inbegrepen BTW plus verzendkosten indien van toepassing",
-    "adding_item": "{count, plural, =1 {Adding {count} item} other {Adding {count} items}}",
-    "pick_option_first": "Pick an option first. {option}",
-    "fill_out_required_input_first": "Fill out the required inputs first.",
+    "adding_item": "{count, plural, =1 {{count} artikel toevoegen} other {{count} artikelen toevoegen}}",
+    "pick_option_first": "Kies eerst een optie. {option}",
+    "fill_out_required_input_first": "Vul eerst de vereiste input in.",
     "add_to_cart": "Voeg aan winkelwagen toe",
     "no_more_found": "Het item: \"{name}\" is niet langer beschikbaar.",
     "quantity": "Aantal",
@@ -78,12 +78,12 @@
       "showMore": "Toon alles"
     },
     "sections": {
-      "information": "Product Information",
-      "options": "Choose Options",
-      "description": "Description",
-      "properties": "Properties",
+      "information": "Productinformatie",
+      "options": "Kies opties",
+      "description": "Omschrijving",
+      "properties": "Eigenschappen",
       "ratings": "Ratings",
-      "purchase": "Purchase Item"
+      "purchase": "Aankoopitem"
     }
   },
   "category": {

--- a/themes/theme-gmd/locale/pt-PT.json
+++ b/themes/theme-gmd/locale/pt-PT.json
@@ -60,9 +60,9 @@
     "description_heading": "Sobre",
     "pick_an_attribute": "Escolher {0}",
     "tax_disclaimer": "* Incl. IVA mais custos de envio, se aplicável",
-    "adding_item": "{count, plural, =1 {Adding {count} item} other {Adding {count} items}}",
-    "pick_option_first": "Pick an option first. {option}",
-    "fill_out_required_input_first": "Fill out the required inputs first.",
+    "adding_item": "{count, plural, =1 {Adicionando {count} item} other {Adicionando {count} items}}",
+    "pick_option_first": "Primeiro escolha uma opção. {option}",
+    "fill_out_required_input_first": "Primeiro preencha os campos obrigatórios.",
     "add_to_cart": "Adicionar ao carrinho",
     "no_more_found": "O item: \"{name}\" não está mais disponível.",
     "quantity": "Quantidade",
@@ -78,12 +78,12 @@
       "showMore": "Mostrar tudo"
     },
     "sections": {
-      "information": "Product Information",
-      "options": "Choose Options",
-      "description": "Description",
-      "properties": "Properties",
-      "ratings": "Ratings",
-      "purchase": "Purchase Item"
+      "information": "Informação do produto",
+      "options": "Escolha as opções",
+      "description": "Descrição",
+      "properties": "Propriedades",
+      "ratings": "Avaliações",
+      "purchase": "Comprar Item"
     }
   },
   "category": {

--- a/themes/theme-ios11/locale/es-ES.json
+++ b/themes/theme-ios11/locale/es-ES.json
@@ -62,9 +62,9 @@
     "pick_an_attribute": "Elegir un {0}",
     "tax_disclaimer": "* Incl. IVA más gastos de envío si procede",
     "item_added": "{count, plural, =0 {# no se agregaron artículos} =1 {{count} artículo agregado} other {{count} artículos agregados}}",
-    "adding_item": "{count, plural, =1 {Adding {count} item} other {Adding {count} items}}",
-    "pick_option_first": "Pick an option first. {option}",
-    "fill_out_required_input_first": "Fill out the required inputs first.",
+    "adding_item": "{count, plural, =1 {Añadiendo {count} artículo} other {Añadiendo {count} artículos}}",
+    "pick_option_first": "Seleccionar primero una opción. {option}",
+    "fill_out_required_input_first": "Rellenar primero las entradas necesarias.",
     "add_to_cart": "Añadir a la cesta",
     "go_to_cart": "Ir a la cesta",
     "no_more_found": "El artículo: \"{name}\" ya no está disponible.",
@@ -81,12 +81,12 @@
       "showMore": "Mostrar todo"
     },
     "sections": {
-      "information": "Product Information",
-      "options": "Choose Options",
-      "description": "Description",
-      "properties": "Properties",
-      "ratings": "Ratings",
-      "purchase": "Purchase Item"
+      "information": "Información sobre el producto",
+      "options": "Elegir opciones",
+      "description": "Descripción",
+      "properties": "Propiedades",
+      "ratings": "Valoraciones",
+      "purchase": "Comprar artículo"
     }
   },
   "category": {

--- a/themes/theme-ios11/locale/fr-FR.json
+++ b/themes/theme-ios11/locale/fr-FR.json
@@ -62,9 +62,9 @@
     "pick_an_attribute": "Choisir un {0}",
     "tax_disclaimer": "* Inclus TVA plus frais de livraison éventuels",
     "item_added": "{count, plural, =0 {# aucun article ajouté} =1 {{count} article ajouté} other {{count} articles ajoutés}}",
-    "adding_item": "{count, plural, =1 {Adding {count} item} other {Adding {count} items}}",
-    "pick_option_first": "Pick an option first. {option}",
-    "fill_out_required_input_first": "Fill out the required inputs first.",
+    "adding_item": "{count, plural, =1 {Ajouter {count} un objet} other {Ajouter {count} des objets}}",
+    "pick_option_first": "Choisissez d'abord une option. {option}",
+    "fill_out_required_input_first": "Remplissez d'abord les entrées requises.",
     "add_to_cart": "Ajouter au panier",
     "go_to_cart": "Aller au panier",
     "no_more_found": "L'article: \"{name}\" n'est plus disponible.",
@@ -81,12 +81,12 @@
       "showMore": "Afficher tout"
     },
     "sections": {
-      "information": "Product Information",
-      "options": "Choose Options",
+      "information": "Informations du produit",
+      "options": "Choisir les options",
       "description": "Description",
-      "properties": "Properties",
-      "ratings": "Ratings",
-      "purchase": "Purchase Item"
+      "properties": "Propriétés",
+      "ratings": "Evaluations",
+      "purchase": "Acheter l'objet"
     }
   },
   "category": {

--- a/themes/theme-ios11/locale/it-IT.json
+++ b/themes/theme-ios11/locale/it-IT.json
@@ -62,9 +62,9 @@
     "pick_an_attribute": "Seleziona un {0}",
     "tax_disclaimer": "* IVA inclusa più le spese di spedizione, se applicabile",
     "item_added": "{count, plural, =0 {# non ci sono elementi aggiunti} =1 {{count} elemento aggiunto} other {{count} elementi aggiunti}}",
-    "adding_item": "{count, plural, =1 {Adding {count} item} other {Adding {count} items}}",
-    "pick_option_first": "Pick an option first. {option}",
-    "fill_out_required_input_first": "Fill out the required inputs first.",
+    "adding_item": "{count, plural, =1 {Aggiungendo {count} articolo} other {Aggiungendo {count} di articoli}}",
+    "pick_option_first": "Prima scegli un'opzione. {option}",
+    "fill_out_required_input_first": "Prima inserisci i dati richiesti.",
     "add_to_cart": "Aggiungi al carrello",
     "go_to_cart": "Vai al carrello",
     "no_more_found": "L'articolo: \"{name}\" non è più disponibile.",
@@ -81,12 +81,12 @@
       "showMore": "Mostra tutto"
     },
     "sections": {
-      "information": "Product Information",
-      "options": "Choose Options",
-      "description": "Description",
-      "properties": "Properties",
-      "ratings": "Ratings",
-      "purchase": "Purchase Item"
+      "information": "Informazioni sul prodotto",
+      "options": "Seleziona le opzioni",
+      "description": "Descrizione",
+      "properties": "Caratteristiche",
+      "ratings": "Valutazioni",
+      "purchase": "Acquista articolo"
     }
   },
   "category": {

--- a/themes/theme-ios11/locale/nl-NL.json
+++ b/themes/theme-ios11/locale/nl-NL.json
@@ -62,9 +62,9 @@
     "pick_an_attribute": "Kies een {0}",
     "tax_disclaimer": "* Inbegrepen BTW plus verzendkosten indien van toepassing",
     "item_added": "{count, plural, =0 {# no items added} =1 {{count} item added} other {{count} items added}}",
-    "adding_item": "{count, plural, =1 {Adding {count} item} other {Adding {count} items}}",
-    "pick_option_first": "Pick an option first. {option}",
-    "fill_out_required_input_first": "Fill out the required inputs first.",
+    "adding_item": "{count, plural, =1 {{count} artikel toevoegen} other {{count} artikelen toevoegen}}",
+    "pick_option_first": "Kies eerst een optie. {option}",
+    "fill_out_required_input_first": "Vul eerst de vereiste input in.",
     "add_to_cart": "Voeg aan winkelwagen toe",
     "go_to_cart": "Winkelwagen",
     "no_more_found": "Het item: \"{name}\" is niet langer beschikbaar.",
@@ -81,12 +81,12 @@
       "showMore": "Toon alles"
     },
     "sections": {
-      "information": "Product Information",
-      "options": "Choose Options",
-      "description": "Description",
-      "properties": "Properties",
+      "information": "Productinformatie",
+      "options": "Kies opties",
+      "description": "Omschrijving",
+      "properties": "Eigenschappen",
       "ratings": "Ratings",
-      "purchase": "Purchase Item"
+      "purchase": "Aankoopitem"
     }
   },
   "category": {

--- a/themes/theme-ios11/locale/pt-PT.json
+++ b/themes/theme-ios11/locale/pt-PT.json
@@ -62,9 +62,9 @@
     "pick_an_attribute": "Escolher {0}",
     "tax_disclaimer": "* Incl. IVA mais custos de envio, se aplicável",
     "item_added": "{count, plural, =0 {# nenhum item adicionado} =1 {{count} item adicionado} other {{count} itens adicionados}}",
-    "adding_item": "{count, plural, =1 {Adding {count} item} other {Adding {count} items}}",
-    "pick_option_first": "Pick an option first. {option}",
-    "fill_out_required_input_first": "Fill out the required inputs first.",
+    "adding_item": "{count, plural, =1 {Adicionando {count} item} other {Adicionando {count} items}}",
+    "pick_option_first": "Primeiro escolha uma opção. {option}",
+    "fill_out_required_input_first": "Primeiro preencha os campos obrigatórios.",
     "add_to_cart": "Adicionar ao carrinho",
     "go_to_cart": "Carrinho",
     "no_more_found": "O item: \"{name}\" não está mais disponível.",
@@ -81,12 +81,12 @@
       "showMore": "Mostrar tudo"
     },
     "sections": {
-      "information": "Product Information",
-      "options": "Choose Options",
-      "description": "Description",
-      "properties": "Properties",
-      "ratings": "Ratings",
-      "purchase": "Purchase Item"
+      "information": "Informação do produto",
+      "options": "Escolha as opções",
+      "description": "Descrição",
+      "properties": "Propriedades",
+      "ratings": "Avaliações",
+      "purchase": "Comprar Item"
     }
   },
   "category": {


### PR DESCRIPTION
# Description

The newly integrated a11y helpers were missing translation strings for all locales but EN and DE. Those have been implemented.

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
