### PR TITLE
Added supported tracking services to the options for tracking plugins

### DIFF
--- a/libraries/core/helpers/version.js
+++ b/libraries/core/helpers/version.js
@@ -36,6 +36,7 @@ export const defaultClientInformation = {
     },
     model,
   },
+  supportedAnalyticsServices: [],
 };
 
 /**

--- a/libraries/tracking/subscriptions/setup.js
+++ b/libraries/tracking/subscriptions/setup.js
@@ -26,6 +26,7 @@ export default function setup(subscribe) {
       type: get(clientInformationResponse, 'value.device.type', TYPE_PHONE),
       os: get(clientInformationResponse, 'value.device.os.platform', OS_ALL),
       state: getState(),
+      services: [get(clientInformationResponse, 'value.device.supportedAnalyticsServices', [])],
     };
 
     // TODO: instantiate the UnifiedPlugin only if a native tracker is configured (FB, AppsFlyer)

--- a/libraries/tracking/subscriptions/setup.js
+++ b/libraries/tracking/subscriptions/setup.js
@@ -26,7 +26,7 @@ export default function setup(subscribe) {
       type: get(clientInformationResponse, 'value.device.type', TYPE_PHONE),
       os: get(clientInformationResponse, 'value.device.os.platform', OS_ALL),
       state: getState(),
-      services: [get(clientInformationResponse, 'value.device.supportedAnalyticsServices', [])],
+      services: get(clientInformationResponse, 'value.device.supportedAnalyticsServices', []),
     };
 
     // TODO: instantiate the UnifiedPlugin only if a native tracker is configured (FB, AppsFlyer)


### PR DESCRIPTION
# Description
This ticket is about to extend the initialization options for tracking plugins. From now on they also receive a list of tracking SDKs which are active within the native part of the Engage app.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
