### PR TITLE
Improved iOS status bar style update system

### DIFF
--- a/libraries/engage/core/actions/__tests__/updateStatusBarBackground.spec.js
+++ b/libraries/engage/core/actions/__tests__/updateStatusBarBackground.spec.js
@@ -32,13 +32,23 @@ describe('engage > core > actions > updateStatusBarBackground()', () => {
     expect(updateLegacyNavigationBar).toHaveBeenCalledTimes(1);
     expect(updateLegacyNavigationBar).toHaveBeenCalledWith({
       statusBarBackground: color,
+      isDefault: false,
     });
   });
 
-  it('should call the updateLegacyNavigationBar helper with an empty object when no color was passed', () => {
+  it('should call the updateLegacyNavigationBar helper with the isDefault flag', () => {
+    updateStatusBarBackground(null, true)(null, getState);
+    expect(isIos).toHaveBeenCalledWith(state);
+    expect(updateLegacyNavigationBar).toHaveBeenCalledTimes(1);
+    expect(updateLegacyNavigationBar).toHaveBeenCalledWith({
+      isDefault: true,
+    });
+  });
+
+  it('should call the updateLegacyNavigationBar helper with just the isDefault property when no color was passed', () => {
     updateStatusBarBackground()(null, getState);
     expect(isIos).toHaveBeenCalledWith(state);
     expect(updateLegacyNavigationBar).toHaveBeenCalledTimes(1);
-    expect(updateLegacyNavigationBar).toHaveBeenCalledWith({});
+    expect(updateLegacyNavigationBar).toHaveBeenCalledWith({ isDefault: false });
   });
 });

--- a/libraries/engage/core/actions/updateStatusBarBackground.js
+++ b/libraries/engage/core/actions/updateStatusBarBackground.js
@@ -4,10 +4,10 @@ import { updateLegacyNavigationBar } from '../helpers/updateLegacyNavigationBar'
 /**
  * Updates the status bar background on iOS devices.
  * @param {string} color The background color.
- * @param {boolean} setDefault When set, the status bar will init with the color on next app start.
+ * @param {boolean} isDefault When set, the status bar will init with the color on next app start.
  * @return {Function} A redux thunk.
  */
-export default function updateStatusBarBackground(color, setDefault = false) {
+export default function updateStatusBarBackground(color, isDefault = false) {
   return (dispatch, getState) => {
     if (!isIos(getState())) {
       return;
@@ -15,7 +15,7 @@ export default function updateStatusBarBackground(color, setDefault = false) {
 
     updateLegacyNavigationBar({
       ...color && ({ statusBarBackground: color }),
-      isDefault: setDefault,
+      isDefault,
     });
   };
 }

--- a/libraries/engage/core/actions/updateStatusBarBackground.js
+++ b/libraries/engage/core/actions/updateStatusBarBackground.js
@@ -4,9 +4,10 @@ import { updateLegacyNavigationBar } from '../helpers/updateLegacyNavigationBar'
 /**
  * Updates the status bar background on iOS devices.
  * @param {string} color The background color.
+ * @param {boolean} setDefault When set, the status bar will init with the color on next app start.
  * @return {Function} A redux thunk.
  */
-export default function updateStatusBarBackground(color) {
+export default function updateStatusBarBackground(color, setDefault = false) {
   return (dispatch, getState) => {
     if (!isIos(getState())) {
       return;
@@ -14,6 +15,7 @@ export default function updateStatusBarBackground(color) {
 
     updateLegacyNavigationBar({
       ...color && ({ statusBarBackground: color }),
+      isDefault: setDefault,
     });
   };
 }

--- a/libraries/engage/core/helpers/__tests__/updateLegacyNavigationBar.spec.js
+++ b/libraries/engage/core/helpers/__tests__/updateLegacyNavigationBar.spec.js
@@ -88,4 +88,25 @@ describe('updateLegacyNavigationBar()', () => {
       }],
     });
   });
+
+  it('should broadcast when called with the isDefault option', () => {
+    const options = {
+      isDefault: true,
+      statusBarStyle: 'dark',
+      targetTab: 'cart',
+      statusBarBackground: 'red',
+    };
+    updateLegacyNavigationBar(options);
+    expect(broadcastEvent).toHaveBeenCalledWith({
+      event: 'updateNavigationBarStyle',
+      parameters: [{
+        isDefault: true,
+        targetTab: 'cart',
+        styles: {
+          statusBarBackground: 'red',
+        },
+        statusBarStyle: 'dark',
+      }],
+    });
+  });
 });

--- a/libraries/engage/core/helpers/updateLegacyNavigationBar.js
+++ b/libraries/engage/core/helpers/updateLegacyNavigationBar.js
@@ -7,6 +7,7 @@ import { broadcastEvent } from '../index';
  */
 export const updateLegacyNavigationBar = (options = {}) => {
   const targetTab = options.targetTab || 'main';
+  const { isDefault } = options;
   const styles = {
     ...options.color && { color: options.color },
     ...options.background && { background: options.background },
@@ -31,6 +32,7 @@ export const updateLegacyNavigationBar = (options = {}) => {
     event: 'updateNavigationBarStyle',
     parameters: [{
       ...statusBarStyle && { statusBarStyle },
+      ...isDefault && { isDefault },
       targetTab,
       styles,
     }],

--- a/themes/theme-gmd/components/AppBar/presets/DefaultBar/connector.js
+++ b/themes/theme-gmd/components/AppBar/presets/DefaultBar/connector.js
@@ -17,8 +17,8 @@ function makeMapStateToProps() {
  * @returns {Object}
  */
 const mapDispatchToProps = dispatch => ({
-  updateStatusBar: ({ background }, setDefault) => {
-    dispatch(updateStatusBarBackground(background, setDefault));
+  updateStatusBar: ({ background }, isDefault) => {
+    dispatch(updateStatusBarBackground(background, isDefault));
   },
   resetStatusBar: () => {
     dispatch(updateStatusBarBackground());

--- a/themes/theme-gmd/components/AppBar/presets/DefaultBar/connector.js
+++ b/themes/theme-gmd/components/AppBar/presets/DefaultBar/connector.js
@@ -17,8 +17,8 @@ function makeMapStateToProps() {
  * @returns {Object}
  */
 const mapDispatchToProps = dispatch => ({
-  updateStatusBar: ({ background }) => {
-    dispatch(updateStatusBarBackground(background));
+  updateStatusBar: ({ background }, setDefault) => {
+    dispatch(updateStatusBarBackground(background, setDefault));
   },
   resetStatusBar: () => {
     dispatch(updateStatusBarBackground());

--- a/themes/theme-gmd/components/AppBar/presets/DefaultBar/index.jsx
+++ b/themes/theme-gmd/components/AppBar/presets/DefaultBar/index.jsx
@@ -9,7 +9,7 @@ import {
   APP_BAR_DEFAULT,
   APP_BAR_DEFAULT_AFTER,
 } from '@shopgate/pwa-common/constants/Portals';
-import { withRoute, withWidgetSettings, withApp } from '@shopgate/engage/core';
+import { withRoute, withWidgetSettings, withApp, INDEX_PATH } from '@shopgate/engage/core';
 import { ViewContext } from 'Components/View/context';
 import AppBarIcon from './components/Icon';
 import CartButton from './components/CartButton';
@@ -68,7 +68,7 @@ class AppBarDefault extends PureComponent {
     }
 
     if (this.props.route.visible) {
-      this.props.updateStatusBar(this.props.widgetSettings);
+      this.updateStatusBar();
     }
   }
 
@@ -91,7 +91,7 @@ class AppBarDefault extends PureComponent {
 
     if (routeDidEnter || engageDidEnter) {
       // Sync the colors of the app bar when the route with the bar came visible.
-      this.props.updateStatusBar(this.props.widgetSettings);
+      this.updateStatusBar();
     }
 
     if (engageWillLeave) {
@@ -112,8 +112,20 @@ class AppBarDefault extends PureComponent {
     if (visible) {
       this.props.resetStatusBar();
     } else {
-      this.props.updateStatusBar(this.props.widgetSettings);
+      this.updateStatusBar();
     }
+  }
+
+  /**
+   * Updates the status bar styling.
+   */
+  updateStatusBar() {
+    const { pathname } = this.props.route;
+    /**
+     * The settings for the startpage need to be preserved within the statusbar to optimize
+     * the initial rendering at the app start.
+     */
+    this.props.updateStatusBar(this.props.widgetSettings, pathname === INDEX_PATH);
   }
 
   /**

--- a/themes/theme-ios11/components/AppBar/presets/DefaultBar/connector.js
+++ b/themes/theme-ios11/components/AppBar/presets/DefaultBar/connector.js
@@ -17,8 +17,8 @@ function makeMapStateToProps() {
  * @returns {Object}
  */
 const mapDispatchToProps = dispatch => ({
-  updateStatusBar: ({ background }, setDefault) => {
-    dispatch(updateStatusBarBackground(background, setDefault));
+  updateStatusBar: ({ background }, isDefault) => {
+    dispatch(updateStatusBarBackground(background, isDefault));
   },
   resetStatusBar: () => {
     dispatch(updateStatusBarBackground());

--- a/themes/theme-ios11/components/AppBar/presets/DefaultBar/connector.js
+++ b/themes/theme-ios11/components/AppBar/presets/DefaultBar/connector.js
@@ -17,8 +17,8 @@ function makeMapStateToProps() {
  * @returns {Object}
  */
 const mapDispatchToProps = dispatch => ({
-  updateStatusBar: ({ background }) => {
-    dispatch(updateStatusBarBackground(background));
+  updateStatusBar: ({ background }, setDefault) => {
+    dispatch(updateStatusBarBackground(background, setDefault));
   },
   resetStatusBar: () => {
     dispatch(updateStatusBarBackground());

--- a/themes/theme-ios11/components/AppBar/presets/DefaultBar/index.jsx
+++ b/themes/theme-ios11/components/AppBar/presets/DefaultBar/index.jsx
@@ -8,7 +8,7 @@ import {
   APP_BAR_DEFAULT_AFTER,
 } from '@shopgate/pwa-common/constants/Portals';
 import { AppBar } from '@shopgate/pwa-ui-ios';
-import { withRoute, withWidgetSettings, withApp } from '@shopgate/engage/core';
+import { withRoute, withWidgetSettings, withApp, INDEX_PATH } from '@shopgate/engage/core';
 import { ViewContext } from 'Components/View/context';
 import AppBarIcon from './components/Icon';
 import ProgressBar from './components/ProgressBar';
@@ -65,7 +65,7 @@ class AppBarDefault extends PureComponent {
     }
 
     if (this.props.route.visible) {
-      this.props.updateStatusBar(this.props.widgetSettings);
+      this.updateStatusBar();
     }
   }
 
@@ -88,13 +88,25 @@ class AppBarDefault extends PureComponent {
 
     if (routeDidEnter || engageDidEnter) {
       // Sync the colors of the app bar when the route with the bar came visible.
-      this.props.updateStatusBar(this.props.widgetSettings);
+      this.updateStatusBar();
     }
 
     if (engageWillLeave) {
       // Reset the status bar when Engage goes into the background.
       this.props.resetStatusBar();
     }
+  }
+
+  /**
+   * Updates the status bar styling.
+   */
+  updateStatusBar() {
+    const { pathname } = this.props.route;
+    /**
+     * The settings for the startpage need to be preserved within the statusbar to optimize
+     * the initial rendering at the app start.
+     */
+    this.props.updateStatusBar(this.props.widgetSettings, pathname === INDEX_PATH);
   }
 
   /**


### PR DESCRIPTION
# Description
This ticket extends the system which syncs the styling of the AppBar component with the iOS status bar. The configuration of the start page will now be preserved within the app to improve the behaviour on app start.

Before the original styling was always visible for a short amount of time. This doesn't happen anymore after the first start after the configuration was changed.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
