### PR TITLE
Implemented login tracking event for apps

### DIFF
--- a/libraries/common/action-creators/user/index.js
+++ b/libraries/common/action-creators/user/index.js
@@ -13,6 +13,8 @@ import {
   DISABLE_LOGIN,
 } from '../../constants/ActionTypes';
 
+import { DEFAULT_LOGIN_STRATEGY } from '../../constants/user';
+
 /**
  * Creates the dispatched REQUEST_LOGIN action object.
  * It also passes login credentials to the action,
@@ -22,7 +24,7 @@ import {
  * @param {string} strategy login strategy
  * @returns {Object} The dispatched action object.
  */
-export const requestLogin = (user, password, strategy = 'basic') => ({
+export const requestLogin = (user, password, strategy = DEFAULT_LOGIN_STRATEGY) => ({
   type: REQUEST_LOGIN,
   user,
   password,
@@ -32,11 +34,13 @@ export const requestLogin = (user, password, strategy = 'basic') => ({
 /**
  * Creates the dispatched RECEIVE_LOGIN action object.
  * @param {string} redirect The location to redirect to.
+ * @param {string} strategy The login strategy.
  * @returns {Object} The dispatched action object.
  */
-export const successLogin = redirect => ({
+export const successLogin = (redirect, strategy = DEFAULT_LOGIN_STRATEGY) => ({
   type: SUCCESS_LOGIN,
   redirect,
+  strategy,
 });
 
 /**

--- a/libraries/common/action-creators/user/spec.js
+++ b/libraries/common/action-creators/user/spec.js
@@ -22,6 +22,7 @@ import {
   ERROR_USER,
   TOGGLE_LOGGED_IN,
 } from '../../constants/ActionTypes';
+import { DEFAULT_LOGIN_STRATEGY } from '../../constants/user';
 
 const messages = [{
   type: 'EUNKNOWN',
@@ -38,16 +39,31 @@ describe('Action Creators: user', () => {
         type: REQUEST_LOGIN,
         user,
         password,
-        strategy: 'basic',
+        strategy: DEFAULT_LOGIN_STRATEGY,
       };
       expect(requestLogin(user, password)).toEqual(expected);
     });
   });
 
   describe('successLogin()', () => {
-    it('should work as expected', () => {
-      const expected = { type: SUCCESS_LOGIN };
+    it('should work as expected with no parameters', () => {
+      const expected = {
+        type: SUCCESS_LOGIN,
+        redirect: undefined,
+        strategy: DEFAULT_LOGIN_STRATEGY,
+      };
       expect(successLogin()).toEqual(expected);
+    });
+
+    it('should work as expected with parameters', () => {
+      const redirect = '/some/url';
+      const strategy = 'custom';
+      const expected = {
+        type: SUCCESS_LOGIN,
+        redirect,
+        strategy,
+      };
+      expect(successLogin(redirect, strategy)).toEqual(expected);
     });
   });
 

--- a/libraries/common/actions/user/login.js
+++ b/libraries/common/actions/user/login.js
@@ -6,6 +6,7 @@ import {
   EINCOMPLETELOGIN,
 } from '@shopgate/pwa-core';
 import { SHOPGATE_USER_LOGIN_USER } from '../../constants/Pipelines';
+import { DEFAULT_LOGIN_STRATEGY } from '../../constants/user';
 import * as actions from '../../action-creators/user';
 
 /**
@@ -17,7 +18,7 @@ import * as actions from '../../action-creators/user';
  * @param {string} strategy basic or facebook, amazon, etc
  * @return {Function} A redux thunk.
  */
-export default function login(parameters, redirect, strategy = 'basic') {
+export default function login(parameters, redirect, strategy = DEFAULT_LOGIN_STRATEGY) {
   return (dispatch) => {
     dispatch(actions.requestLogin(parameters.login, parameters.password, strategy));
 
@@ -35,7 +36,7 @@ export default function login(parameters, redirect, strategy = 'basic') {
       .dispatch()
       .then(({ success, messages }) => {
         if (success) {
-          dispatch(actions.successLogin(redirect));
+          dispatch(actions.successLogin(redirect, strategy));
         } else {
           dispatch(actions.errorLogin(messages));
         }
@@ -49,7 +50,7 @@ export default function login(parameters, redirect, strategy = 'basic') {
            * in. In that situation the success action can also dispatch to trigger the necessary
            * processes which has to happen after a successful login.
            */
-          dispatch(actions.successLogin(redirect));
+          dispatch(actions.successLogin(redirect, strategy));
         } else if (code === ELEGACYSGCONNECT) {
           /**
            * The app is connected to the shop system via the legacy shopgate connect. Login via

--- a/libraries/common/constants/user.js
+++ b/libraries/common/constants/user.js
@@ -1,0 +1,1 @@
+export const DEFAULT_LOGIN_STRATEGY = 'basic';

--- a/libraries/common/reducers/user/login.js
+++ b/libraries/common/reducers/user/login.js
@@ -13,6 +13,7 @@ const defaultState = {
   disabled: false,
   isLoggedIn: false,
   errors: null,
+  strategy: null,
 };
 
 /**
@@ -36,6 +37,7 @@ export default function userLoginReducer(state = defaultState, action) {
     case REQUEST_LOGIN:
       return {
         ...state,
+        strategy: action.strategy,
         isFetching: true,
       };
     case SUCCESS_LOGIN:
@@ -44,6 +46,7 @@ export default function userLoginReducer(state = defaultState, action) {
         isLoggedIn: true,
         errors: null,
         isFetching: false,
+        strategy: action.strategy,
       };
     case ERROR_LOGIN:
       return {
@@ -56,6 +59,7 @@ export default function userLoginReducer(state = defaultState, action) {
       return {
         ...state,
         isLoggedIn: action.value,
+        strategy: null,
       };
     case SUCCESS_LOGOUT:
       return defaultState;

--- a/libraries/core/commands/unifiedTracking.js
+++ b/libraries/core/commands/unifiedTracking.js
@@ -136,6 +136,13 @@ import AppCommand from '../classes/AppCommand';
  */
 
 /**
+ * Data definition for a log login command payload within the unified tracking system
+ * @typedef {Object} UnifiedLogin
+ * @property {string} type Defines the type of the login. “guest”, “facebook”.
+ * @property {UnifiedRestrictions} [restrictions] Restrictions for the command
+ */
+
+/**
  * Additional definitions of data for the multiple tracking events
  */
 
@@ -247,4 +254,12 @@ export function analyticsSetCampaignWithUrl(data) {
  */
 export function analyticsLogItemView(data) {
   executeCommand('analyticsLogItemView', data);
+}
+
+/**
+ * This command can be used to log a login event to all installed trackers.
+ * @param {UnifiedLogin} data The payload for the command
+ */
+export function analyticsLogLogin(data) {
+  executeCommand('analyticsLogLogin', data);
 }

--- a/libraries/engage/user/index.js
+++ b/libraries/engage/user/index.js
@@ -9,10 +9,12 @@ export { default as logout } from '@shopgate/pwa-common/actions/user/logout';
 
 // CONSTANTS
 export * from '@shopgate/pwa-common/constants/Registration';
+export * from '@shopgate/pwa-common/constants/user';
 export { REGISTER_PATH, LOGIN_PATH };
 
 // SELECTORS
 export * from '@shopgate/pwa-common/selectors/user';
+export * from './selectors/login';
 
 // STREAMS
 export * from '@shopgate/pwa-common/streams/user';

--- a/libraries/engage/user/selectors/__tests__/login.spec.js
+++ b/libraries/engage/user/selectors/__tests__/login.spec.js
@@ -1,0 +1,49 @@
+import { makeGetLoginStrategy } from '../login';
+
+const mockedState = {
+  user: {
+    login: {
+      isFetching: false,
+      disabled: false,
+      isLoggedIn: true,
+      errors: null,
+      strategy: 'default',
+    },
+  },
+};
+
+describe('engage > user > selectors > login', () => {
+  describe('getProductMedia()', () => {
+    let getLoginStrategy;
+
+    beforeEach(() => {
+      getLoginStrategy = makeGetLoginStrategy();
+    });
+
+    it('should return different selector instances', () => {
+      expect(getLoginStrategy).not.toBe(makeGetLoginStrategy());
+    });
+
+    it('should return NULL when the store is empty', () => {
+      const result = getLoginStrategy({});
+      expect(result).toBeNull();
+    });
+
+    it('should return NULL when the login state does not contain a strategy', () => {
+      const result = getLoginStrategy({
+        user: {
+          login: {
+            ...mockedState.user.login,
+            strategy: null,
+          },
+        },
+      });
+      expect(result).toBeNull();
+    });
+
+    it('should return a login strategy', () => {
+      const result = getLoginStrategy(mockedState);
+      expect(result).toBe(mockedState.user.login.strategy);
+    });
+  });
+});

--- a/libraries/engage/user/selectors/login.js
+++ b/libraries/engage/user/selectors/login.js
@@ -1,0 +1,23 @@
+import { createSelector } from 'reselect';
+import { getLoginData } from '@shopgate/pwa-common/selectors/user';
+
+/**
+ * Creates a selector that retrieves the login strategy for logged in users.
+ * @returns {Function}
+ */
+export function makeGetLoginStrategy() {
+  /**
+   * Retrieves the login strategy for logged in users. If the user isn't logged in, it returns null.
+   * @returns {string|null}
+   */
+  return createSelector(
+    getLoginData,
+    (login) => {
+      if (!login || !login.strategy) {
+        return null;
+      }
+
+      return login.strategy;
+    }
+  );
+}

--- a/libraries/tracking-core/core/AppHandler.js
+++ b/libraries/tracking-core/core/AppHandler.js
@@ -100,7 +100,7 @@ class AppHandler {
   }
 
   /**
-   * Log when a search happend
+   * Log when a search happened
    *
    * @param {UnifiedSearched} data Tracking data for this event
    * @param {UnifiedRestrictions} [restrictions] Info about the restrictions
@@ -129,8 +129,20 @@ class AppHandler {
    * @param {UnifiedRestrictions} [restrictions] Info about the restrictions
    * @returns {AppHandler} Instance of SgTrackingAppHandler
    */
-  logItemView(data, restrictions) {
+  itemView(data, restrictions) {
     SGAction.analyticsLogItemView(AppHandler.prepareTrackingData(data, restrictions));
+    return this;
+  }
+
+  /**
+   * Log a login
+   *
+   * @param {UnifiedLogin} data Tracking data for this event
+   * @param {UnifiedRestrictions} [restrictions] Info about the restrictions
+   * @returns {AppHandler} Instance of SgTrackingAppHandler
+   */
+  login(data, restrictions) {
+    SGAction.analyticsLogLogin(AppHandler.prepareTrackingData(data, restrictions));
     return this;
   }
 

--- a/libraries/tracking-core/helpers/formatHelpers.js
+++ b/libraries/tracking-core/helpers/formatHelpers.js
@@ -424,7 +424,7 @@ dataFormatHelpers.addedPaymentInfo = rawData => ({
  * @param {Object} rawData Raw data from the core
  * @returns {UnifiedItemView} Data for the logItemView event
  */
-dataFormatHelpers.logItemView = (rawData) => {
+dataFormatHelpers.itemView = (rawData) => {
   let product;
 
   if (rawData.product) {

--- a/libraries/tracking-core/helpers/formatHelpers.spec.js
+++ b/libraries/tracking-core/helpers/formatHelpers.spec.js
@@ -1,0 +1,59 @@
+import helpers from './formatHelpers';
+
+const { itemView } = helpers;
+
+const mockBaseProduct = {
+  uid: 'base-product',
+  name: 'Product name',
+  manufacturer: 'Product manufacturer',
+  quantity: 3,
+  tags: [],
+  amount: {
+    currency: 'EUR',
+    gross: '100.99',
+    net: '90.99',
+    striked: '0.00',
+  },
+};
+
+const mockMockVariantProduct = {
+  ...mockBaseProduct,
+  uid: 'variant-product',
+};
+
+describe('Format helpers', () => {
+  describe('itemView()', () => {
+    it('should format raw base product data', () => {
+      const raw = {
+        product: mockBaseProduct,
+      };
+
+      expect(itemView(raw)).toEqual({
+        id: 'base-product',
+        type: '',
+        name: 'Product name',
+        priceNet: 90.99,
+        priceGross: 100.99,
+        currency: 'EUR',
+        brand: 'Product manufacturer',
+      });
+    });
+
+    it('should format raw variant product data', () => {
+      const raw = {
+        baseProduct: mockBaseProduct,
+        variant: mockMockVariantProduct,
+      };
+
+      expect(itemView(raw)).toEqual({
+        id: 'variant-product',
+        type: '',
+        name: 'Product name',
+        priceNet: 90.99,
+        priceGross: 100.99,
+        currency: 'EUR',
+        brand: 'Product manufacturer',
+      });
+    });
+  });
+});

--- a/libraries/tracking/selectors/user.js
+++ b/libraries/tracking/selectors/user.js
@@ -1,0 +1,46 @@
+import { createSelector } from 'reselect';
+import {
+  DEFAULT_LOGIN_STRATEGY,
+  isUserLoggedIn,
+  getUserData,
+  makeGetLoginStrategy,
+} from '@shopgate/engage/user';
+
+/**
+ * Creates a selector that retrieves user tracking data from the store.
+ * @param {string} name The name of the desired parameter.
+ * @returns {Function}
+ */
+export function makeGetUser() {
+  const getLoginStrategy = makeGetLoginStrategy();
+
+  return createSelector(
+    isUserLoggedIn,
+    getUserData,
+    getLoginStrategy,
+    (isLoggedIn, userData, loginStrategy) => {
+      if (!isLoggedIn || !userData) {
+        return null;
+      }
+
+      const { isFetching, loginType, ...trackedData } = userData || {};
+
+      if (Object.keys(trackedData).length === 0) {
+        return null;
+      }
+
+      let type = null;
+
+      if (loginStrategy !== DEFAULT_LOGIN_STRATEGY) {
+        type = loginStrategy;
+      } else if (['userGuest', 'userAccount'].includes(loginType)) {
+        type = loginType === 'userGuest' ? 'guest' : 'standard';
+      }
+
+      return {
+        ...trackedData,
+        type,
+      };
+    }
+  );
+}

--- a/libraries/tracking/selectors/user.spec.js
+++ b/libraries/tracking/selectors/user.spec.js
@@ -1,0 +1,111 @@
+import {
+  DEFAULT_LOGIN_STRATEGY,
+  isUserLoggedIn,
+  getUserData,
+  makeGetLoginStrategy,
+} from '@shopgate/engage/user';
+
+import { makeGetUser } from './user';
+
+const mockDefaultStrategy = 'default';
+const mockUserData = {
+  id: 'abc123',
+  firstName: 'John',
+  lastName: 'Doe',
+  isFetching: false,
+  loginType: 'userAccount',
+};
+
+const { isFetching, loginType, ...mockTrackableData } = mockUserData;
+
+const mockLoginStrategy = DEFAULT_LOGIN_STRATEGY;
+
+jest.mock('@shopgate/engage/user', () => ({
+  DEFAULT_LOGIN_STRATEGY: mockDefaultStrategy,
+  isUserLoggedIn: jest.fn(),
+  getUserData: jest.fn(),
+  makeGetLoginStrategy: jest.fn(),
+}));
+
+describe('User selectors', () => {
+  const getLoginStrategy = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isUserLoggedIn.mockReturnValue(true);
+    getUserData.mockReturnValue(mockUserData);
+    makeGetLoginStrategy.mockReturnValue(getLoginStrategy);
+    getLoginStrategy.mockReturnValue(mockLoginStrategy);
+  });
+
+  describe('makeGetUser()', () => {
+    let getUser;
+
+    beforeEach(() => {
+      getUser = makeGetUser();
+    });
+
+    it('should return different selector instances', () => {
+      expect(getUser).not.toBe(makeGetUser());
+    });
+
+    it('should return NULL when the user is not logged in', () => {
+      isUserLoggedIn.mockReturnValueOnce(false);
+      expect(getUser({})).toBeNull();
+    });
+
+    it('should return NULL when no user data is available', () => {
+      getUserData.mockReturnValueOnce(null);
+      expect(getUser({})).toBeNull();
+    });
+
+    it('should return NULL when the user data does not contain trackable properties', () => {
+      getUserData.mockReturnValueOnce({
+        isFetching: false,
+        loginType: 'userGuest',
+      });
+      expect(getUser({})).toBeNull();
+    });
+
+    it('should return the expected data when a special login strategy was used', () => {
+      getLoginStrategy.mockReturnValueOnce('special');
+      expect(getUser({})).toEqual({
+        ...mockTrackableData,
+        type: 'special',
+      });
+    });
+
+    it('should return the expected data when the login type is userGuest', () => {
+      getUserData.mockReturnValueOnce({
+        ...mockUserData,
+        loginType: 'userGuest',
+      });
+      expect(getUser({})).toEqual({
+        ...mockTrackableData,
+        type: 'guest',
+      });
+    });
+
+    it('should return the expected data when the login type is userAccount', () => {
+      getUserData.mockReturnValueOnce({
+        ...mockUserData,
+        loginType: 'userAccount',
+      });
+      expect(getUser({})).toEqual({
+        ...mockTrackableData,
+        type: 'standard',
+      });
+    });
+
+    it('should return the expected data when an unknown login type is set', () => {
+      getUserData.mockReturnValueOnce({
+        ...mockUserData,
+        loginType: 'unknown',
+      });
+      expect(getUser({})).toEqual({
+        ...mockTrackableData,
+        type: null,
+      });
+    });
+  });
+});

--- a/libraries/tracking/streams/user.js
+++ b/libraries/tracking/streams/user.js
@@ -1,0 +1,9 @@
+import {
+  userDidLogin$,
+  userDataReceived$,
+} from '@shopgate/engage/user';
+
+/**
+ * Gets triggered if login was successful and we received the user data.
+ */
+export const loginSuccess$ = userDidLogin$.switchMap(() => userDataReceived$.first());

--- a/libraries/tracking/streams/user.spec.js
+++ b/libraries/tracking/streams/user.spec.js
@@ -1,0 +1,77 @@
+import {
+  SUCCESS_LOGIN,
+  RECEIVE_USER,
+} from '@shopgate/pwa-common/constants/ActionTypes';
+import { mainSubject } from '@shopgate/pwa-common/store/middelwares/streams';
+import { loginSuccess$ } from './user';
+
+const mockedReceiveUser = {
+  action: {
+    type: RECEIVE_USER,
+    user: {
+      id: 'abc123',
+      firstName: 'John',
+      lastName: 'Doe',
+    },
+  },
+};
+
+/**
+ * Simulate dispatch of the SUCCESS_LOGIN action
+ */
+const dispatchReceiveUser = () => {
+  mainSubject.next(mockedReceiveUser);
+};
+
+/**
+ * Simulate dispatch of the SUCCESS_LOGIN action
+ */
+const dispatchSuccessLogin = () => {
+  mainSubject.next({
+    action: {
+      type: SUCCESS_LOGIN,
+    },
+  });
+};
+
+describe('User streams', () => {
+  let subscriber;
+  let subscription;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    subscriber = jest.fn();
+  });
+
+  describe('loginSuccess$', () => {
+    beforeEach(() => {
+      subscription = loginSuccess$.subscribe(subscriber);
+    });
+
+    afterEach(() => {
+      subscription.unsubscribe();
+    });
+
+    it('should emit after the user logged in, and user data was received', () => {
+      dispatchSuccessLogin();
+      expect(subscriber).not.toHaveBeenCalled();
+      dispatchReceiveUser();
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(subscriber).toHaveBeenCalledWith(mockedReceiveUser);
+    });
+
+    it('should only emit if both actions are dispatched in the correct order', () => {
+      dispatchReceiveUser();
+      expect(subscriber).not.toHaveBeenCalled();
+      dispatchReceiveUser();
+      expect(subscriber).not.toHaveBeenCalled();
+      dispatchSuccessLogin();
+      expect(subscriber).not.toHaveBeenCalled();
+      dispatchReceiveUser();
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(subscriber).toHaveBeenCalledWith(mockedReceiveUser);
+      dispatchReceiveUser();
+      expect(subscriber).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/libraries/tracking/subscriptions/user.js
+++ b/libraries/tracking/subscriptions/user.js
@@ -1,8 +1,6 @@
-import {
-  userDidLogin$,
-  userDataReceived$,
-  loginDidFail$,
-} from '@shopgate/pwa-common/streams/user';
+import { loginDidFail$ } from '@shopgate/engage/user';
+import { makeGetUser } from '../selectors/user';
+import { loginSuccess$ } from '../streams/user';
 import { track } from '../helpers/index';
 
 /**
@@ -10,15 +8,11 @@ import { track } from '../helpers/index';
  * @param {Function} subscribe The subscribe function.
  */
 export default function user(subscribe) {
-  /**
-   * Gets triggered if login was successful and we received the user data.
-   */
-  const loginSuccess$ = userDataReceived$
-    .zip(userDidLogin$)
-    .map(([first]) => first);
-
-  subscribe(loginSuccess$, ({ action, getState }) => (
-    track('loginSuccess', action.user, getState())));
+  subscribe(loginSuccess$, ({ getState }) => {
+    const getUser = makeGetUser();
+    const state = getState();
+    track('loginSuccess', getUser(state), state);
+  });
 
   /**
    * Gets triggered if login failed.

--- a/libraries/tracking/subscriptions/user.spec.js
+++ b/libraries/tracking/subscriptions/user.spec.js
@@ -1,0 +1,56 @@
+import { loginDidFail$ } from '@shopgate/engage/user';
+import * as helpers from '../helpers';
+import subscription from './user';
+
+const mockedGetUser = jest.fn().mockReturnValue('getUser');
+jest.mock('../selectors/user', () => ({
+  makeGetUser: () => mockedGetUser,
+}));
+
+describe('User subscriptions', () => {
+  const subscribe = jest.fn();
+  const getState = jest.fn().mockReturnValue('getState');
+  const trackSpy = jest.spyOn(helpers, 'track');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    subscription(subscribe);
+  });
+
+  it('should call subscribe as expected', () => {
+    expect(subscribe).toHaveBeenCalledTimes(2);
+  });
+
+  describe('loginSuccess$', () => {
+    let callback;
+
+    beforeAll(() => {
+      [[, callback]] = subscribe.mock.calls;
+    });
+
+    it('should track the loginSuccess event', () => {
+      callback({ getState });
+      expect(trackSpy).toHaveBeenCalledTimes(1);
+      expect(trackSpy).toHaveBeenCalledWith('loginSuccess', 'getUser', 'getState');
+    });
+  });
+
+  describe('loginDidFail$', () => {
+    let stream;
+    let callback;
+
+    beforeAll(() => {
+      [, [stream, callback]] = subscribe.mock.calls;
+    });
+
+    it('should subscribe the the correct stream', () => {
+      expect(stream).toBe(loginDidFail$);
+    });
+
+    it('should track the loginFailed event', () => {
+      callback({ getState });
+      expect(trackSpy).toHaveBeenCalledTimes(1);
+      expect(trackSpy).toHaveBeenCalledWith('loginFailed', undefined, 'getState');
+    });
+  });
+});


### PR DESCRIPTION
# Description
This ticket is about to implement the `analyticsLogLogin` app tracking command. To archive the related requirements, the `login` state was extended to provide the login strategy which was used for a user login. Furthermore the tracking data of the `loginSuccess` tracking event was extended by the type of the login strategy.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
