### PR TITLE
Updated react-spring module to the latest version

### DIFF
--- a/libraries/ui-material/SnackBar/index.jsx
+++ b/libraries/ui-material/SnackBar/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Spring, config } from 'react-spring';
+import { config } from 'react-spring';
+import { Spring } from 'react-spring/renderprops.cjs';
 import Ellipsis from '@shopgate/pwa-common/components/Ellipsis';
 import I18n from '@shopgate/pwa-common/components/I18n';
 import styles from './style';

--- a/libraries/ui-material/package.json
+++ b/libraries/ui-material/package.json
@@ -15,7 +15,7 @@
     "color": "^3.1.0",
     "glamor": "^2.20.40",
     "prop-types": "^15.6.2",
-    "react-spring": "^6.1.8",
+    "react-spring": "^8.0.27",
     "react-transition-group": "^2.2.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -748,7 +748,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
   integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
@@ -7647,14 +7647,7 @@ react-sizeme@^2.3.6:
     lodash.throttle "^4.1.1"
     shallowequal "^1.0.2"
 
-react-spring@^6.1.8:
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-6.1.10.tgz#ae28796dccfb32baa02d34fb94289c2088f63a1b"
-  integrity sha512-msMoHyXHzb3KdHNY6Yo6wm1t+1GKjy6k2kqaYT3bG6nM//HOL5798OD6Qg719SEDskRDh2vXxIyJ5KEoAUbecA==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-
-react-spring@^8.0.15:
+react-spring@^8.0.15, react-spring@^8.0.27:
   version "8.0.27"
   resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.27.tgz#97d4dee677f41e0b2adcb696f3839680a3aa356a"
   integrity sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==


### PR DESCRIPTION
# Description
This ticket updates the `react-spring` module within `@shopgate/pwa-ui-material` to the latest version (^8.0.27). This was necessary as a workaround for a potential bug within `@shopgate/cloud-sdk-webpack` where the local modules within the `@shopgate/pwa-ui-material` where ignored.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
