### PR TITLE
Fixed spacing between icons and labels of iOS TabBar entries

### DIFF
--- a/themes/theme-ios11/components/TabBar/components/TabBarAction/index.jsx
+++ b/themes/theme-ios11/components/TabBar/components/TabBarAction/index.jsx
@@ -21,7 +21,7 @@ const TabBarAction = (props) => {
   );
 
   return (
-    <Grid.Item role="presentation">
+    <Grid.Item role="presentation" className={style.item}>
       <Button
         className={className}
         onClick={props.onClick}

--- a/themes/theme-ios11/components/TabBar/components/TabBarAction/style.js
+++ b/themes/theme-ios11/components/TabBar/components/TabBarAction/style.js
@@ -18,7 +18,6 @@ const container = css({
   padding: 0,
   '> svg': {
     flexGrow: 1,
-    marginTop: 2,
     marginRight: 'auto',
     marginLeft: 'auto',
   },
@@ -36,8 +35,17 @@ const label = css({
   marginBottom: 2,
 }).toString();
 
+const item = css({
+  display: 'flex',
+  flexFlow: 'column',
+  justifyContent: 'space-between',
+  height: '100%',
+  marginTop: 5,
+}).toString();
+
 export default {
   container,
+  item,
   regular,
   highlighted,
   label,


### PR DESCRIPTION
# Description
This ticket increases the spacing between icons and labels of iOS TabBar entries. Now layout matches the TabBars of e.g. the AppStore or the Music App.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

