### PR TITLE
Fixed flickering pdp ui elements on iOS 13

### DIFF
--- a/libraries/common/components/Swiper/styles.js
+++ b/libraries/common/components/Swiper/styles.js
@@ -14,6 +14,7 @@ export const innerContainer = css({
     height: 'auto',
   },
   ' .swiper-pagination': {
+    transform: 'translate3d(-50%,0,0) !important',
     ' .swiper-pagination-bullet': {
       background: '#808080',
       opacity: '.5',

--- a/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/style.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/style.js
@@ -15,6 +15,7 @@ const buttons = css({
 }).toString();
 
 const favButton = css({
+  transform: 'translate3d(0, 0, 0)',
   marginRight: variables.gap.big,
   zIndex: 1, // Prevents the icons to be visible outside of the circle
   fontSize: iconSize,

--- a/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
@@ -88,7 +88,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
               allowSlideNext={true}
               allowSlidePrev={true}
               autoplay={false}
-              containerClass="css-15qycmt css-sa13d4 css-qb469q"
+              containerClass="css-xvw7af css-sa13d4 css-qb469q"
               freeMode={false}
               getSwiper={[Function]}
               initialSlide={3}
@@ -234,7 +234,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
               }
             >
               <div
-                className="css-15qycmt css-sa13d4 css-qb469q"
+                className="css-xvw7af css-sa13d4 css-qb469q"
               >
                 <div
                   className="swiper-wrapper"
@@ -379,7 +379,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
               allowSlideNext={true}
               allowSlidePrev={true}
               autoplay={false}
-              containerClass="css-15qycmt css-sa13d4 css-qb469q"
+              containerClass="css-xvw7af css-sa13d4 css-qb469q"
               freeMode={false}
               getSwiper={[Function]}
               initialSlide={0}
@@ -525,7 +525,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
               }
             >
               <div
-                className="css-15qycmt css-sa13d4 css-qb469q"
+                className="css-xvw7af css-sa13d4 css-qb469q"
               >
                 <div
                   className="swiper-wrapper"

--- a/themes/theme-gmd/widgets/ImageSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/widgets/ImageSlider/__snapshots__/spec.jsx.snap
@@ -63,7 +63,7 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
           allowSlideNext={true}
           allowSlidePrev={true}
           autoplay={false}
-          containerClass="css-15qycmt"
+          containerClass="css-xvw7af"
           freeMode={false}
           getSwiper={[Function]}
           initialSlide={0}
@@ -203,7 +203,7 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
           zoom={false}
         >
           <div
-            className="css-15qycmt"
+            className="css-xvw7af"
           >
             <div
               className="swiper-wrapper"
@@ -501,7 +501,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
           allowSlideNext={true}
           allowSlidePrev={true}
           autoplay={false}
-          containerClass="css-15qycmt"
+          containerClass="css-xvw7af"
           freeMode={false}
           getSwiper={[Function]}
           initialSlide={0}
@@ -641,7 +641,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
           zoom={false}
         >
           <div
-            className="css-15qycmt"
+            className="css-xvw7af"
           >
             <div
               className="swiper-wrapper"
@@ -787,7 +787,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
           allowSlideNext={true}
           allowSlidePrev={true}
           autoplay={false}
-          containerClass="css-15qycmt"
+          containerClass="css-xvw7af"
           freeMode={false}
           getSwiper={[Function]}
           initialSlide={0}
@@ -927,7 +927,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
           zoom={false}
         >
           <div
-            className="css-15qycmt"
+            className="css-xvw7af"
           >
             <div
               className="swiper-wrapper"

--- a/themes/theme-ios11/pages/Product/components/Header/components/CTAButtons/style.js
+++ b/themes/theme-ios11/pages/Product/components/Header/components/CTAButtons/style.js
@@ -15,6 +15,7 @@ const buttons = css({
 }).toString();
 
 const favButton = css({
+  transform: 'translate3d(0, 0, 0)',
   zIndex: 1, // Prevents the icons to be visible outside of the circle
   fontSize: iconSize,
 }).toString();

--- a/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
@@ -88,7 +88,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
               allowSlideNext={true}
               allowSlidePrev={true}
               autoplay={false}
-              containerClass="css-15qycmt css-sa13d4 css-qb469q"
+              containerClass="css-xvw7af css-sa13d4 css-qb469q"
               freeMode={false}
               getSwiper={[Function]}
               initialSlide={3}
@@ -234,7 +234,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
               }
             >
               <div
-                className="css-15qycmt css-sa13d4 css-qb469q"
+                className="css-xvw7af css-sa13d4 css-qb469q"
               >
                 <div
                   className="swiper-wrapper"
@@ -379,7 +379,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
               allowSlideNext={true}
               allowSlidePrev={true}
               autoplay={false}
-              containerClass="css-15qycmt css-sa13d4 css-qb469q"
+              containerClass="css-xvw7af css-sa13d4 css-qb469q"
               freeMode={false}
               getSwiper={[Function]}
               initialSlide={0}
@@ -525,7 +525,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
               }
             >
               <div
-                className="css-15qycmt css-sa13d4 css-qb469q"
+                className="css-xvw7af css-sa13d4 css-qb469q"
               >
                 <div
                   className="swiper-wrapper"

--- a/themes/theme-ios11/widgets/ImageSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/widgets/ImageSlider/__snapshots__/spec.jsx.snap
@@ -63,7 +63,7 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
           allowSlideNext={true}
           allowSlidePrev={true}
           autoplay={false}
-          containerClass="css-15qycmt"
+          containerClass="css-xvw7af"
           freeMode={false}
           getSwiper={[Function]}
           initialSlide={0}
@@ -203,7 +203,7 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
           zoom={false}
         >
           <div
-            className="css-15qycmt"
+            className="css-xvw7af"
           >
             <div
               className="swiper-wrapper"
@@ -505,7 +505,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
           allowSlideNext={true}
           allowSlidePrev={true}
           autoplay={false}
-          containerClass="css-15qycmt"
+          containerClass="css-xvw7af"
           freeMode={false}
           getSwiper={[Function]}
           initialSlide={0}
@@ -645,7 +645,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
           zoom={false}
         >
           <div
-            className="css-15qycmt"
+            className="css-xvw7af"
           >
             <div
               className="swiper-wrapper"
@@ -793,7 +793,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
           allowSlideNext={true}
           allowSlidePrev={true}
           autoplay={false}
-          containerClass="css-15qycmt"
+          containerClass="css-xvw7af"
           freeMode={false}
           getSwiper={[Function]}
           initialSlide={0}
@@ -933,7 +933,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
           zoom={false}
         >
           <div
-            className="css-15qycmt"
+            className="css-xvw7af"
           >
             <div
               className="swiper-wrapper"


### PR DESCRIPTION
# Description
This ticket is about to fix an issue which occurs on iOS 13 when a pdp was scrolled. In this situation the favourites button and the pagination bullets of the product image gallery where flickering.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Open a PDP for a product with many pictures on an iOS 13 device. Scroll the page up and down with the favourites button inside of the viewport. Neither the favourites button nor the gallery pagination bullets should flicker.