### PR TITLE
Product Image does not flicker when opening the PDP for the first time.

### DIFF
--- a/libraries/engage/product/components/Media/MediaImage.jsx
+++ b/libraries/engage/product/components/Media/MediaImage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Image from '@shopgate/pwa-common/components/Image';
-import appConfig, { themeConfig } from '@shopgate/pwa-common/helpers/config';
+import appConfig from '@shopgate/pwa-common/helpers/config';
 import { SurroundPortals } from '../../../components';
 import { PORTAL_PRODUCT_IMAGE } from '../../../components/constants';
 import { buildMediaImageUrl } from './helpers';
@@ -10,8 +10,6 @@ import { useWidgetSettings } from '../../../core';
 import { defaultProps, propTypes } from './props';
 import MediaPlaceholder from './MediaPlaceholder';
 import { innerShadow } from './style';
-
-const { colors } = themeConfig;
 
 /**
  * The featured image component.
@@ -46,7 +44,7 @@ const MediaImage = ({
         src={buildMediaImageUrl(url, params)}
         alt={altText}
         className={classes}
-        backgroundColor={colors.light}
+        backgroundColor="transparent"
         onError={() => setPlaceholderEnabled(true)}
       />
     </SurroundPortals>

--- a/libraries/engage/product/components/ProductImage/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/product/components/ProductImage/__snapshots__/spec.jsx.snap
@@ -12,7 +12,7 @@ exports[`<ProductImage /> should apply an inner shadow to the image if turned of
       alt={null}
       animating={true}
       aria-hidden={null}
-      backgroundColor="#f2f2f2"
+      backgroundColor="transparent"
       className="css-3hjqnz"
       forcePlaceholder={false}
       highestResolutionLoaded={[Function]}
@@ -78,7 +78,7 @@ exports[`<ProductImage /> should not apply an inner shadow to the image if turne
       alt={null}
       animating={true}
       aria-hidden={null}
-      backgroundColor="#f2f2f2"
+      backgroundColor="transparent"
       className=""
       forcePlaceholder={false}
       highestResolutionLoaded={[Function]}
@@ -218,7 +218,7 @@ exports[`<ProductImage /> should render the image without a placeholder 1`] = `
       alt={null}
       animating={true}
       aria-hidden={null}
-      backgroundColor="#f2f2f2"
+      backgroundColor="transparent"
       className="css-3hjqnz"
       forcePlaceholder={false}
       highestResolutionLoaded={[Function]}

--- a/libraries/engage/product/components/ProductImage/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/product/components/ProductImage/__snapshots__/spec.jsx.snap
@@ -12,10 +12,11 @@ exports[`<ProductImage /> should apply an inner shadow to the image if turned of
       alt={null}
       animating={true}
       aria-hidden={null}
-      backgroundColor="transparent"
+      backgroundColor="#f2f2f2"
       className="css-3hjqnz"
       forcePlaceholder={false}
       highestResolutionLoaded={[Function]}
+      noBackground={false}
       onError={[Function]}
       onLoad={null}
       ratio={null}
@@ -78,10 +79,11 @@ exports[`<ProductImage /> should not apply an inner shadow to the image if turne
       alt={null}
       animating={true}
       aria-hidden={null}
-      backgroundColor="transparent"
+      backgroundColor="#f2f2f2"
       className=""
       forcePlaceholder={false}
       highestResolutionLoaded={[Function]}
+      noBackground={false}
       onError={[Function]}
       onLoad={null}
       ratio={null}
@@ -119,6 +121,7 @@ exports[`<ProductImage /> should not apply an inner shadow to the image if turne
   className={null}
   forcePlaceholder={false}
   highestResolutionLoaded={[Function]}
+  noBackground={false}
   ratio={null}
   resolutions={
     Array [
@@ -218,10 +221,11 @@ exports[`<ProductImage /> should render the image without a placeholder 1`] = `
       alt={null}
       animating={true}
       aria-hidden={null}
-      backgroundColor="transparent"
+      backgroundColor="#f2f2f2"
       className="css-3hjqnz"
       forcePlaceholder={false}
       highestResolutionLoaded={[Function]}
+      noBackground={false}
       onError={[Function]}
       onLoad={null}
       ratio={null}

--- a/libraries/engage/product/components/ProductImage/index.jsx
+++ b/libraries/engage/product/components/ProductImage/index.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import classnames from 'classnames';
-import appConfig, { themeConfig } from '@shopgate/pwa-common/helpers/config';
+import appConfig from '@shopgate/pwa-common/helpers/config';
 import Image from '@shopgate/pwa-common/components/Image';
 import PlaceholderIcon from '@shopgate/pwa-ui-shared/icons/PlaceholderIcon';
 import SurroundPortals from '@shopgate/pwa-common/components/SurroundPortals';
@@ -10,8 +10,6 @@ import { withWidgetSettings } from '../../../core/hocs/withWidgetSettings';
 import { PORTAL_PRODUCT_IMAGE } from '../../../components/constants';
 
 import styles from './style';
-
-const { colors } = themeConfig;
 
 /**
  * The product image component.
@@ -126,8 +124,8 @@ class ProductImage extends Component {
         <SurroundPortals portalName={PORTAL_PRODUCT_IMAGE} >
           <div
             className={classnames(styles.placeholderContainer, {
-            [styles.innerShadow]: showInnerShadow,
-          })}
+              [styles.innerShadow]: showInnerShadow,
+            })}
             aria-hidden={this.props['aria-hidden']}
           >
             <div className={styles.placeholderContent} data-test-id="placeHolder">
@@ -145,7 +143,7 @@ class ProductImage extends Component {
           <Image
             {...this.props}
             className={showInnerShadow ? styles.innerShadow : ''}
-            backgroundColor={colors.light}
+            backgroundColor="transparent"
             onError={this.imageLoadingFailed}
           />
         </div>

--- a/libraries/engage/product/components/ProductImage/index.jsx
+++ b/libraries/engage/product/components/ProductImage/index.jsx
@@ -2,14 +2,15 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import classnames from 'classnames';
-import appConfig from '@shopgate/pwa-common/helpers/config';
+import appConfig, { themeConfig } from '@shopgate/pwa-common/helpers/config';
 import Image from '@shopgate/pwa-common/components/Image';
 import PlaceholderIcon from '@shopgate/pwa-ui-shared/icons/PlaceholderIcon';
 import SurroundPortals from '@shopgate/pwa-common/components/SurroundPortals';
 import { withWidgetSettings } from '../../../core/hocs/withWidgetSettings';
 import { PORTAL_PRODUCT_IMAGE } from '../../../components/constants';
-
 import styles from './style';
+
+const { colors } = themeConfig;
 
 /**
  * The product image component.
@@ -28,6 +29,7 @@ class ProductImage extends Component {
     className: PropTypes.string,
     forcePlaceholder: PropTypes.bool,
     highestResolutionLoaded: PropTypes.func,
+    noBackground: PropTypes.bool,
     ratio: PropTypes.arrayOf(PropTypes.number),
     resolutions: PropTypes.arrayOf(PropTypes.shape({
       width: PropTypes.number.isRequired,
@@ -46,6 +48,7 @@ class ProductImage extends Component {
     className: null,
     forcePlaceholder: false,
     highestResolutionLoaded: () => { },
+    noBackground: false,
     ratio: null,
     resolutions: [
       {
@@ -112,6 +115,7 @@ class ProductImage extends Component {
    * @returns {JSX}
    */
   render() {
+    const { noBackground } = this.props;
     let { showInnerShadow } = this.props.widgetSettings;
 
     if (typeof showInnerShadow === 'undefined') {
@@ -143,7 +147,7 @@ class ProductImage extends Component {
           <Image
             {...this.props}
             className={showInnerShadow ? styles.innerShadow : ''}
-            backgroundColor="transparent"
+            backgroundColor={noBackground ? 'transparent' : colors.light}
             onError={this.imageLoadingFailed}
           />
         </div>

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -128,6 +128,11 @@ class ProductImageSlider extends Component {
       onKeyDown = noop;
     }
 
+    const imageStyle = product ? {
+      background: `url(${product.featuredImageUrl}?w=440&h=440&q=70&zc=resize&fillc=FFFFFF)`,
+      backgroundSize: 'contain',
+    } : null;
+
     return (
       <Fragment>
         <Portal name={PRODUCT_IMAGE_BEFORE} />
@@ -139,6 +144,7 @@ class ProductImageSlider extends Component {
             role="button"
             tabIndex="0"
             aria-hidden={ariaHidden}
+            style={imageStyle}
           >
             {content}
           </div>

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -108,7 +108,7 @@ class ProductImageSlider extends Component {
           >
             {imagesByIndex.map(imagesInIndex => (
               <Swiper.Item key={`${product.id}-${imagesInIndex[0]}`}>
-                <ProductImage srcmap={imagesInIndex} animating={false} />
+                <ProductImage srcmap={imagesInIndex} animating={false} noBackground />
               </Swiper.Item>
             ))}
           </Swiper>

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import noop from 'lodash/noop';
+import { getActualImageSource } from '@shopgate/engage/core';
 import { Swiper, Portal } from '@shopgate/pwa-common/components';
 import {
   PRODUCT_IMAGE,
@@ -129,7 +130,7 @@ class ProductImageSlider extends Component {
     }
 
     const imageStyle = product ? {
-      background: `url(${product.featuredImageUrl}?w=440&h=440&q=70&zc=resize&fillc=FFFFFF)`,
+      background: `url(${getActualImageSource(product.featuredImageUrl, fallbackResolutions[0])})`,
       backgroundSize: 'contain',
     } : null;
 

--- a/themes/theme-gmd/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-gmd/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
@@ -145,6 +145,7 @@ exports[`<ProductCard /> should render as expected 1`] = `
                     forcePlaceholder={false}
                     highestResolutionLoaded={[Function]}
                     itemProp="image"
+                    noBackground={false}
                     ratio={null}
                     resolutions={
                       Array [

--- a/themes/theme-gmd/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-gmd/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
@@ -79,6 +79,7 @@ exports[`<ProductCardRender /> should not render the discount badge when the is 
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -836,6 +837,7 @@ exports[`<ProductCardRender /> should not render the rating stars when there is 
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -1314,6 +1316,7 @@ exports[`<ProductCardRender /> should render as expected 1`] = `
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -2139,6 +2142,7 @@ exports[`<ProductCardRender /> should render with one row for the product name 1
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -2964,6 +2968,7 @@ exports[`<ProductCardRender /> should render without name 1`] = `
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -3753,6 +3758,7 @@ exports[`<ProductCardRender /> should render without prices 1`] = `
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -4316,6 +4322,7 @@ exports[`<ProductCardRender /> should render without rating 1`] = `
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -128,6 +128,11 @@ class ProductImageSlider extends Component {
       onKeyDown = noop;
     }
 
+    const imageStyle = product ? {
+      background: `url(${product.featuredImageUrl}?w=440&h=440&q=70&zc=resize&fillc=FFFFFF)`,
+      backgroundSize: 'contain',
+    } : null;
+
     return (
       <Fragment>
         <Portal name={PRODUCT_IMAGE_BEFORE} />
@@ -139,6 +144,7 @@ class ProductImageSlider extends Component {
             role="button"
             tabIndex="0"
             aria-hidden={ariaHidden}
+            style={imageStyle}
           >
             {content}
           </div>

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -108,7 +108,7 @@ class ProductImageSlider extends Component {
           >
             {imagesByIndex.map(imagesInIndex => (
               <Swiper.Item key={`${product.id}-${imagesInIndex[0]}`}>
-                <ProductImage srcmap={imagesInIndex} animating={false} />
+                <ProductImage srcmap={imagesInIndex} animating={false} noBackground />
               </Swiper.Item>
             ))}
           </Swiper>

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import noop from 'lodash/noop';
+import { getActualImageSource } from '@shopgate/engage/core';
 import { Swiper, Portal } from '@shopgate/pwa-common/components';
 import {
   PRODUCT_IMAGE,
@@ -129,7 +130,7 @@ class ProductImageSlider extends Component {
     }
 
     const imageStyle = product ? {
-      background: `url(${product.featuredImageUrl}?w=440&h=440&q=70&zc=resize&fillc=FFFFFF)`,
+      background: `url(${getActualImageSource(product.featuredImageUrl, fallbackResolutions[0])})`,
       backgroundSize: 'contain',
     } : null;
 

--- a/themes/theme-ios11/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
@@ -145,6 +145,7 @@ exports[`<ProductCard /> should render as expected 1`] = `
                     forcePlaceholder={false}
                     highestResolutionLoaded={[Function]}
                     itemProp="image"
+                    noBackground={false}
                     ratio={null}
                     resolutions={
                       Array [

--- a/themes/theme-ios11/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
@@ -79,6 +79,7 @@ exports[`<ProductCardRender /> should not render the discount badge when the is 
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -836,6 +837,7 @@ exports[`<ProductCardRender /> should not render the rating stars when there is 
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -1314,6 +1316,7 @@ exports[`<ProductCardRender /> should render as expected 1`] = `
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -2139,6 +2142,7 @@ exports[`<ProductCardRender /> should render with one row for the product name 1
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -2964,6 +2968,7 @@ exports[`<ProductCardRender /> should render without name 1`] = `
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -3753,6 +3758,7 @@ exports[`<ProductCardRender /> should render without prices 1`] = `
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [
@@ -4316,6 +4322,7 @@ exports[`<ProductCardRender /> should render without rating 1`] = `
               forcePlaceholder={false}
               highestResolutionLoaded={[Function]}
               itemProp="image"
+              noBackground={false}
               ratio={null}
               resolutions={
                 Array [


### PR DESCRIPTION
# Description

If the featured image of a product has already been loaded before the user enters the Product Detail Page, this browser cached featured image will be shown underneath any other image or media related implementation, such as the image slider or the media slider. This will prevent the UI from flickering when the elements are exchanged.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Navigate to a category page and open multiple products. Pay attention to the product image on the PDP. It should not flicker when transitioning from the featured image to a slider or higher resolution.
