### PR TITLE
Improved extensibility of CTA button portals

### DIFF
--- a/libraries/engage/product/components/MediaSlider/style.js
+++ b/libraries/engage/product/components/MediaSlider/style.js
@@ -3,6 +3,7 @@ import { css } from 'glamor';
 export const full = css({
   width: '100%',
   height: '100%',
+  transform: 'translate3d(0, 0, 0)',
 });
 
 export const videoWrapper = css({
@@ -27,6 +28,7 @@ export const video = css({
 });
 
 export const container = css({
+  transform: 'translate3d(0, 0, 0)',
   position: 'relative',
   top: 0,
   bottom: 0,

--- a/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/style.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/style.js
@@ -15,7 +15,6 @@ const buttons = css({
 }).toString();
 
 const favButton = css({
-  transform: 'translate3d(0, 0, 0)',
   marginRight: variables.gap.big,
   zIndex: 1, // Prevents the icons to be visible outside of the circle
   fontSize: iconSize,

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -132,6 +132,7 @@ class ProductImageSlider extends Component {
     const imageStyle = product ? {
       background: `url(${getActualImageSource(product.featuredImageUrl, fallbackResolutions[0])})`,
       backgroundSize: 'contain',
+      transform: 'translate3d(0, 0, 0)',
     } : null;
 
     return (

--- a/themes/theme-ios11/pages/Product/components/Header/components/CTAButtons/style.js
+++ b/themes/theme-ios11/pages/Product/components/Header/components/CTAButtons/style.js
@@ -15,7 +15,6 @@ const buttons = css({
 }).toString();
 
 const favButton = css({
-  transform: 'translate3d(0, 0, 0)',
   zIndex: 1, // Prevents the icons to be visible outside of the circle
   fontSize: iconSize,
 }).toString();

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -132,6 +132,7 @@ class ProductImageSlider extends Component {
     const imageStyle = product ? {
       background: `url(${getActualImageSource(product.featuredImageUrl, fallbackResolutions[0])})`,
       backgroundSize: 'contain',
+      transform: 'translate3d(0, 0, 0)',
     } : null;
 
     return (


### PR DESCRIPTION
# Description
This ticket solves and issue at the PDP on iOS 13 devices. When additional buttons where added to the CTA button Portals, they flickered when the user scrolled the page.

We already tried to fix the issue earlier, but applied the optimization only to the buttons within the main Portal. The new approach from this PR applies to the fix to the Media components, instead of the CTAButton component.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Checkout and attach the [ext-pdp-native-share](https://github.com/shopgate/ext-pdp-native-share) extension and open a PDP on an iOS 13 device. Scroll a little bit and check if the CTA buttons are still flickering.
