### PR TITLE
Refactored category selectors

### DIFF
--- a/libraries/commerce/category/selectors/index.spec.js
+++ b/libraries/commerce/category/selectors/index.spec.js
@@ -1,0 +1,304 @@
+import { getCurrentRoute, getCurrentParams } from '@shopgate/pwa-common/selectors/router';
+import { bin2hex } from '@shopgate/pwa-common/helpers/data';
+
+import {
+  getCategoryId,
+  getCategory,
+  getRootCategories,
+  getCategoryChildren,
+  getCategoryChildCount,
+  hasCategoryChildren,
+  getCategoryProductCount,
+  hasCategoryProducts,
+  getCategoryName,
+} from './index';
+
+jest.mock('@shopgate/pwa-common/selectors/router', () => ({
+  getCurrentRoute: jest.fn(),
+  getCurrentParams: jest.fn(),
+}));
+
+const mockState = {
+  category: {
+    categoriesById: {
+      r1: {
+        id: 'r1',
+        name: 'Root Category One',
+        childrenCount: 10,
+        productCount: 10,
+        isFetching: false,
+        expires: 123456,
+      },
+      r2: {
+        id: 'r2',
+        name: 'Root Category Two',
+        childrenCount: 11,
+        productCount: 11,
+        isFetching: false,
+        expires: 123456,
+      },
+      c1: {
+        id: 'c1',
+        name: 'Category One',
+        childrenCount: 12,
+        productCount: 12,
+        isFetching: false,
+        expires: 123456,
+      },
+      c2: {
+        id: 'c2',
+        name: 'Category Two',
+        childrenCount: 13,
+        productCount: 13,
+        isFetching: false,
+        expires: 123456,
+      },
+      c3: {
+        id: 'c3',
+        name: 'Category Three',
+        childrenCount: 0,
+        productCount: 0,
+        isFetching: false,
+        expires: 123456,
+      },
+    },
+    childrenByCategoryId: {
+      r1: {
+        children: ['c1', 'c2'],
+        isFetching: false,
+        expires: 123456,
+      },
+      c1: {
+        children: ['c3'],
+        isFetching: false,
+        expires: 123456,
+      },
+    },
+    rootCategories: {
+      categories: ['r1', 'r2'],
+      expires: 123456,
+      isFetching: false,
+    },
+  },
+};
+
+const { categoriesById, childrenByCategoryId } = mockState.category;
+const propCategoryId = 'c2';
+const propCategory = categoriesById[propCategoryId];
+const propCategoryName = propCategory.name;
+const routeCategoryId = 'c1';
+const routeCategory = categoriesById[routeCategoryId];
+const routeCategoryName = routeCategory.name;
+
+describe('Category page selectors', () => {
+  beforeAll(() => {
+    getCurrentParams.mockReturnValue({
+      categoryId: bin2hex(routeCategoryId),
+    });
+
+    getCurrentRoute.mockReturnValue({
+      state: {
+        title: routeCategoryName,
+      },
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getCategoryId()', () => {
+    it('should return the categoryId from the props when present', () => {
+      expect(getCategoryId({}, { categoryId: routeCategoryId })).toBe(routeCategoryId);
+    });
+
+    it('should return the categoryId from the current route params', () => {
+      expect(getCategoryId({})).toBe(routeCategoryId);
+    });
+
+    it('should return NULL when no categoryId is present within the props or the current route', () => {
+      getCurrentParams.mockReturnValueOnce(undefined);
+      expect(getCategoryId({})).toBeNull();
+      getCurrentParams.mockReturnValueOnce({});
+      expect(getCategoryId({})).toBeNull();
+    });
+  });
+
+  describe('getCategory()', () => {
+    it('should return the category from the props', () => {
+      expect(getCategory(mockState, { categoryId: propCategoryId })).toBe(propCategory);
+    });
+
+    it('should return the category from the route', () => {
+      expect(getCategory(mockState)).toBe(routeCategory);
+    });
+
+    it('should return NULL when the category from the props does not exist', () => {
+      expect(getCategory(mockState, { categoryId: 'invalid' })).toBeNull();
+    });
+
+    it('should return NULL when category data is not available yet', () => {
+      expect(getCategory({})).toBeNull();
+    });
+  });
+
+  describe('getRootCategories()', () => {
+    it('should get the root categories', () => {
+      expect(getRootCategories(mockState)).toEqual([categoriesById.r1, categoriesById.r2]);
+    });
+
+    it('should return NULL when the root categories state is empty', () => {
+      expect(getRootCategories({
+        category: {
+          ...mockState.category,
+          rootCategories: {},
+        },
+      })).toBeNull();
+    });
+
+    it('should return NULL when no root categories are available yet', () => {
+      expect(getRootCategories({
+        category: {
+          ...mockState.category,
+          rootCategories: {
+            ...mockState.category.rootCategories,
+            categories: undefined,
+          },
+        },
+      })).toBeNull();
+    });
+
+    it('should return an empty array when no matching category data can be determined', () => {
+      expect(getRootCategories({
+        category: {
+          ...mockState.category,
+          categoriesById: {},
+        },
+      })).toEqual([]);
+    });
+  });
+
+  describe('getCategoryChildCount()', () => {
+    it('should return the correct count for a categoryId within the props', () => {
+      expect(getCategoryChildCount(mockState, { categoryId: propCategoryId }))
+        .toBe(propCategory.childrenCount);
+    });
+
+    it('should return the correct count for the categoryId within the route', () => {
+      expect(getCategoryChildCount(mockState))
+        .toBe(routeCategory.childrenCount);
+    });
+
+    it('should return NULL when no category can be determined', () => {
+      expect(getCategoryChildCount(mockState, { categoryId: 'invalid' })).toBeNull();
+    });
+  });
+
+  describe('hasCategoryChildren()', () => {
+    it('should return TRUE for a category from the props with children', () => {
+      expect(hasCategoryChildren(mockState, { categoryId: propCategoryId })).toBe(true);
+    });
+
+    it('should return TRUE for a category from the route with children', () => {
+      expect(hasCategoryChildren(mockState)).toBe(true);
+    });
+
+    it('should return FALSE for a category without children', () => {
+      expect(hasCategoryChildren(mockState, { categoryId: 'c4' })).toBe(false);
+    });
+
+    it('should return FALSE for an invalid category', () => {
+      expect(hasCategoryChildren(mockState, { categoryId: 'invalid' })).toBe(false);
+    });
+  });
+
+  describe('getCategoryChildren()', () => {
+    it('should return child categories for a category from the props', () => {
+      const categoryId = 'r1';
+      const expected = childrenByCategoryId[categoryId].children
+        .map(childId => categoriesById[childId]);
+
+      expect(getCategoryChildren(mockState, { categoryId })).toEqual(expected);
+    });
+
+    it('should return child categories for a category from the route', () => {
+      const categoryId = routeCategoryId;
+      const expected = childrenByCategoryId[categoryId].children
+        .map(childId => categoriesById[childId]);
+
+      expect(getCategoryChildren(mockState)).toEqual(expected);
+    });
+
+    it('should return NULL when no child categories entry can be determined', () => {
+      expect(getCategoryChildren(mockState, { categoryId: 'invalid' })).toBeNull();
+    });
+
+    it('should return NULL when no child categories entry can be determined', () => {
+      expect(getCategoryChildren({
+        category: {
+          ...mockState.category,
+          childrenByCategoryId: {
+            ...mockState.category.childrenByCategoryId,
+            [routeCategoryId]: {
+              ...mockState.category.childrenByCategoryId[routeCategoryId],
+              children: undefined,
+            },
+          },
+        },
+      }, { category: routeCategoryId })).toBeNull();
+    });
+  });
+
+  describe('getCategoryProductCount()', () => {
+    it('should return the correct count for a categoryId within the props', () => {
+      expect(getCategoryProductCount(mockState, { categoryId: propCategoryId }))
+        .toBe(propCategory.productCount);
+    });
+
+    it('should return the correct count for the categoryId within the route', () => {
+      expect(getCategoryProductCount(mockState))
+        .toBe(routeCategory.productCount);
+    });
+
+    it('should return NULL when no category can be determined', () => {
+      expect(getCategoryProductCount(mockState, { categoryId: 'invalid' })).toBeNull();
+    });
+
+    it('should return 0 when the category has no products', () => {
+      expect(getCategoryProductCount(mockState, { categoryId: 'c3' })).toBe(0);
+    });
+  });
+
+  describe('hasCategoryProducts()', () => {
+    it('should return TRUE for a category from the props with products', () => {
+      expect(hasCategoryProducts(mockState, { categoryId: propCategoryId })).toBe(true);
+    });
+
+    it('should return TRUE for a category from the route with products', () => {
+      expect(hasCategoryProducts(mockState)).toBe(true);
+    });
+
+    it('should return FALSE for a category without products', () => {
+      expect(hasCategoryProducts(mockState, { categoryId: 'c4' })).toBe(false);
+    });
+
+    it('should return FALSE for an invalid category', () => {
+      expect(hasCategoryProducts(mockState, { categoryId: 'invalid' })).toBe(false);
+    });
+  });
+
+  describe('getCategoryName()', () => {
+    it('should return the title from the route state when no categoryId is passed witin the props', () => {
+      expect(getCategoryName(mockState)).toBe(routeCategoryName);
+    });
+
+    it('should return the name of a category from the props', () => {
+      expect(getCategoryName(mockState, { categoryId: propCategoryId })).toBe(propCategoryName);
+    });
+
+    it('should return NULL when no category name can be determined', () => {
+      getCurrentRoute.mockReturnValueOnce({ state: {} });
+      expect(getCategoryName(mockState, { categoryId: 'invalid' })).toBeNull();
+    });
+  });
+});

--- a/libraries/commerce/scanner/actions/handleQrCode.js
+++ b/libraries/commerce/scanner/actions/handleQrCode.js
@@ -2,7 +2,7 @@ import { historyPop, historyReplace } from '@shopgate/pwa-common/actions/router'
 import { fetchPageConfig } from '@shopgate/pwa-common/actions/page';
 import { getPageConfigById } from '@shopgate/pwa-common/selectors/page';
 import { fetchProductsById, getProductById } from '@shopgate/pwa-common-commerce/product';
-import { fetchCategory, getCategoryById } from '@shopgate/pwa-common-commerce/category';
+import { fetchCategory, getCategory } from '@shopgate/pwa-common-commerce/category';
 import successHandleScanner from '../action-creators/successHandleScanner';
 import {
   QR_CODE_TYPE_CATEGORY,
@@ -76,7 +76,7 @@ export default ({ scope, format, payload }) => async (dispatch, getState) => {
     case QR_CODE_TYPE_CATEGORY:
       await dispatch(fetchCategory(data.categoryId));
 
-      if (!getCategoryById(getState(), data)) {
+      if (!getCategory(getState(), data)) {
         notFound();
       } else {
         dispatch(successHandleScanner(scope, format, payload));

--- a/libraries/commerce/scanner/actions/handleQrCode.spec.js
+++ b/libraries/commerce/scanner/actions/handleQrCode.spec.js
@@ -4,7 +4,7 @@ import { historyReplace, historyPop } from '@shopgate/pwa-common/actions/router'
 import { fetchPageConfig } from '@shopgate/pwa-common/actions/page';
 import { getPageConfigById } from '@shopgate/pwa-common/selectors/page';
 import { fetchProductsById, getProductById } from '@shopgate/pwa-common-commerce/product';
-import { fetchCategory, getCategoryById } from '@shopgate/pwa-common-commerce/category';
+import { fetchCategory, getCategory } from '@shopgate/pwa-common-commerce/category';
 import {
   QR_CODE_TYPE_HOMEPAGE,
   QR_CODE_TYPE_PRODUCT,
@@ -36,7 +36,7 @@ jest.mock('@shopgate/pwa-common-commerce/product', () => ({
 }));
 jest.mock('@shopgate/pwa-common-commerce/category', () => ({
   fetchCategory: jest.fn().mockResolvedValue(null),
-  getCategoryById: jest.fn(),
+  getCategory: jest.fn(),
 }));
 jest.mock('../helpers', () => ({
   parse2dsQrCode: jest.fn(),
@@ -186,14 +186,14 @@ describe('handleQrCode', () => {
     });
 
     it('should trigger "no result" handling when the category is not found', async () => {
-      getCategoryById.mockReturnValue(null);
+      getCategory.mockReturnValue(null);
       const event = { scope, format, payload };
       await handleQrCode(event)(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith(handleNoResults(event, 'scanner.noResult.qrCode'));
     });
 
     it('should navigate to PLP when category exists', async () => {
-      getCategoryById.mockReturnValue(true);
+      getCategory.mockReturnValue(true);
       await handleQrCode({ scope, format, payload })(dispatch, getState);
       expect(historyReplace).toHaveBeenCalledWith({
         pathname: '/category/SG2',

--- a/libraries/tracking/selectors/category.js
+++ b/libraries/tracking/selectors/category.js
@@ -8,7 +8,7 @@ import {
   CATEGORY_PATTERN,
   ROOT_CATEGORY_PATTERN,
   getRootCategories,
-  getCategoryById,
+  getCategory,
 } from '@shopgate/engage/category';
 import {
   createCategoryData,
@@ -34,7 +34,7 @@ export const makeGetRouteCategory = () => {
       if (pattern === ROOT_CATEGORY_PATTERN) {
         return createRootCategoryData(rootCategories);
       } if (pattern === CATEGORY_PATTERN && decodedCategoryId) {
-        return createCategoryData(getCategoryById(state, { categoryId: decodedCategoryId }));
+        return createCategoryData(getCategory(state, { categoryId: decodedCategoryId }));
       }
 
       return null;

--- a/themes/theme-gmd/components/FilterBar/components/Content/selectors.js
+++ b/themes/theme-gmd/components/FilterBar/components/Content/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import {
   getCategoryProductCount,
-  getCurrentCategoryChildCount,
+  getCategoryChildCount,
 } from '@shopgate/pwa-common-commerce/category/selectors';
 import { getProductsResult } from '@shopgate/pwa-common-commerce/product/selectors/product';
 import { hasActiveFilters } from '@shopgate/pwa-common-commerce/filter/selectors';
@@ -11,7 +11,7 @@ import { hasActiveFilters } from '@shopgate/pwa-common-commerce/filter/selectors
   * @return {bool}
   */
 export const isFilterBarShown = createSelector(
-  getCurrentCategoryChildCount,
+  getCategoryChildCount,
   getCategoryProductCount,
   hasActiveFilters,
   getProductsResult,

--- a/themes/theme-gmd/pages/Category/components/CategoryListContent/connector.js
+++ b/themes/theme-gmd/pages/Category/components/CategoryListContent/connector.js
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import {
-  getChildCategoriesById,
-  getCurrentCategoryChildCount,
-  hasChildren,
+  getCategoryChildren,
+  getCategoryChildCount,
+  hasCategoryChildren,
 } from '@shopgate/pwa-common-commerce/category/selectors';
 
 /**
@@ -13,9 +13,9 @@ import {
  * @return {Object} The extended component props.
  */
 const mapStateToProps = (state, props) => ({
-  categories: getChildCategoriesById(state, props),
-  hasChildren: hasChildren(state, props),
-  childrenCount: getCurrentCategoryChildCount(state, props),
+  categories: getCategoryChildren(state, props),
+  hasChildren: hasCategoryChildren(state, props),
+  childrenCount: getCategoryChildCount(state, props),
 });
 
 /**

--- a/themes/theme-gmd/pages/Category/components/Content/connector.js
+++ b/themes/theme-gmd/pages/Category/components/Content/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { hasChildren, hasProducts } from '@shopgate/pwa-common-commerce/category/selectors';
+import { hasCategoryChildren, hasCategoryProducts } from '@shopgate/pwa-common-commerce/category/selectors';
 
 /**
  * Maps the contents of the state to the component props.
@@ -8,8 +8,8 @@ import { hasChildren, hasProducts } from '@shopgate/pwa-common-commerce/category
  * @return {Object} The extended component props.
  */
 const mapStateToProps = (state, props) => ({
-  hasProducts: hasProducts(state, props),
-  hasChildren: hasChildren(state, props),
+  hasProducts: hasCategoryProducts(state, props),
+  hasChildren: hasCategoryChildren(state, props),
 });
 
 /**

--- a/themes/theme-gmd/pages/Category/components/Empty/selectors.js
+++ b/themes/theme-gmd/pages/Category/components/Empty/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import {
   getCategoryProductCount,
-  getCurrentCategoryChildCount,
+  getCategoryChildCount,
 } from '@shopgate/pwa-common-commerce/category/selectors';
 import { getProductsResult } from '@shopgate/pwa-common-commerce/product/selectors/product';
 
@@ -11,7 +11,7 @@ import { getProductsResult } from '@shopgate/pwa-common-commerce/product/selecto
  */
 export const isCategoryEmpty = createSelector(
   getCategoryProductCount,
-  getCurrentCategoryChildCount,
+  getCategoryChildCount,
   getProductsResult,
   (productCount, childrenCount, { products, totalProductCount }) => {
     if (childrenCount !== 0) {

--- a/themes/theme-gmd/widgets/selectors.js
+++ b/themes/theme-gmd/widgets/selectors.js
@@ -7,7 +7,7 @@ import {
   getProduct,
 } from '@shopgate/pwa-common-commerce/product/selectors/product';
 import {
-  getChildCategoriesById,
+  getCategoryChildren,
   getRootCategories,
 } from '@shopgate/pwa-common-commerce/category/selectors';
 import * as pipelines from '@shopgate/pwa-common-commerce/product/constants/Pipelines';
@@ -163,7 +163,7 @@ export const getProductsFetchingState = createSelector(
  * @returns {Object[]} The categories collection.
  */
 export const getCategoriesById = createSelector(
-  getChildCategoriesById,
+  getCategoryChildren,
   getRootCategories,
   (state, props) => props.categoryId,
   (childCategories, rootCategories, categoryId) => {

--- a/themes/theme-ios11/components/FilterBar/components/Content/selectors.js
+++ b/themes/theme-ios11/components/FilterBar/components/Content/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import {
   getCategoryProductCount,
-  getCurrentCategoryChildCount,
+  getCategoryChildCount,
 } from '@shopgate/pwa-common-commerce/category/selectors';
 import { getProductsResult } from '@shopgate/pwa-common-commerce/product/selectors/product';
 import { hasActiveFilters } from '@shopgate/pwa-common-commerce/filter/selectors';
@@ -11,7 +11,7 @@ import { hasActiveFilters } from '@shopgate/pwa-common-commerce/filter/selectors
   * @return {bool}
   */
 export const isFilterBarShown = createSelector(
-  getCurrentCategoryChildCount,
+  getCategoryChildCount,
   getCategoryProductCount,
   hasActiveFilters,
   getProductsResult,

--- a/themes/theme-ios11/pages/Category/components/CategoryListContent/connector.js
+++ b/themes/theme-ios11/pages/Category/components/CategoryListContent/connector.js
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import {
-  getChildCategoriesById,
-  getCurrentCategoryChildCount,
-  hasChildren,
+  getCategoryChildren,
+  getCategoryChildCount,
+  hasCategoryChildren,
 } from '@shopgate/pwa-common-commerce/category/selectors';
 
 /**
@@ -13,9 +13,9 @@ import {
  * @return {Object} The extended component props.
  */
 const mapStateToProps = (state, props) => ({
-  categories: getChildCategoriesById(state, props),
-  hasChildren: hasChildren(state, props),
-  childrenCount: getCurrentCategoryChildCount(state, props),
+  categories: getCategoryChildren(state, props),
+  hasChildren: hasCategoryChildren(state, props),
+  childrenCount: getCategoryChildCount(state, props),
 });
 
 /**

--- a/themes/theme-ios11/pages/Category/components/Content/connector.js
+++ b/themes/theme-ios11/pages/Category/components/Content/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { hasChildren, hasProducts } from '@shopgate/pwa-common-commerce/category/selectors';
+import { hasCategoryChildren, hasCategoryProducts } from '@shopgate/pwa-common-commerce/category/selectors';
 
 /**
  * Maps the contents of the state to the component props.
@@ -8,8 +8,8 @@ import { hasChildren, hasProducts } from '@shopgate/pwa-common-commerce/category
  * @return {Object} The extended component props.
  */
 const mapStateToProps = (state, props) => ({
-  hasProducts: hasProducts(state, props),
-  hasChildren: hasChildren(state, props),
+  hasProducts: hasCategoryProducts(state, props),
+  hasChildren: hasCategoryChildren(state, props),
 });
 
 /**

--- a/themes/theme-ios11/pages/Category/components/Empty/selectors.js
+++ b/themes/theme-ios11/pages/Category/components/Empty/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import {
   getCategoryProductCount,
-  getCurrentCategoryChildCount,
+  getCategoryChildCount,
 } from '@shopgate/pwa-common-commerce/category/selectors';
 import { getProductsResult } from '@shopgate/pwa-common-commerce/product/selectors/product';
 
@@ -11,7 +11,7 @@ import { getProductsResult } from '@shopgate/pwa-common-commerce/product/selecto
  */
 export const isCategoryEmpty = createSelector(
   getCategoryProductCount,
-  getCurrentCategoryChildCount,
+  getCategoryChildCount,
   getProductsResult,
   (productCount, childrenCount, { products, totalProductCount }) => {
     if (childrenCount !== 0) {

--- a/themes/theme-ios11/widgets/selectors.js
+++ b/themes/theme-ios11/widgets/selectors.js
@@ -7,7 +7,7 @@ import {
   getProduct,
 } from '@shopgate/pwa-common-commerce/product/selectors/product';
 import {
-  getChildCategoriesById,
+  getCategoryChildren,
   getRootCategories,
 } from '@shopgate/pwa-common-commerce/category/selectors';
 import * as pipelines from '@shopgate/pwa-common-commerce/product/constants/Pipelines';
@@ -163,7 +163,7 @@ export const getProductsFetchingState = createSelector(
  * @returns {Object[]} The categories collection.
  */
 export const getCategoriesById = createSelector(
-  getChildCategoriesById,
+  getCategoryChildren,
   getRootCategories,
   (state, props) => props.categoryId,
   (childCategories, rootCategories, categoryId) => {


### PR DESCRIPTION
# Description
This PR is about to improve the category selectors from the `@shopgate/pwa-common-commerce` package. It improves the naming of all selectors, so that they all follow a unified schema. Additionally similar selectors where merged into one to avoid confusion during consultation of the documentation.

To keep backwards compatibility a mapping between old imports and the new selectors is provided.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
