### PR TITLE
Changed the search component in theme-gmd to use the event's currentTarget propery over the target to obtain the updated query.

### DIFF
--- a/themes/theme-gmd/components/Search/components/Suggestions/components/List/index.spec.jsx
+++ b/themes/theme-gmd/components/Search/components/Suggestions/components/List/index.spec.jsx
@@ -82,6 +82,6 @@ describe('<SuggestionList />', () => {
 
     wrapper.find('button').at(2).simulate('click');
     const [[event]] = onClickMock.mock.calls;
-    expect(event.target.value).toBe('foo bar buz');
+    expect(event.currentTarget.value).toBe('foo bar buz');
   });
 });

--- a/themes/theme-gmd/components/Search/components/Suggestions/components/List/index.spec.jsx
+++ b/themes/theme-gmd/components/Search/components/Suggestions/components/List/index.spec.jsx
@@ -82,6 +82,6 @@ describe('<SuggestionList />', () => {
 
     wrapper.find('button').at(2).simulate('click');
     const [[event]] = onClickMock.mock.calls;
-    expect(event.currentTarget.value).toBe('foo bar buz');
+    expect(event.target.value).toBe('foo bar buz');
   });
 });

--- a/themes/theme-gmd/components/Search/index.jsx
+++ b/themes/theme-gmd/components/Search/index.jsx
@@ -94,7 +94,7 @@ class Search extends Component {
    * @param {Event} event The event.
    */
   update = (event) => {
-    const query = event.target.value;
+    const query = event.currentTarget.value;
     this.fetchSuggestions(query);
     this.setState({ query });
   };
@@ -114,7 +114,7 @@ class Search extends Component {
   fetchResults = (event) => {
     event.preventDefault();
 
-    const searchQuery = (event.target.value || this.state.query).trim();
+    const searchQuery = (event.currentTarget.value || this.state.query).trim();
 
     if (searchQuery.length === 0) {
       return;


### PR DESCRIPTION
# Description

This PR resolves the wrong target in #793. Alternatively we could also catch `e` ourself, set the needed value to the one of `currentTarget` and call the original onClick method with `e`.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Create any html elements in the button element for the search suggestion item and click on the element. It should correctly get the value of the element with the event listener, not one of its children.