### PR TITLE
Added empty data check to getKnownRelatives selector

### DIFF
--- a/libraries/commerce/product/selectors/variants.js
+++ b/libraries/commerce/product/selectors/variants.js
@@ -94,6 +94,10 @@ export const getKnownRelatives = createSelector(
   getProductById,
   getKnownProductRelatives,
   (product, knownRelations) => {
+    if (!product) {
+      return [];
+    }
+
     const { productData } = product;
     let parentId = productData.id;
     // Product is parent.

--- a/libraries/commerce/product/selectors/variants.spec.js
+++ b/libraries/commerce/product/selectors/variants.spec.js
@@ -107,6 +107,10 @@ describe('Variants selectors', () => {
     it('should return notAChild and it\'s parent only', () => {
       expect(getKnownRelatives(mockedState, { productId: 'notAChild' })).toEqual(['notAChild', 'foo']);
     });
+
+    it('should return empty array on empty product data', () => {
+      expect(getKnownRelatives(mockedState, { productId: 'not_exist' })).toEqual([]);
+    });
   });
 });
 


### PR DESCRIPTION
# Description

Added empty data check to getKnownRelatives selector. So it doesn't throw an error if the product data are not there yet

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.