### PR TITLE
Prevented opening of the product gallery from placeholder images

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,12 @@
 const jestConfig = require('@shopgate/pwa-unit-test/jest.config');
 
+const testedExtensions = [
+  '@shopgate-tracking-ga-native',
+  '@shopgate-product-reviews',
+  '@shopgate-user-privacy',
+  '@shopgate-theme-config',
+];
+
 module.exports = {
   ...jestConfig,
   moduleNameMapper: {
@@ -18,6 +25,7 @@ module.exports = {
     '/node_modules/',
     '/themes/*/extensions/',
     '/themes/*/e2e/',
+    `/extensions/(?!(${testedExtensions.join('|')}))`,
   ],
   transformIgnorePatterns: [
     'node_modules/(?!(swiper|dom7)/)',

--- a/themes/theme-gmd/pages/Product/components/Media/components/ImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ImageSlider/index.jsx
@@ -74,14 +74,13 @@ class ImageSlider extends Component {
 
   currentSlide = 0;
 
-  handleOpenGallery = () => {
-    const { images } = this.props;
-
-    if (!images || (Array.isArray(images) && !images.length)) {
-      return;
+  /**
+   * @param {boolean} hasImages Tells if the slider rendered images.
+   */
+  handleOpenGallery = (hasImages) => {
+    if (hasImages) {
+      this.props.navigate(this.currentSlide);
     }
-
-    this.props.navigate(this.currentSlide);
   };
 
   handleSlideChange = (currentSlide) => {
@@ -95,9 +94,10 @@ class ImageSlider extends Component {
   render() {
     const { product, images, 'aria-hidden': ariaHidden } = this.props;
     let content;
+    let imagesByIndex = [];
 
     if (product && Array.isArray(images) && images.length > 1) {
-      const imagesByIndex = getImagesByIndex(images);
+      imagesByIndex = getImagesByIndex(images);
 
       if (imagesByIndex.length) {
         content = (
@@ -133,8 +133,8 @@ class ImageSlider extends Component {
         <Portal name={PRODUCT_IMAGE}>
           <div
             data-test-id={`product: ${product ? product.name : ''}`}
-            onClick={this.handleOpenGallery}
-            onKeyDown={this.handleOpenGallery}
+            onClick={() => { this.handleOpenGallery(!!imagesByIndex.length); }}
+            onKeyDown={() => { this.handleOpenGallery(!!imagesByIndex.length); }}
             role="button"
             tabIndex="0"
             aria-hidden={ariaHidden}

--- a/themes/theme-gmd/pages/Product/components/Media/components/ImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ImageSlider/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import noop from 'lodash/noop';
 import { Swiper, Portal } from '@shopgate/pwa-common/components';
 import {
   PRODUCT_IMAGE,
@@ -74,13 +75,8 @@ class ImageSlider extends Component {
 
   currentSlide = 0;
 
-  /**
-   * @param {boolean} hasImages Tells if the slider rendered images.
-   */
-  handleOpenGallery = (hasImages) => {
-    if (hasImages) {
-      this.props.navigate(this.currentSlide);
-    }
+  handleOpenGallery = () => {
+    this.props.navigate(this.currentSlide);
   };
 
   handleSlideChange = (currentSlide) => {
@@ -95,6 +91,9 @@ class ImageSlider extends Component {
     const { product, images, 'aria-hidden': ariaHidden } = this.props;
     let content;
     let imagesByIndex = [];
+
+    let onClick = this.handleOpenGallery;
+    let onKeyDown = this.handleOpenGallery;
 
     if (product && Array.isArray(images) && images.length > 1) {
       imagesByIndex = getImagesByIndex(images);
@@ -125,6 +124,8 @@ class ImageSlider extends Component {
           resolutions={fallbackResolutions}
         />
       );
+      onClick = noop;
+      onKeyDown = noop;
     }
 
     return (
@@ -133,8 +134,8 @@ class ImageSlider extends Component {
         <Portal name={PRODUCT_IMAGE}>
           <div
             data-test-id={`product: ${product ? product.name : ''}`}
-            onClick={() => { this.handleOpenGallery(!!imagesByIndex.length); }}
-            onKeyDown={() => { this.handleOpenGallery(!!imagesByIndex.length); }}
+            onClick={onClick}
+            onKeyDown={onKeyDown}
             role="button"
             tabIndex="0"
             aria-hidden={ariaHidden}

--- a/themes/theme-ios11/pages/Product/components/Media/components/ImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ImageSlider/index.jsx
@@ -74,14 +74,13 @@ class ImageSlider extends Component {
 
   currentSlide = 0;
 
-  handleOpenGallery = () => {
-    const { images } = this.props;
-
-    if (!images || (Array.isArray(images) && !images.length)) {
-      return;
+  /**
+   * @param {boolean} hasImages Tells if the slider rendered images.
+   */
+  handleOpenGallery = (hasImages) => {
+    if (hasImages) {
+      this.props.navigate(this.currentSlide);
     }
-
-    this.props.navigate(this.currentSlide);
   };
 
   handleSlideChange = (currentSlide) => {
@@ -95,9 +94,10 @@ class ImageSlider extends Component {
   render() {
     const { product, images, 'aria-hidden': ariaHidden } = this.props;
     let content;
+    let imagesByIndex = [];
 
     if (product && Array.isArray(images) && images.length > 1) {
-      const imagesByIndex = getImagesByIndex(images);
+      imagesByIndex = getImagesByIndex(images);
 
       if (imagesByIndex.length) {
         content = (
@@ -133,8 +133,8 @@ class ImageSlider extends Component {
         <Portal name={PRODUCT_IMAGE}>
           <div
             data-test-id={`product: ${product ? product.name : ''}`}
-            onClick={this.handleOpenGallery}
-            onKeyDown={this.handleOpenGallery}
+            onClick={() => { this.handleOpenGallery(!!imagesByIndex.length); }}
+            onKeyDown={() => { this.handleOpenGallery(!!imagesByIndex.length); }}
             role="button"
             tabIndex="0"
             aria-hidden={ariaHidden}

--- a/themes/theme-ios11/pages/Product/components/Media/components/ImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ImageSlider/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import noop from 'lodash/noop';
 import { Swiper, Portal } from '@shopgate/pwa-common/components';
 import {
   PRODUCT_IMAGE,
@@ -74,13 +75,8 @@ class ImageSlider extends Component {
 
   currentSlide = 0;
 
-  /**
-   * @param {boolean} hasImages Tells if the slider rendered images.
-   */
-  handleOpenGallery = (hasImages) => {
-    if (hasImages) {
-      this.props.navigate(this.currentSlide);
-    }
+  handleOpenGallery = () => {
+    this.props.navigate(this.currentSlide);
   };
 
   handleSlideChange = (currentSlide) => {
@@ -95,6 +91,8 @@ class ImageSlider extends Component {
     const { product, images, 'aria-hidden': ariaHidden } = this.props;
     let content;
     let imagesByIndex = [];
+    let onClick = this.handleOpenGallery;
+    let onKeyDown = this.handleOpenGallery;
 
     if (product && Array.isArray(images) && images.length > 1) {
       imagesByIndex = getImagesByIndex(images);
@@ -125,6 +123,8 @@ class ImageSlider extends Component {
           resolutions={fallbackResolutions}
         />
       );
+      onClick = noop;
+      onKeyDown = noop;
     }
 
     return (
@@ -133,8 +133,8 @@ class ImageSlider extends Component {
         <Portal name={PRODUCT_IMAGE}>
           <div
             data-test-id={`product: ${product ? product.name : ''}`}
-            onClick={() => { this.handleOpenGallery(!!imagesByIndex.length); }}
-            onKeyDown={() => { this.handleOpenGallery(!!imagesByIndex.length); }}
+            onClick={onClick}
+            onKeyDown={onKeyDown}
             role="button"
             tabIndex="0"
             aria-hidden={ariaHidden}


### PR DESCRIPTION
# Description
This ticket fixes an issue where it was possible to open the gallery page from the product page when a placeholder image was clicked.

As an addition to the bugfix, non core extensions are excluded from jest tests from now.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

