### PR TITLE
Implemented logItemview tracking event for the tracking core

### DIFF
--- a/libraries/core/commands/unifiedTracking.js
+++ b/libraries/core/commands/unifiedTracking.js
@@ -121,7 +121,7 @@ import AppCommand from '../classes/AppCommand';
 
 /**
  * Data definition for a log item view command payload within the unified tracking system
- * @typedef {Object} UnifiedItemview
+ * @typedef {Object} UnifiedItemView
  * @property {string} id A unique identifier for the item
  * @property {string} name A name to easier distinguish this item in the tracking tool
  * @property {string} type An identifier for the type of the item like "simple", "configurable"
@@ -243,8 +243,8 @@ export function analyticsSetCampaignWithUrl(data) {
 
 /**
  * This command can be used to log an item view event to all installed trackers.
- * @param {UnifiedItemview} data The payload for the command
+ * @param {UnifiedItemView} data The payload for the command
  */
-export function analyticsLogItemview(data) {
-  executeCommand('analyticsLogItemview', data);
+export function analyticsLogItemView(data) {
+  executeCommand('analyticsLogItemView', data);
 }

--- a/libraries/core/commands/unifiedTracking.js
+++ b/libraries/core/commands/unifiedTracking.js
@@ -120,6 +120,22 @@ import AppCommand from '../classes/AppCommand';
  */
 
 /**
+ * Data definition for a log item view command payload within the unified tracking system
+ * @typedef {Object} UnifiedItemview
+ * @property {string} id A unique identifier for the item
+ * @property {string} name A name to easier distinguish this item in the tracking tool
+ * @property {string} type An identifier for the type of the item like "simple", "configurable"
+ * @property {number} priceNet The net price of the item
+ * @property {number} priceGross The gross price of the item
+ * @property {string} currency The currency code as ISO 4217 string
+ * @property {string} variant A summary of selected item options
+ * @property {string} [brand] The brand of the item
+ * @property {string} [categoryId] A unique identifier for the category of the item
+ * @property {string} [categoryName] Category path of the item (apparel/shoes/sneakers)
+ * @property {UnifiedRestrictions} [restrictions] Restrictions for the command
+ */
+
+/**
  * Additional definitions of data for the multiple tracking events
  */
 
@@ -223,4 +239,12 @@ export function analyticsLogSearch(data) {
  */
 export function analyticsSetCampaignWithUrl(data) {
   executeCommand('analyticsSetCampaignWithUrl', data);
+}
+
+/**
+ * This command can be used to log an item view event to all installed trackers.
+ * @param {UnifiedItemview} data The payload for the command
+ */
+export function analyticsLogItemview(data) {
+  executeCommand('analyticsLogItemview', data);
 }

--- a/libraries/tracking-core/core/AppHandler.js
+++ b/libraries/tracking-core/core/AppHandler.js
@@ -125,12 +125,12 @@ class AppHandler {
   /**
    * Log an itemview
    *
-   * @param {UnifiedItemview} data Tracking data for this event
+   * @param {UnifiedItemView} data Tracking data for this event
    * @param {UnifiedRestrictions} [restrictions] Info about the restrictions
    * @returns {AppHandler} Instance of SgTrackingAppHandler
    */
-  logItemview(data, restrictions) {
-    SGAction.analyticsLogItemview(AppHandler.prepareTrackingData(data, restrictions));
+  logItemView(data, restrictions) {
+    SGAction.analyticsLogItemView(AppHandler.prepareTrackingData(data, restrictions));
     return this;
   }
 

--- a/libraries/tracking-core/core/AppHandler.js
+++ b/libraries/tracking-core/core/AppHandler.js
@@ -123,6 +123,18 @@ class AppHandler {
   }
 
   /**
+   * Log an itemview
+   *
+   * @param {UnifiedItemview} data Tracking data for this event
+   * @param {UnifiedRestrictions} [restrictions] Info about the restrictions
+   * @returns {AppHandler} Instance of SgTrackingAppHandler
+   */
+  logItemview(data, restrictions) {
+    SGAction.analyticsLogItemview(AppHandler.prepareTrackingData(data, restrictions));
+    return this;
+  }
+
+  /**
    * Add the properties restriction, blacklist and trackers to the tracking event data if needed
    *
    * @param {Object} data The tracking event data

--- a/libraries/tracking-core/helpers/formatHelpers.js
+++ b/libraries/tracking-core/helpers/formatHelpers.js
@@ -419,12 +419,12 @@ dataFormatHelpers.addedPaymentInfo = rawData => ({
 });
 
 /**
- * Converter for the logItemview event.
+ * Converter for the logItemView event.
  *
  * @param {Object} rawData Raw data from the core
- * @returns {UnifiedItemview} Data for the logItemview event
+ * @returns {UnifiedItemView} Data for the logItemView event
  */
-dataFormatHelpers.logItemview = (rawData) => {
+dataFormatHelpers.logItemView = (rawData) => {
   let product;
 
   if (rawData.product) {

--- a/libraries/tracking-core/helpers/formatHelpers.js
+++ b/libraries/tracking-core/helpers/formatHelpers.js
@@ -148,6 +148,7 @@ function formatSgDataProduct(product) {
     priceGross: getUnifiedNumber(get(product, 'amount.gross')),
     quantity: getUnifiedNumber(get(product, 'quantity')),
     currency: get(product, 'amount.currency'),
+    brand: get(product, 'manufacturer'),
   };
 }
 
@@ -416,5 +417,29 @@ dataFormatHelpers.addedPaymentInfo = rawData => ({
   success: get(rawData, 'paymentMethodAdded.success'),
   name: get(rawData, 'paymentMethodAdded.name'),
 });
+
+/**
+ * Converter for the logItemview event.
+ *
+ * @param {Object} rawData Raw data from the core
+ * @returns {UnifiedItemview} Data for the logItemview event
+ */
+dataFormatHelpers.logItemview = (rawData) => {
+  let product;
+
+  if (rawData.product) {
+    ({ product } = rawData);
+  } else if (rawData.variant) {
+    product = rawData.variant;
+  }
+
+  product = formatSgDataProduct(product);
+  delete product.quantity;
+
+  return {
+    ...product,
+    type: '',
+  };
+};
 
 export default dataFormatHelpers;

--- a/libraries/tracking/subscriptions/setup.js
+++ b/libraries/tracking/subscriptions/setup.js
@@ -27,6 +27,8 @@ export default function setup(subscribe) {
       os: get(clientInformationResponse, 'value.device.os.platform', OS_ALL),
       state: getState(),
       services: get(clientInformationResponse, 'value.device.supportedAnalyticsServices', []),
+      libVersion: get(clientInformationResponse, 'value.libVersion'),
+      appVersion: get(clientInformationResponse, 'value.appVersion'),
     };
 
     // TODO: instantiate the UnifiedPlugin only if a native tracker is configured (FB, AppsFlyer)


### PR DESCRIPTION
# Description
This pull request is about to implement the `logItemview` tracking event into the tracking core. It adds the necessary command and format helper to the tracking-core library. This event is supposed to the dispatched when users navigate to a product, or select a product variant.

Additionally `libVersion` and `appVersion` parameters are now passed the the client information object, which is used to initialize tracking plugins.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

