### PR TITLE
Added missing portal props in ScannerBar

### DIFF
--- a/libraries/ui-shared/ScannerOverlay/__snapshots__/index.spec.jsx.snap
+++ b/libraries/ui-shared/ScannerOverlay/__snapshots__/index.spec.jsx.snap
@@ -38,15 +38,30 @@ exports[`<ScannerOverlay /> should render the component 1`] = `
     >
       <SurroundPortals
         portalName="scanner.bar"
-        portalProps={null}
+        portalProps={
+          Object {
+            "flashlightState": false,
+            "onToggleFlashlight": [Function],
+          }
+        }
       >
         <Portal
           name="scanner.bar.before"
-          props={null}
+          props={
+            Object {
+              "flashlightState": false,
+              "onToggleFlashlight": [Function],
+            }
+          }
         />
         <Portal
           name="scanner.bar"
-          props={null}
+          props={
+            Object {
+              "flashlightState": false,
+              "onToggleFlashlight": [Function],
+            }
+          }
         >
           <Grid
             className="css-kwl6fj"
@@ -196,7 +211,12 @@ exports[`<ScannerOverlay /> should render the component 1`] = `
         </Portal>
         <Portal
           name="scanner.bar.after"
-          props={null}
+          props={
+            Object {
+              "flashlightState": false,
+              "onToggleFlashlight": [Function],
+            }
+          }
         />
       </SurroundPortals>
     </div>

--- a/libraries/ui-shared/ScannerOverlay/components/ScannerBar/index.jsx
+++ b/libraries/ui-shared/ScannerOverlay/components/ScannerBar/index.jsx
@@ -15,7 +15,13 @@ import styles from './style';
  */
 const ScannerBar = ({ flashlightState, onToggleFlashlight }) => createPortal(
   (
-    <SurroundPortals portalName={SCANNER_BAR}>
+    <SurroundPortals
+      portalName={SCANNER_BAR}
+      portalProps={{
+        flashlightState,
+        onToggleFlashlight,
+      }}
+    >
       <Grid className={styles.container}>
         <Grid.Item className={styles.column}>
           <FlashlightButton onToggle={onToggleFlashlight} flashlightState={flashlightState} />


### PR DESCRIPTION
# Description
This PR adds the properties to the portal so we can use / access them when we replace the portal content.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Replace the portal content and try to use one of both properties.
