### PR TITLE
Fixed inconsistent spacing from the Browse page of the iOS theme

### DIFF
--- a/themes/theme-ios11/pages/Browse/components/Content/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Browse/components/Content/__snapshots__/spec.jsx.snap
@@ -18,12 +18,7 @@ exports[`<Content /> should render 1`] = `
   >
     <Connect(BackBar) />
     <Headline
-      style={
-        Object {
-          "marginLeft": 20,
-          "marginRight": 20,
-        }
-      }
+      style={null}
       tag="h1"
       text=""
     />

--- a/themes/theme-ios11/pages/Browse/components/Content/index.jsx
+++ b/themes/theme-ios11/pages/Browse/components/Content/index.jsx
@@ -4,7 +4,6 @@ import { BackBar } from 'Components/AppBar/presets';
 import Headline from 'Components/Headline';
 import SearchField from '../SearchField';
 import RootCategories from '../RootCategories';
-import styles from './styles';
 
 /**
  * The BrowseContent component.
@@ -19,7 +18,7 @@ const BrowseContent = ({ pageId, query }, context) => {
   return (
     <Fragment>
       <BackBar />
-      <Headline style={styles.headline} text={__('titles.browse')} tag="h1" />
+      <Headline text={__('titles.browse')} tag="h1" />
       <SearchField pageId={pageId} query={query} />
       <RootCategories />
     </Fragment>

--- a/themes/theme-ios11/pages/Browse/components/Content/styles.js
+++ b/themes/theme-ios11/pages/Browse/components/Content/styles.js
@@ -1,8 +1,0 @@
-const headline = {
-  marginLeft: 20,
-  marginRight: 20,
-};
-
-export default {
-  headline,
-};

--- a/themes/theme-ios11/pages/Browse/components/RootCategories/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Browse/components/RootCategories/__snapshots__/spec.jsx.snap
@@ -42,8 +42,6 @@ exports[`<RootCategories /> should render category list with root categories fro
         <Headline
           style={
             Object {
-              "marginLeft": 20,
-              "marginRight": 20,
               "marginTop": 20,
             }
           }

--- a/themes/theme-ios11/pages/Browse/components/RootCategories/styles.js
+++ b/themes/theme-ios11/pages/Browse/components/RootCategories/styles.js
@@ -1,6 +1,4 @@
 const headline = {
-  marginLeft: 20,
-  marginRight: 20,
   marginTop: 20,
 };
 

--- a/themes/theme-ios11/pages/Browse/components/SearchField/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/__snapshots__/spec.jsx.snap
@@ -30,7 +30,7 @@ exports[`<Content /> Check search field should render with initial search query 
         data-test-id="SearchField"
       >
         <div
-          className="css-1jyozbi"
+          className="css-2ciheh"
         >
           <div
             className="css-1utu657"
@@ -169,7 +169,7 @@ exports[`<Content /> Check search field should render with initial search query 
           </div>
           <div>
             <button
-              className="css-1su7ayj css-gyrv08"
+              className="css-1ctsi2c css-gyrv08"
               onClick={[Function]}
             >
               <Translate
@@ -222,7 +222,7 @@ exports[`<Content /> Check search field should show suggestions when focused 1`]
         data-test-id="SearchField"
       >
         <div
-          className="css-1jyozbi"
+          className="css-2ciheh"
         >
           <div
             className="css-1utu657"
@@ -317,7 +317,7 @@ exports[`<Content /> Check search field should show suggestions when focused 1`]
           </div>
           <div>
             <button
-              className="css-1su7ayj"
+              className="css-1ctsi2c"
               onClick={[Function]}
             >
               <Translate

--- a/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/__snapshots__/spec.jsx.snap
@@ -18,7 +18,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
     className="css-7w6rep css-90ryaa"
   >
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo"
       key="foo"
       onClick={[Function]}
@@ -27,7 +27,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
       foo
     </button>
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo bar"
       key="foo bar"
       onClick={[Function]}
@@ -36,7 +36,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
       foo bar
     </button>
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo bar buz"
       key="foo bar buz"
       onClick={[Function]}
@@ -45,7 +45,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
       foo bar buz
     </button>
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo bar buz quz"
       key="foo bar buz quz"
       onClick={[Function]}
@@ -75,7 +75,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
     className="css-7w6rep css-90ryaa"
   >
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo"
       key="foo"
       onClick={[Function]}
@@ -84,7 +84,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
       foo
     </button>
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo bar"
       key="foo bar"
       onClick={[Function]}
@@ -93,7 +93,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
       foo bar
     </button>
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo bar buz"
       key="foo bar buz"
       onClick={[Function]}
@@ -102,7 +102,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
       foo bar buz
     </button>
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo bar buz quz"
       key="foo bar buz quz"
       onClick={[Function]}
@@ -132,7 +132,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
     className="css-7w6rep css-90ryaa"
   >
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo bar buz quz"
       key="foo bar buz quz"
       onClick={[Function]}
@@ -141,7 +141,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
       foo bar buz quz
     </button>
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo bar buz"
       key="foo bar buz"
       onClick={[Function]}
@@ -150,7 +150,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
       foo bar buz
     </button>
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo bar"
       key="foo bar"
       onClick={[Function]}
@@ -159,7 +159,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
       foo bar
     </button>
     <button
-      className="css-hxezjv"
+      className="css-crua9x"
       data-test-id="searchSuggestion foo"
       key="foo"
       onClick={[Function]}
@@ -205,7 +205,7 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
         className="css-7w6rep css-90ryaa"
       >
         <button
-          className="css-hxezjv"
+          className="css-crua9x"
           data-test-id="searchSuggestion foo"
           key="foo"
           onClick={[Function]}
@@ -214,7 +214,7 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
           foo
         </button>
         <button
-          className="css-hxezjv"
+          className="css-crua9x"
           data-test-id="searchSuggestion foo bar"
           key="foo bar"
           onClick={[Function]}
@@ -223,7 +223,7 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
           foo bar
         </button>
         <button
-          className="css-hxezjv"
+          className="css-crua9x"
           data-test-id="searchSuggestion foo bar buz"
           key="foo bar buz"
           onClick={[Function]}
@@ -232,7 +232,7 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
           foo bar buz
         </button>
         <button
-          className="css-hxezjv"
+          className="css-crua9x"
           data-test-id="searchSuggestion foo bar buz quz"
           key="foo bar buz quz"
           onClick={[Function]}

--- a/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/style.js
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/style.js
@@ -34,7 +34,7 @@ const item = css({
   display: 'flex',
   marginTop: 2,
   outline: 0,
-  padding: '10px 16px 10px 50px',
+  padding: '10px 16px 10px 46px',
   width: '100%',
   textAlign: 'left',
 }).toString();

--- a/themes/theme-ios11/pages/Browse/components/SearchField/style.js
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/style.js
@@ -9,8 +9,8 @@ const container = css({
   flexDirection: 'row',
   flexWrap: 'nowrap',
   marginBottom: 4,
-  paddingLeft: 20,
-  paddingRight: 20,
+  paddingLeft: 16,
+  paddingRight: 16,
 }).toString();
 
 const inputWrapper = css({
@@ -51,7 +51,7 @@ const button = css({
   lineHeight: '36px',
   color: colors.accent,
   paddingTop: 0,
-  paddingLeft: 20,
+  paddingLeft: 16,
   paddingRight: 0,
   marginLeft: 0,
   marginRight: 0,


### PR DESCRIPTION
# Description
This ticket fixes a wrong left / right spacing on the browse page of the iOS theme. The default spacing within the theme is 16px, but it was set to 20px.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
