### PR TITLE
Extended source data for the tracking system

### DIFF
--- a/libraries/common/selectors/router.js
+++ b/libraries/common/selectors/router.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import { isObject } from '../helpers/validation';
 
 /**
  * @param {Object} state The application state.
@@ -126,3 +127,48 @@ export function makeIsLastStackEntry() {
     }
   );
 }
+
+/**
+ * Creates a selector that retrieves the pattern of the route.
+ * @returns {Function}
+ */
+export const makeGetRoutePattern = () =>
+  /**
+   * Retrieves the route pattern.
+   * @param {Object} state The application state.
+   * @param {Object} props The component props.
+   * @returns {string|null} The pattern.
+   */
+  createSelector(
+    getCurrentRoute,
+    (route) => {
+      if (!route || !route.pattern) {
+        return null;
+      }
+
+      return route.pattern;
+    }
+  );
+
+/**
+ * Creates a selector that retrieves the value of a specific parameter from the route.
+ * @param {string} name The name of the desired parameter.
+ * @returns {Function}
+ */
+export const makeGetRouteParam = (name = '') =>
+  /**
+   * Retrieves a parameter from the route.
+   * @param {Object} state The application state.
+   * @param {Object} props The component props.
+   * @returns {string|null} The parameter value.
+   */
+  createSelector(
+    getCurrentParams,
+    (params) => {
+      if (!isObject(params)) {
+        return null;
+      }
+
+      return params[name] || null;
+    }
+  );

--- a/libraries/common/selectors/router.spec.js
+++ b/libraries/common/selectors/router.spec.js
@@ -1,4 +1,8 @@
-import { makeIsLastStackEntry } from './router';
+import {
+  makeIsLastStackEntry,
+  makeGetRoutePattern,
+  makeGetRouteParam,
+} from './router';
 
 const mockState = {
   router: {
@@ -12,7 +16,19 @@ const mockState = {
       pathname: '/some-route',
       pattern: '/some-route',
       state: {},
+      params: {
+        key: 'value',
+      },
     }],
+    currentRoute: {
+      id: '123',
+      pathname: '/some-route',
+      pattern: '/some-route',
+      state: {},
+      params: {
+        key: 'value',
+      },
+    },
   },
 };
 
@@ -40,6 +56,64 @@ describe('Router selectors', () => {
       const isLastStackEntry = makeIsLastStackEntry();
       const result = isLastStackEntry({ router: { stack: [] } }, { routeId: 'xyz' });
       expect(result).toBe(false);
+    });
+  });
+
+  describe('makeGetRoutePattern()', () => {
+    it('should create a fresh instance on every call', () => {
+      const instanceOne = makeGetRoutePattern();
+      const instanceTwo = makeGetRoutePattern();
+      expect(instanceOne).not.toBe(instanceTwo);
+    });
+
+    it('should return the expected route pattern for the current route', () => {
+      const getRoutePattern = makeGetRoutePattern();
+      const result = getRoutePattern(mockState, {});
+      expect(result).toBe('/some-route');
+    });
+
+    it('should return the expected route pattern for a route referenced by a routeId', () => {
+      const getRoutePattern = makeGetRoutePattern();
+      const result = getRoutePattern(mockState, { routeId: '123' });
+      expect(result).toBe('/some-route');
+    });
+
+    it('should return NULL when no route can be determined', () => {
+      const getRoutePattern = makeGetRoutePattern();
+      const result = getRoutePattern({ router: { stack: [] } }, { routeId: 'xyz' });
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('makeGetRouteParam()', () => {
+    it('should create a fresh instance on every call', () => {
+      const instanceOne = makeGetRouteParam();
+      const instanceTwo = makeGetRouteParam();
+      expect(instanceOne).not.toBe(instanceTwo);
+    });
+
+    it('should return the expected route param for the current route', () => {
+      const getRouteParam = makeGetRouteParam('key');
+      const result = getRouteParam(mockState, {});
+      expect(result).toBe('value');
+    });
+
+    it('should return the expected route pattern for a route referenced by a routeId', () => {
+      const getRouteParam = makeGetRouteParam('key');
+      const result = getRouteParam(mockState, { routeId: '123' });
+      expect(result).toBe('value');
+    });
+
+    it('should return NULL when no route params can be determined', () => {
+      const getRouteParam = makeGetRouteParam('key');
+      const result = getRouteParam(mockState, { routeId: 'abc' });
+      expect(result).toBe(null);
+    });
+
+    it('should return NULL when the requested parameter does not exist within the params', () => {
+      const getRouteParam = makeGetRouteParam('does-not-exist');
+      const result = getRouteParam(mockState);
+      expect(result).toBe(null);
     });
   });
 });

--- a/libraries/engage/page/index.js
+++ b/libraries/engage/page/index.js
@@ -1,12 +1,12 @@
 /** @module page */
-import { PAGE_PATH } from '@shopgate/pwa-common/constants/RoutePaths';
+import { PAGE_PATH, PAGE_PATTERN } from '@shopgate/pwa-common/constants/RoutePaths';
 
 // ACTIONS
 export { default as fetchPageConfig } from '@shopgate/pwa-common/actions/page/fetchPageConfig';
 
 // CONSTANTS
 export * from '@shopgate/pwa-common/constants/PageIDs';
-export { PAGE_PATH };
+export { PAGE_PATH, PAGE_PATTERN };
 
 // SELECTORS
 export * from '@shopgate/pwa-common/selectors/page';

--- a/libraries/tracking/helpers/index.js
+++ b/libraries/tracking/helpers/index.js
@@ -15,6 +15,7 @@ import {
 import { parse2dsQrCode } from '@shopgate/pwa-common-commerce/scanner/helpers';
 import core from '@shopgate/tracking-core/core/Core';
 import { shopNumber } from '@shopgate/pwa-common/helpers/config';
+import { i18n } from '@shopgate/engage/core';
 
 /**
  * Converts a price to a formatted string.
@@ -30,7 +31,7 @@ export const convertPriceToString = (price) => {
 };
 
 /**
- * Re-format a given product form the store.
+ * Re-format a given product from the store.
  * @param {Object} productData The product data from the store
  * @returns {Object|null} The formatted product.
  */
@@ -271,6 +272,76 @@ export const buildScannerUtmUrl = ({
   return `${newPath.pathname}${newPath.search}`;
 };
 
+/**
+ * Creates tracking data for a category.
+ * @param {Object} category The category data from the store.
+ * @returns {Object|null}
+ */
+export const createCategoryData = (category) => {
+  if (!category) {
+    return null;
+  }
+
+  const { name, id: uid, path } = category;
+
+  return {
+    uid,
+    name,
+    path,
+  };
+};
+
+/**
+ * Creates tracking data for the root category.
+ * @param {Object} rootCategory The category data from the store.
+ * @return {Object|null}
+ */
+export const createRootCategoryData = (rootCategory) => {
+  if (!rootCategory) {
+    return null;
+  }
+
+  return {
+    uid: null,
+    name: i18n.text('titles.categories'),
+    path: null,
+  };
+};
+
+/**
+ * Creates tracking data for the page view event.
+ * @param {Object} data The input data.
+ * @return {Object}
+ */
+export const createPageviewData = ({
+  page = null,
+  cart = null,
+  search = null,
+  category = null,
+  product = null,
+  pageConfig,
+}) => {
+  let title = '';
+
+  if (pageConfig) {
+    ({ title } = pageConfig);
+  } else if (category && category.name) {
+    title = category.name;
+  } else if (product && product.name) {
+    title = product.name;
+  }
+
+  return {
+    page: page ? {
+      ...page,
+      title,
+    } : null,
+    cart,
+    search,
+    category,
+    product,
+  };
+};
 /**
  * Helper to pass the redux state to the tracking core
  * @param {string} eventName The name of the event.

--- a/libraries/tracking/selectors/category.js
+++ b/libraries/tracking/selectors/category.js
@@ -1,0 +1,43 @@
+import { createSelector } from 'reselect';
+import {
+  hex2bin,
+  makeGetRouteParam,
+  makeGetRoutePattern,
+} from '@shopgate/engage/core';
+import {
+  CATEGORY_PATTERN,
+  ROOT_CATEGORY_PATTERN,
+  getRootCategories,
+  getCategoryById,
+} from '@shopgate/engage/category';
+import {
+  createCategoryData,
+  createRootCategoryData,
+} from '../helpers';
+
+/**
+ * Creates a selector that retrieves a formatted category for the current route.
+ * @returns {Function}
+ */
+export const makeGetRouteCategory = () => {
+  const getRoutePattern = makeGetRoutePattern();
+  const getCategoryIdRouteParam = makeGetRouteParam('categoryId');
+
+  return createSelector(
+    state => state,
+    getRoutePattern,
+    getCategoryIdRouteParam,
+    getRootCategories,
+    (state, pattern, categoryId, rootCategories) => {
+      const decodedCategoryId = categoryId ? hex2bin(categoryId) : null;
+
+      if (pattern === ROOT_CATEGORY_PATTERN) {
+        return createRootCategoryData(rootCategories);
+      } else if (pattern === CATEGORY_PATTERN && decodedCategoryId) {
+        return createCategoryData(getCategoryById(state, { categoryId: decodedCategoryId }));
+      }
+
+      return null;
+    }
+  );
+};

--- a/libraries/tracking/selectors/index.js
+++ b/libraries/tracking/selectors/index.js
@@ -1,20 +1,41 @@
 import { createSelector } from 'reselect';
-import getPage from './page';
+import { createPageviewData } from '../helpers';
+import getPage, { makeGetRoutePageConfig } from './page';
 import getCart from './cart';
 import getSearch from './search';
+import { makeGetRouteCategory } from './category';
+import { makeGetRouteProduct } from './product';
 
 /**
- * Selects the combined tracking information.
- * @param {Object} state The current state.
- * @returns {Object} The tracking data.
+ * Creates a selector that retrieves tracking data for the current route.
+ * @returns {Function}
  */
-export default createSelector(
-  getPage,
-  getCart,
-  getSearch,
-  (page, cart, search) => ({
-    page,
-    cart,
-    search,
-  })
-);
+export const makeGetTrackingData = () => {
+  const getRouteCategory = makeGetRouteCategory();
+  const getRouteProduct = makeGetRouteProduct();
+  const getRoutePageConfig = makeGetRoutePageConfig();
+
+  /**
+   * Selects the combined tracking information.
+   * @param {Object} state The current state.
+   * @returns {Object} The tracking data.
+   */
+  return createSelector(
+    getPage,
+    getCart,
+    getSearch,
+    getRouteCategory,
+    getRouteProduct,
+    getRoutePageConfig,
+    (state, props = {}) => props.pattern,
+    (page, cart, search, category, product, pageConfig, pattern) => createPageviewData({
+      page,
+      cart,
+      search,
+      category,
+      product,
+      pageConfig,
+      pattern,
+    })
+  );
+};

--- a/libraries/tracking/selectors/page.js
+++ b/libraries/tracking/selectors/page.js
@@ -1,7 +1,8 @@
 import { createSelector } from 'reselect';
 import { shopNumber } from '@shopgate/pwa-common/helpers/config';
 import { getCurrentPathname } from '@shopgate/pwa-common/selectors/router';
-
+import { getPageConfigById } from '@shopgate/engage/page';
+import { makeGetRouteParam } from '@shopgate/engage/core';
 import { isDev } from '@shopgate/pwa-common/helpers/environment';
 
 /**
@@ -50,6 +51,21 @@ const getPageTrackingName = createSelector(
   getPageName,
   pageName => pageNameMap[pageName] || pageName
 );
+
+/**
+ * Creates a selector that retrieves a page config for the current route from the store.
+ * @param {string} name The name of the desired parameter.
+ * @returns {Function}
+ */
+export const makeGetRoutePageConfig = () => {
+  const getPageIdRouteParam = makeGetRouteParam('pageId');
+
+  return createSelector(
+    state => state,
+    getPageIdRouteParam,
+    (state, pageId) => (pageId ? getPageConfigById(state, { pageId }) : null)
+  );
+};
 
 /**
  * Selects the page information.

--- a/libraries/tracking/selectors/product.js
+++ b/libraries/tracking/selectors/product.js
@@ -3,6 +3,12 @@ import {
   getBaseProduct,
   getProduct,
 } from '@shopgate/pwa-common-commerce/product/selectors/product';
+import {
+  hex2bin,
+  makeGetRouteParam,
+  makeGetRoutePattern,
+} from '@shopgate/engage/core';
+import { ITEM_PATTERN } from '@shopgate/engage/product';
 import { formatProductData } from '../helpers';
 
 /**
@@ -24,3 +30,27 @@ export const getProductFormatted = createSelector(
   getProduct,
   formatProductData
 );
+
+/**
+ * Creates a selector that retrieves a formatted product for the current route.
+ * @returns {Function}
+ */
+export const makeGetRouteProduct = () => {
+  const getRoutePattern = makeGetRoutePattern();
+  const getProductIdRouteParam = makeGetRouteParam('productId');
+
+  return createSelector(
+    state => state,
+    getRoutePattern,
+    getProductIdRouteParam,
+    (state, pattern, productId) => {
+      const decodedProductId = productId ? hex2bin(productId) : null;
+
+      if (pattern === ITEM_PATTERN && decodedProductId) {
+        return getProductFormatted(state, { productId: decodedProductId });
+      }
+
+      return null;
+    }
+  );
+};

--- a/libraries/tracking/streams/page.js
+++ b/libraries/tracking/streams/page.js
@@ -1,0 +1,40 @@
+import 'rxjs/add/operator/switchMap';
+import 'rxjs/add/observable/of';
+import { Observable } from 'rxjs/Observable';
+import { RECEIVE_PAGE_CONFIG } from '@shopgate/pwa-common/constants/ActionTypes';
+import { main$, routeDidEnter$, pwaDidAppear$ } from '@shopgate/engage/core';
+import { PAGE_PATTERN, getPageConfigById } from '@shopgate/engage/page';
+
+/**
+ * Emits when a "page" was entered.
+ */
+const pageDidEnter$ = routeDidEnter$
+  .filter(({ action }) => action.route.pattern === PAGE_PATTERN);
+
+/**
+ * Emits when the page route comes active again after a legacy page was active.
+ */
+const pageRouteReappeared$ = pwaDidAppear$
+  .filter(({ action }) => action.route.pattern === PAGE_PATTERN);
+
+const pageConfigReceived$ = main$
+  .filter(({ action }) => action.type === RECEIVE_PAGE_CONFIG);
+
+/**
+ * Emits when a "page" was opened, and its config is available.
+ */
+export const pageIsReady$ = pageDidEnter$
+  .switchMap((data) => {
+    const { action, getState } = data;
+    const { pageId } = action.route.params;
+
+    // Check if the page config for the current route is already available within Redux.
+    const pageConfig = getPageConfigById(getState(), { pageId });
+
+    if (!pageConfig || pageConfig.isFetching) {
+      // Wait for incoming page data if it's not available yet.
+      return pageConfigReceived$.first().switchMap(() => Observable.of(data));
+    }
+
+    return Observable.of(data);
+  }).merge(pageRouteReappeared$);

--- a/libraries/tracking/streams/page.spec.js
+++ b/libraries/tracking/streams/page.spec.js
@@ -1,0 +1,148 @@
+import { mainSubject } from '@shopgate/pwa-common/store/middelwares/streams';
+import { getCurrentRoute } from '@shopgate/pwa-common/selectors/router';
+import {
+  ROUTE_DID_ENTER,
+  PWA_DID_APPEAR,
+  RECEIVE_PAGE_CONFIG,
+} from '@shopgate/pwa-common/constants/ActionTypes';
+import { PAGE_PATTERN, getPageConfigById } from '@shopgate/engage/page';
+import { pageIsReady$ } from './page';
+
+jest.mock('@shopgate/engage/core', () => {
+  const {
+    main$, routeDidEnter$, pwaDidAppear$,
+  } = require.requireActual('@shopgate/engage/core');
+
+  return {
+    main$,
+    routeDidEnter$,
+    pwaDidAppear$,
+  };
+});
+
+jest.mock('@shopgate/engage/page', () => {
+  const {
+    PAGE_PATTERN: PAGE_PATTERN_ORIGINAL,
+  } = require.requireActual('@shopgate/engage/page');
+
+  return {
+    PAGE_PATTERN: PAGE_PATTERN_ORIGINAL,
+    getPageConfigById: jest.fn(),
+  };
+});
+
+jest.mock('@shopgate/pwa-common/selectors/router', () => {
+  const actual = require.requireActual('@shopgate/pwa-common/selectors/router');
+  return {
+    ...actual,
+    getCurrentRoute: jest.fn(),
+  };
+});
+
+const pageConfig = {
+  isFetching: false,
+  name: 'Some Page Name',
+};
+
+const pageRoute = {
+  pattern: PAGE_PATTERN,
+};
+
+const pageId = 'page-id';
+
+describe('Page streams', () => {
+  let subscriber;
+  const getState = jest.fn().mockReturnValue({});
+
+  beforeAll(() => {
+    getPageConfigById.mockReturnValue(pageConfig);
+    getCurrentRoute.mockReturnValue(pageRoute);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    subscriber = jest.fn();
+  });
+
+  describe('pageIsReady$', () => {
+    let subscription;
+
+    afterEach(() => {
+      subscription.unsubscribe();
+    });
+
+    describe('page route', () => {
+      const routeDidEnterPayload = {
+        action: {
+          type: ROUTE_DID_ENTER,
+          route: {
+            pattern: PAGE_PATTERN,
+            params: { pageId },
+          },
+        },
+        getState,
+      };
+
+      it('should emit when a page is already available within the store', () => {
+        subscription = pageIsReady$.subscribe(subscriber);
+        mainSubject.next(routeDidEnterPayload);
+
+        expect(subscriber).toHaveBeenCalledTimes(1);
+        expect(subscriber).toHaveBeenCalledWith(routeDidEnterPayload);
+        expect(getPageConfigById).toHaveBeenCalledTimes(1);
+        expect(getPageConfigById).toHaveBeenCalledWith({}, { pageId });
+      });
+
+      it('should not emit when a page is already available within the store, but it is fetching', () => {
+        getPageConfigById.mockReturnValueOnce({
+          ...pageConfig,
+          isFetching: true,
+        });
+
+        subscription = pageIsReady$.subscribe(subscriber);
+        mainSubject.next(routeDidEnterPayload);
+
+        expect(subscriber).not.toHaveBeenCalled();
+        expect(getPageConfigById).toHaveBeenCalledTimes(1);
+        expect(getPageConfigById).toHaveBeenCalledWith({}, { pageId });
+      });
+
+      it('should emit after the page config comes available', () => {
+        getPageConfigById.mockReturnValueOnce(null);
+
+        subscription = pageIsReady$.subscribe(subscriber);
+        mainSubject.next(routeDidEnterPayload);
+        expect(subscriber).not.toHaveBeenCalled();
+        expect(getPageConfigById).toHaveBeenCalledTimes(1);
+        expect(getPageConfigById).toHaveBeenCalledWith({}, { pageId });
+
+        mainSubject.next({ action: { type: RECEIVE_PAGE_CONFIG } });
+
+        expect(subscriber).toHaveBeenCalledTimes(1);
+        expect(subscriber).toHaveBeenCalledWith(routeDidEnterPayload);
+        expect(getPageConfigById).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('navigating back from legacy pages', () => {
+      it('should emit when pwaDidAppear is dispatched and a page route is active', () => {
+        subscription = pageIsReady$.subscribe(subscriber);
+        mainSubject.next({
+          action: { type: PWA_DID_APPEAR },
+          getState,
+        });
+        expect(subscriber).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not emit when pwaDidAppear is dispatched and no page route is active', () => {
+        getCurrentRoute.mockReturnValueOnce({ pattern: '/some/:pattern' });
+        subscription = pageIsReady$.subscribe(subscriber);
+        mainSubject.next({
+          action: { type: PWA_DID_APPEAR },
+          getState,
+        });
+        expect(subscriber).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/libraries/tracking/streams/pages.js
+++ b/libraries/tracking/streams/pages.js
@@ -21,6 +21,7 @@ import {
   ITEM_WRITE_REVIEW_PATTERN,
 } from '@shopgate/pwa-common-commerce/product/constants';
 import { FAVORITES_PATH } from '@shopgate/pwa-common-commerce/favorites/constants';
+import { PAGE_PATTERN } from '@shopgate/engage/page';
 import { pwaVisibility$ } from './app';
 import { checkoutDidEnter$ } from './checkout';
 
@@ -40,6 +41,7 @@ export const blacklistedPatterns = [
   ITEM_GALLERY_PATTERN,
   ITEM_REVIEWS_PATTERN,
   ITEM_WRITE_REVIEW_PATTERN,
+  PAGE_PATTERN,
 ];
 
 const latestAppActions$ = appWillStart$.merge(pwaVisibility$, checkoutDidEnter$);

--- a/libraries/tracking/subscriptions/pages.js
+++ b/libraries/tracking/subscriptions/pages.js
@@ -3,7 +3,8 @@ import { categoryIsReady$ } from '../streams/category';
 import { searchIsReady$ } from '../streams/search';
 import { productIsReady$ } from '../streams/product';
 import { pagesAreReady$ } from '../streams/pages';
-import getTrackingData from '../selectors';
+import { pageIsReady$ } from '../streams/page';
+import { makeGetTrackingData } from '../selectors';
 import { track } from '../helpers';
 
 /**
@@ -12,10 +13,11 @@ import { track } from '../helpers';
  */
 const callPageViewTracker = ({ getState }) => {
   const state = getState();
+  const getTrackingData = makeGetTrackingData();
 
   track(
     'pageview',
-    getTrackingData(state, getCurrentRoute(getState())),
+    getTrackingData(state, getCurrentRoute(state)),
     state
   );
 };
@@ -29,4 +31,5 @@ export default function pages(subscribe) {
   subscribe(searchIsReady$, callPageViewTracker);
   subscribe(productIsReady$, callPageViewTracker);
   subscribe(pagesAreReady$, callPageViewTracker);
+  subscribe(pageIsReady$, callPageViewTracker);
 }

--- a/libraries/tracking/subscriptions/product.js
+++ b/libraries/tracking/subscriptions/product.js
@@ -1,9 +1,8 @@
 import { getCurrentRoute } from '@shopgate/pwa-common/selectors/router';
-import { hex2bin } from '@shopgate/pwa-common/helpers/data';
 import { variantDidChange$ } from '@shopgate/pwa-common-commerce/product/streams';
 import { productIsReady$ } from '../streams/product';
 import { getBaseProductFormatted, getProductFormatted } from '../selectors/product';
-import getPage from '../selectors/page';
+import { makeGetTrackingData } from '../selectors';
 import { track } from '../helpers';
 
 /**
@@ -32,14 +31,7 @@ export default function product(subscribe) {
    */
   subscribe(productIsReady$, ({ getState }) => {
     const state = getState();
-    const { params: { productId } } = getCurrentRoute(getState());
-    const props = { productId: hex2bin(productId) };
-
-    const trackingData = {
-      page: getPage(state),
-      product: getProductFormatted(state, props),
-    };
-
-    track('viewContent', trackingData, state);
+    const getTrackingData = makeGetTrackingData();
+    track('viewContent', getTrackingData(state, getCurrentRoute(state)), state);
   });
 }


### PR DESCRIPTION
# Description
This pull request is about to extend the data which is used by the tracking system.

At category pages a new `category` property is now available, which contains basic data about the category. The `page` property now has a new `title` property which is set to the "page" title, the category name, or the product name for now - based on the tracked route.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
