### PR TITLE
The SuggestionList component is now persistent in the component tree

### DIFF
--- a/themes/theme-gmd/components/Search/components/Suggestions/components/List/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-gmd/components/Search/components/Suggestions/components/List/__snapshots__/index.spec.jsx.snap
@@ -102,6 +102,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
               }
               data-test-id="searchSuggestion foo"
               onClick={[Function]}
+              type="button"
               value="foo"
             >
               <SurroundPortals
@@ -191,6 +192,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
               }
               data-test-id="searchSuggestion foo bar"
               onClick={[Function]}
+              type="button"
               value="foo bar"
             >
               <SurroundPortals
@@ -280,6 +282,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
               }
               data-test-id="searchSuggestion foo bar buz"
               onClick={[Function]}
+              type="button"
               value="foo bar buz"
             >
               <SurroundPortals
@@ -369,6 +372,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
               }
               data-test-id="searchSuggestion foo bar buz quz"
               onClick={[Function]}
+              type="button"
               value="foo bar buz quz"
             >
               <SurroundPortals
@@ -541,6 +545,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
               }
               data-test-id="searchSuggestion foo"
               onClick={[Function]}
+              type="button"
               value="foo"
             >
               <SurroundPortals
@@ -630,6 +635,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
               }
               data-test-id="searchSuggestion foo bar"
               onClick={[Function]}
+              type="button"
               value="foo bar"
             >
               <SurroundPortals
@@ -719,6 +725,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
               }
               data-test-id="searchSuggestion foo bar buz"
               onClick={[Function]}
+              type="button"
               value="foo bar buz"
             >
               <SurroundPortals
@@ -808,6 +815,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
               }
               data-test-id="searchSuggestion foo bar buz quz"
               onClick={[Function]}
+              type="button"
               value="foo bar buz quz"
             >
               <SurroundPortals
@@ -980,6 +988,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
               }
               data-test-id="searchSuggestion foo bar buz quz"
               onClick={[Function]}
+              type="button"
               value="foo bar buz quz"
             >
               <SurroundPortals
@@ -1069,6 +1078,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
               }
               data-test-id="searchSuggestion foo bar buz"
               onClick={[Function]}
+              type="button"
               value="foo bar buz"
             >
               <SurroundPortals
@@ -1158,6 +1168,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
               }
               data-test-id="searchSuggestion foo bar"
               onClick={[Function]}
+              type="button"
               value="foo bar"
             >
               <SurroundPortals
@@ -1247,6 +1258,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
               }
               data-test-id="searchSuggestion foo"
               onClick={[Function]}
+              type="button"
               value="foo"
             >
               <SurroundPortals
@@ -1435,6 +1447,7 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
                   }
                   data-test-id="searchSuggestion foo"
                   onClick={[Function]}
+                  type="button"
                   value="foo"
                 >
                   <SurroundPortals
@@ -1524,6 +1537,7 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
                   }
                   data-test-id="searchSuggestion foo bar"
                   onClick={[Function]}
+                  type="button"
                   value="foo bar"
                 >
                   <SurroundPortals
@@ -1613,6 +1627,7 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
                   }
                   data-test-id="searchSuggestion foo bar buz"
                   onClick={[Function]}
+                  type="button"
                   value="foo bar buz"
                 >
                   <SurroundPortals
@@ -1702,6 +1717,7 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
                   }
                   data-test-id="searchSuggestion foo bar buz quz"
                   onClick={[Function]}
+                  type="button"
                   value="foo bar buz quz"
                 >
                   <SurroundPortals

--- a/themes/theme-gmd/components/Search/components/Suggestions/components/List/index.jsx
+++ b/themes/theme-gmd/components/Search/components/Suggestions/components/List/index.jsx
@@ -23,6 +23,7 @@ class SuggestionList extends Component {
     fetching: false,
     suggestions: [],
   };
+
   /**
    * @param { Object } nextProps Next props.
    * @return {boolean}
@@ -61,6 +62,7 @@ class SuggestionList extends Component {
               key={suggestion}
             >
               <button
+                type="button"
                 className={styles.item}
                 onClick={onClick}
                 value={suggestion}

--- a/themes/theme-ios11/pages/Browse/components/SearchField/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/__snapshots__/spec.jsx.snap
@@ -186,6 +186,12 @@ exports[`<Content /> Check search field should render with initial search query 
             </button>
           </div>
         </div>
+        <Component
+          bottomHeight={0}
+          onClick={[Function]}
+          searchPhrase="foo"
+          visible={false}
+        />
       </div>
     </SearchField>
   </Connect(SearchField)>
@@ -341,6 +347,7 @@ exports[`<Content /> Check search field should show suggestions when focused 1`]
           bottomHeight={0}
           onClick={[Function]}
           searchPhrase="foo"
+          visible={true}
         />
       </div>
     </SearchField>

--- a/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/__snapshots__/spec.jsx.snap
@@ -13,6 +13,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
       "foo bar buz quz",
     ]
   }
+  visible={false}
 >
   <SurroundPortals
     portalName="search.suggestions"
@@ -29,7 +30,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
     }
   >
     <div
-      className="css-7w6rep css-90ryaa"
+      className="css-7w6rep css-90ryaa css-6zy2pv"
     >
       <SurroundPortals
         key="foo"
@@ -165,6 +166,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
       "foo",
     ]
   }
+  visible={false}
 >
   <SurroundPortals
     portalName="search.suggestions"
@@ -181,7 +183,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
     }
   >
     <div
-      className="css-7w6rep css-90ryaa"
+      className="css-7w6rep css-90ryaa css-6zy2pv"
     >
       <SurroundPortals
         key="foo"
@@ -317,6 +319,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
       "foo",
     ]
   }
+  visible={false}
 >
   <SurroundPortals
     portalName="search.suggestions"
@@ -333,7 +336,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
     }
   >
     <div
-      className="css-7w6rep css-90ryaa"
+      className="css-7w6rep css-90ryaa css-6zy2pv"
     >
       <SurroundPortals
         key="foo bar buz quz"
@@ -485,6 +488,7 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
           "foo bar buz quz",
         ]
       }
+      visible={false}
     >
       <SurroundPortals
         portalName="search.suggestions"
@@ -501,7 +505,7 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
         }
       >
         <div
-          className="css-7w6rep css-90ryaa"
+          className="css-7w6rep css-90ryaa css-6zy2pv"
         >
           <SurroundPortals
             key="foo"

--- a/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/index.jsx
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/index.jsx
@@ -19,11 +19,13 @@ class SuggestionList extends Component {
     onClick: PropTypes.func.isRequired,
     fetching: PropTypes.bool,
     suggestions: PropTypes.arrayOf(PropTypes.string),
+    visible: PropTypes.bool,
   }
 
   static defaultProps = {
     suggestions: [],
     fetching: false,
+    visible: false,
   }
 
   /**
@@ -38,7 +40,9 @@ class SuggestionList extends Component {
    * @return {JSX}
    */
   render() {
-    const { onClick, suggestions, bottomHeight } = this.props;
+    const {
+      onClick, suggestions, bottomHeight, visible,
+    } = this.props;
 
     if (!suggestions) {
       return null;
@@ -52,7 +56,13 @@ class SuggestionList extends Component {
           suggestions,
         }}
       >
-        <div className={classnames(styles.list, styles.bottom(bottomHeight))}>
+        <div
+          className={classnames(
+            styles.list,
+            styles.bottom(bottomHeight),
+            { [styles.hidden]: !visible }
+          )}
+        >
           {suggestions.map(suggestion => (
             <SurroundPortals
               portalName={SEARCH_SUGGESTION_ITEM}

--- a/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/style.js
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/style.js
@@ -39,8 +39,14 @@ const item = css({
   textAlign: 'left',
 }).toString();
 
+const hidden = css({
+  display: 'none',
+  visibility: 'hidden',
+});
+
 export default {
   bottom,
   list,
   item,
+  hidden,
 };

--- a/themes/theme-ios11/pages/Browse/components/SearchField/index.jsx
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/index.jsx
@@ -257,16 +257,13 @@ class SearchField extends Component {
             {this.renderCancelButton()}
           </div>
         </div>
-        {focused && (
-          <Fragment>
-            <div className={styles.overlay} />
-            <SuggestionList
-              searchPhrase={this.state.query}
-              onClick={this.handleSubmit}
-              bottomHeight={this.state.bottomHeight}
-            />
-          </Fragment>)
-        }
+        {focused && <div className={styles.overlay} />}
+        <SuggestionList
+          visible={focused}
+          searchPhrase={this.state.query}
+          onClick={this.handleSubmit}
+          bottomHeight={this.state.bottomHeight}
+        />
       </div>
     );
   }

--- a/themes/theme-ios11/pages/Browse/components/SearchField/spec.jsx
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/spec.jsx
@@ -85,7 +85,6 @@ describe('<Content />', () => {
       const wrapper = createWrapper();
 
       // Suggestion should not be visible when blured.
-      expect(wrapper.find(SuggestionList).length).toEqual(0);
       jest.useFakeTimers();
       wrapper.find('input').simulate('focus');
       jest.runAllTimers();
@@ -94,7 +93,6 @@ describe('<Content />', () => {
       // Should be rendered now with current query.
       expect(wrapper).toMatchSnapshot();
 
-      expect(wrapper.find(SuggestionList).length).toEqual(1);
       expect(wrapper.find(SuggestionList).prop('searchPhrase')).toEqual('foo');
       expect(wrapper.find(`button.${styles.scannerIcon}`)).not.toExist();
     });


### PR DESCRIPTION
# Description

If the search field has not been focused, we still keep the SuggestionList component in the component tree. We now only hide it via CSS. This makes it possible for injected portal components to register the default click event handler.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
