### PR TITLE
New theme config "product.variantPreselect" is added.

### DIFF
--- a/libraries/common/components/ProductCharacteristics/helpers/index.js
+++ b/libraries/common/components/ProductCharacteristics/helpers/index.js
@@ -1,4 +1,8 @@
 import isMatch from 'lodash/isMatch';
+import appConfig from '@shopgate/pwa-common/helpers/config';
+
+const { variantSelectionMode, product: { variantPreselect } = {} } = appConfig;
+const preselectVariant = variantPreselect || parseInt(variantSelectionMode, 10) === 1;
 
 /**
  * Returns the index of a particular characteristic from a set of characteristics.
@@ -99,4 +103,44 @@ export function prepareState(id, value, selections, characteristics, products) {
   });
 
   return currentSelection;
+}
+/**
+ * Preselect characteristics for variant
+ * or pre-select the first available product
+ * @param {string} [variantId=null] The selected variant
+ * @param {{products: Object[], characteristics: Object[]}} [variants=null] All possible variants.
+ * @return {Object}
+ */
+export function selectCharacteristics({ variantId, variants = {} }) {
+  if (!variants || !variants.products || !variants.products.length) {
+    return {};
+  }
+  if (variantId) {
+    const variant = variants.products.find(product => product.id === variantId) || {};
+    return { ...variant.characteristics };
+  }
+  // If product has only 1 variant preselect no matter if "preselect" is chosen or not.
+  if (variants.products.length === 1) {
+    return { ...variants.products[0].characteristics };
+  }
+  // Pre-selection is off
+  if (!preselectVariant) {
+    return {};
+  }
+  // Find the first selectable product by characteristics
+  return variants.characteristics.reduce((acc, char) => {
+    // Find the first char value with selectable products
+    const firstVal = char.values.find((val) => {
+      // eslint-disable-next-line extra-rules/no-single-line-objects
+      const source = { ...acc, [char.id]: val.id };
+      return variants.products.filter(p => (
+        isMatch(p.characteristics, source)
+      )).length > 0;
+    });
+    if (!firstVal) {
+      return acc;
+    }
+    // eslint-disable-next-line extra-rules/no-single-line-objects
+    return { ...acc, [char.id]: firstVal.id };
+  }, {});
 }

--- a/libraries/common/components/ProductCharacteristics/helpers/index.spec.js
+++ b/libraries/common/components/ProductCharacteristics/helpers/index.spec.js
@@ -1,6 +1,4 @@
-/* eslint-disable extra-rules/no-single-line-objects */
-
-import { findSelectionIndex, prepareState } from './index';
+/* eslint-disable extra-rules/no-single-line-objects,global-require */
 
 const products = [{
   id: '007-001',
@@ -28,6 +26,7 @@ const characteristics = [{
   id: '1',
   label: 'Size',
   values: [
+    { id: '0', label: 'Resilient' },
     { id: '1', label: 'L' },
     { id: '2', label: 'XL' },
   ],
@@ -35,6 +34,7 @@ const characteristics = [{
   id: '2',
   label: 'Color',
   values: [
+    { id: '0', label: 'Transparent' },
     { id: '1', label: 'Black' },
     { id: '2', label: 'Blue' },
   ],
@@ -42,6 +42,7 @@ const characteristics = [{
   id: '3',
   label: 'Pattern',
   values: [
+    { id: '0', label: 'No pattern' },
     { id: '1', label: 'None' },
     { id: '2', label: 'Checked' },
     { id: '3', label: 'Stripes' },
@@ -49,7 +50,11 @@ const characteristics = [{
 }];
 
 describe('ProductCharacteristics helpers', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
   describe('findSelectionIndex()', () => {
+    const { findSelectionIndex } = require('./index');
     it('should return the index', () => {
       expect(findSelectionIndex(characteristics, '2')).toBe(1);
     });
@@ -60,6 +65,7 @@ describe('ProductCharacteristics helpers', () => {
   });
 
   describe('prepareState()', () => {
+    const { prepareState } = require('./index');
     it('should return the current selections, when the selected ID is not found', () => {
       const selections = { 1: '1', 2: '1', 3: '1' };
       const result = prepareState('4', '2', selections, characteristics, products);
@@ -134,6 +140,35 @@ describe('ProductCharacteristics helpers', () => {
       });
     });
   });
+  describe('selectCharacteristics()', () => {
+    describe('default config', () => {
+      const { selectCharacteristics } = require('./index');
+      it('should return empty characteristics', () => {
+        expect(selectCharacteristics({})).toEqual({});
+      });
+      it('should return characteristics for selected variant', () => {
+        expect(selectCharacteristics({ variantId: '007-001', variants: { products } }))
+          .toEqual(products[0].characteristics);
+      });
+      it('should preselect characteristics for only 1 variant', () => {
+        expect(selectCharacteristics({ variants: { products: [products[0]] } }))
+          .toEqual(products[0].characteristics);
+      });
+      it('should not preselect characteristics by config', () => {
+        expect(selectCharacteristics({ variants: { products } })).toEqual({});
+      });
+    });
+    describe('preselect config', () => {
+      jest.doMock('@shopgate/pwa-common/helpers/config', () => ({
+        product: { variantPreselect: true },
+      }));
+      it('should preselect characteristics for selectable product', () => {
+        const { selectCharacteristics: selectCharacteristicsPreselect } = require('./index');
+        expect(selectCharacteristicsPreselect({ variants: { characteristics, products } }))
+          .toEqual(products[0].characteristics);
+      });
+    });
+  });
 });
 
-/* eslint-enable extra-rules/no-single-line-objects */
+/* eslint-enable extra-rules/no-single-line-objects,global-require */

--- a/libraries/common/helpers/config/index.js
+++ b/libraries/common/helpers/config/index.js
@@ -5,7 +5,7 @@ import { isObject } from '../validation';
 
 /**
  * Provides a default app config as a fallback.
- * @type {Object}
+ * @mixin AppConfig
  */
 const defaultAppConfig = {
   appId: 'shop_30177',
@@ -31,6 +31,10 @@ const defaultAppConfig = {
   theme: {},
   cartShippingHideAnonymousLegacy: null,
   cartShippingTextAnonymousLegacy: null,
+  variantSelectionMode: null,
+  product: {
+    variantPreselect: false,
+  },
   cart: {},
   scanner: {},
   favorites: {},
@@ -62,7 +66,7 @@ export const componentsConfig = {
 /**
  * The app.json config from the theme which will automatically be resolved.
  * Be careful when changing existing properties on the fly, reassignments should never be done!
- * @type {Object}
+ * @mixes AppConfig
  */
 const appConfig = process.env.NODE_ENV !== 'test' ? process.env.APP_CONFIG : defaultAppConfig;
 
@@ -135,4 +139,5 @@ export function writeToConfig(newConfig, arrayComparator = null) {
 const { appId } = appConfig;
 export const shopNumber = appId ? appId.replace('shop_', '') : '';
 
+/** @mixes AppConfig */
 export default appConfig;

--- a/libraries/common/reducers/page/index.js
+++ b/libraries/common/reducers/page/index.js
@@ -62,10 +62,9 @@ export default function pageReducer(state = {}, action) {
       };
     }
     case APP_WILL_START: {
-      return Object.keys(state).reduce((newState, pageId) => {
-        // eslint-disable-next-line no-param-reassign
-        newState[pageId].expires = 0;
-        return newState;
+      return Object.keys(state).reduce((acc, pageId) => {
+        acc[pageId].expires = 0;
+        return acc;
       }, { ...state });
     }
 

--- a/libraries/engage/product/components/ProductCharacteristics/helpers/index.spec.js
+++ b/libraries/engage/product/components/ProductCharacteristics/helpers/index.spec.js
@@ -1,6 +1,4 @@
-/* eslint-disable extra-rules/no-single-line-objects */
-
-import { findSelectionIndex, prepareState } from './index';
+/* eslint-disable extra-rules/no-single-line-objects,global-require */
 
 const products = [{
   id: '007-001',
@@ -28,6 +26,7 @@ const characteristics = [{
   id: '1',
   label: 'Size',
   values: [
+    { id: '0', label: 'Resilient' },
     { id: '1', label: 'L' },
     { id: '2', label: 'XL' },
   ],
@@ -35,6 +34,7 @@ const characteristics = [{
   id: '2',
   label: 'Color',
   values: [
+    { id: '0', label: 'Transparent' },
     { id: '1', label: 'Black' },
     { id: '2', label: 'Blue' },
   ],
@@ -42,6 +42,7 @@ const characteristics = [{
   id: '3',
   label: 'Pattern',
   values: [
+    { id: '0', label: 'No pattern' },
     { id: '1', label: 'None' },
     { id: '2', label: 'Checked' },
     { id: '3', label: 'Stripes' },
@@ -49,7 +50,13 @@ const characteristics = [{
 }];
 
 describe('ProductCharacteristics helpers', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
   describe('findSelectionIndex()', () => {
+    const { findSelectionIndex } = require('./index');
+
     it('should return the index', () => {
       expect(findSelectionIndex(characteristics, '2')).toBe(1);
     });
@@ -60,6 +67,8 @@ describe('ProductCharacteristics helpers', () => {
   });
 
   describe('prepareState()', () => {
+    const { prepareState } = require('./index');
+
     it('should return the current selections, when the selected ID is not found', () => {
       const selections = { 1: '1', 2: '1', 3: '1' };
       const result = prepareState('4', '2', selections, characteristics, products);
@@ -134,6 +143,41 @@ describe('ProductCharacteristics helpers', () => {
       });
     });
   });
+
+  describe('selectCharacteristics()', () => {
+    describe('default config', () => {
+      const { selectCharacteristics } = require('./index');
+
+      it('should return empty characteristics', () => {
+        expect(selectCharacteristics({})).toEqual({});
+      });
+
+      it('should return characteristics for selected variant', () => {
+        expect(selectCharacteristics({ variantId: '007-001', variants: { products } }))
+          .toEqual(products[0].characteristics);
+      });
+
+      it('should preselect characteristics for only 1 variant', () => {
+        expect(selectCharacteristics({ variants: { products: [products[0]] } }))
+          .toEqual(products[0].characteristics);
+      });
+
+      it('should not preselect characteristics by config', () => {
+        expect(selectCharacteristics({ variants: { products } })).toEqual({});
+      });
+    });
+
+    describe('preselect config', () => {
+      jest.doMock('@shopgate/pwa-common/helpers/config', () => ({
+        product: { variantPreselect: true },
+      }));
+      it('should preselect characteristics for selectable product', () => {
+        const { selectCharacteristics: selectCharacteristicsPreselect } = require('./index');
+        expect(selectCharacteristicsPreselect({ variants: { characteristics, products } }))
+          .toEqual(products[0].characteristics);
+      });
+    });
+  });
 });
 
-/* eslint-enable extra-rules/no-single-line-objects */
+/* eslint-enable extra-rules/no-single-line-objects,global-require */

--- a/libraries/engage/product/components/ProductCharacteristics/index.jsx
+++ b/libraries/engage/product/components/ProductCharacteristics/index.jsx
@@ -8,6 +8,7 @@ import {
   isCharacteristicEnabled,
   getSelectedValue,
   prepareState,
+  selectCharacteristics,
 } from './helpers';
 
 /**
@@ -21,7 +22,10 @@ class ProductCharacteristics extends Component {
     setCharacteristics: PropTypes.func.isRequired,
     finishTimeout: PropTypes.number,
     variantId: PropTypes.string,
-    variants: PropTypes.shape(),
+    variants: PropTypes.shape({
+      characteristics: PropTypes.arrayOf(PropTypes.shape()),
+      products: PropTypes.arrayOf(PropTypes.shape()),
+    }),
   }
 
   static defaultProps = {
@@ -40,12 +44,17 @@ class ProductCharacteristics extends Component {
 
     this.state = {
       highlight: null,
-      characteristics: this.getCharacteristics(props),
+      characteristics: selectCharacteristics(props),
     };
 
     this.setRefs(props);
 
     props.conditioner.addConditioner('product-variants', this.checkSelection);
+  }
+
+  /** @inheritDoc */
+  componentDidMount() {
+    this.checkSelectedCharacteristics();
   }
 
   /**
@@ -56,8 +65,8 @@ class ProductCharacteristics extends Component {
       // Initialize refs and characteristics when the variants prop was updated with a valid value.
       this.setRefs(nextProps);
       this.setState({
-        characteristics: this.getCharacteristics(nextProps),
-      });
+        characteristics: selectCharacteristics(nextProps),
+      }, this.checkSelectedCharacteristics);
     }
   }
 
@@ -73,22 +82,6 @@ class ProductCharacteristics extends Component {
         this.refsStore[char.id] = React.createRef();
       });
     }
-  }
-
-  /**
-   * Creates the characteristics relative to the given props.
-   * @param {Object} props The props to check against.
-   * @return {Object}
-   */
-  getCharacteristics = (props) => {
-    const { variantId, variants } = props;
-
-    if (!variants) {
-      return {};
-    }
-
-    const { characteristics } = variants.products.find(product => product.id === variantId) || {};
-    return characteristics || {};
   }
 
   /**
@@ -128,11 +121,14 @@ class ProductCharacteristics extends Component {
     return selected;
   }
 
-  handleFinished = () => {
+  checkSelectedCharacteristics = () => {
     const { characteristics } = this.state;
-    const {
-      variantId, variants, finishTimeout,
-    } = this.props;
+    const { variantId, variants, finishTimeout } = this.props;
+
+    if (!variants) {
+      return;
+    }
+
     const filteredValues = Object.keys(characteristics).filter(key => !!characteristics[key]);
 
     if (filteredValues.length !== variants.characteristics.length) {
@@ -181,7 +177,7 @@ class ProductCharacteristics extends Component {
         },
         highlight: null,
       };
-    }, this.handleFinished);
+    }, this.checkSelectedCharacteristics);
   }
 
   /**

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -387,6 +387,28 @@
         "label": "Configure the display of cart information."
       }
     },
+    "variantSelectionMode": {
+      "type": "bigApi",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "method": "GET",
+        "service": "config",
+        "path": "/v1/shop/%(shopId)s/product_selection_mode?parsed=true",
+        "key": "value"
+      }
+    },
+    "product": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": {
+        "variantPreselect": false
+      },
+      "params": {
+        "type": "json",
+        "label": "Product settings."
+      }
+    },
     "hasNoScanner": {
       "type": "bigApi",
       "destination": "frontend",

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -379,6 +379,28 @@
         "label": "Configure the display of cart information."
       }
     },
+    "variantSelectionMode": {
+      "type": "bigApi",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "method": "GET",
+        "service": "config",
+        "path": "/v1/shop/%(shopId)s/product_selection_mode?parsed=true",
+        "key": "value"
+      }
+    },
+    "product": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": {
+        "variantPreselect": false
+      },
+      "params": {
+        "type": "json",
+        "label": "Product settings."
+      }
+    },
     "hasNoScanner": {
       "type": "bigApi",
       "destination": "frontend",


### PR DESCRIPTION
# Description

New theme config "product.variantPreselect" is added to pre-select variant on Product Details Page. If product has only 1 variant, it will be always pre-selected.

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [X] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
