### PR TITLE
Updated dependencies of @shopgate/tracking-ga-native package

### DIFF
--- a/extensions/@shopgate-tracking-ga-native/frontend/package.json
+++ b/extensions/@shopgate-tracking-ga-native/frontend/package.json
@@ -22,13 +22,11 @@
       "*.{js,jsx}": "yarn run lint"
     }
   },
-  "dependencies": {
-    "@shopgate/tracking-core": "6.7.0"
-  },
   "devDependencies": {
     "@shopgate/eslint-config": "6.7.0",
     "@shopgate/pwa-common": "6.7.0",
     "@shopgate/pwa-core": "6.7.0",
+    "@shopgate/tracking-core": "6.7.0",
     "babel-core": "^6.26.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",
@@ -41,5 +39,8 @@
     "husky": "^1.0.0-rc.13",
     "jest": "^23.6.0",
     "lint-staged": "^7.2.2"
+  },
+  "peerDependencies": {
+    "@shopgate/tracking-core": "6.7.0"
   }
 }


### PR DESCRIPTION
# Description
Moved the dependency to `@shopgate/tracking-core` to the devDependencies to avoid duplicate installation of node modules when combined with other tracking plugins.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.
