### PR TITLE
Fixed an issue where the cart loading indicator didn't stop

### DIFF
--- a/libraries/commerce/cart/subscriptions/index.js
+++ b/libraries/commerce/cart/subscriptions/index.js
@@ -135,7 +135,7 @@ export default function cart(subscribe) {
   });
 
   subscribe(cartIdle$, () => {
-    LoadingProvider.unsetLoading(CART_PATH);
+    LoadingProvider.resetLoading(CART_PATH);
   });
 
   subscribe(cartDidEnterOrAppDidStart$, ({ dispatch }) => {

--- a/libraries/common/providers/loading/index.jsx
+++ b/libraries/common/providers/loading/index.jsx
@@ -9,6 +9,8 @@ import LoadingContext from './context';
 class LoadingProvider extends Component {
   static SET = 'loading_set';
 
+  static RESET = 'loading_reset';
+
   static UNSET = 'loading_unset';
 
   static propTypes = {
@@ -16,7 +18,7 @@ class LoadingProvider extends Component {
   }
 
   /**
-   * Adds or increases a loading counter for a path.
+   * Adds or increases the loading counter for a path.
    * @param {string} path The path which loads.
    */
   static setLoading(path) {
@@ -24,7 +26,15 @@ class LoadingProvider extends Component {
   }
 
   /**
-   * Decreases a loading counter for a path.
+   * Resets the loading counter for a path.
+   * @param {string} path The path which loads.
+   */
+  static resetLoading(path) {
+    UIEvents.emit(LoadingProvider.RESET, path);
+  }
+
+  /**
+   * Decreases the loading counter for a path.
    * @param {string} path The path which loads.
    */
   static unsetLoading(path) {
@@ -43,6 +53,7 @@ class LoadingProvider extends Component {
     };
 
     UIEvents.addListener(this.constructor.SET, this.setLoading);
+    UIEvents.addListener(this.constructor.RESET, this.resetLoading);
     UIEvents.addListener(this.constructor.UNSET, this.unsetLoading);
   }
 
@@ -61,6 +72,7 @@ class LoadingProvider extends Component {
    */
   componentWillUnmount() {
     UIEvents.removeListener(this.constructor.SET, this.setLoading);
+    UIEvents.removeListener(this.constructor.RESET, this.resetLoading);
     UIEvents.removeListener(this.constructor.UNSET, this.unsetLoading);
   }
 
@@ -78,7 +90,7 @@ class LoadingProvider extends Component {
   }
 
   /**
-   * Adds or increases a loading counter for a path.
+   * Adds or increases the loading counter for a path.
    * @param {string} path The path which loads.
    */
   setLoading = (path) => {
@@ -98,7 +110,24 @@ class LoadingProvider extends Component {
   }
 
   /**
-   * Decreases a loading counter for a path.
+   * Resets the loading counter for a path.
+   * @param {string} path The path which loads.
+   */
+  resetLoading = (path) => {
+    const { loading } = this.state;
+
+    if (loading.has(path)) {
+      loading.delete(path);
+    }
+
+    this.setState({
+      lastUpdate: Date.now(),
+      loading,
+    });
+  }
+
+  /**
+   * Decreases the loading counter for a path.
    * @param {string} path The path which loads.
    */
   unsetLoading = (path) => {

--- a/libraries/common/providers/loading/index.spec.jsx
+++ b/libraries/common/providers/loading/index.spec.jsx
@@ -79,9 +79,11 @@ describe('LoadingProvider', () => {
 
   it('should register event listeners within the constructor', () => {
     const wrapper = createWrapper();
-    expect(UIEvents.addListener).toHaveBeenCalledTimes(2);
+    expect(UIEvents.addListener).toHaveBeenCalledTimes(3);
     expect(UIEvents.addListener)
       .toHaveBeenCalledWith(LoadingProvider.SET, wrapper.instance().setLoading);
+    expect(UIEvents.addListener)
+      .toHaveBeenCalledWith(LoadingProvider.RESET, wrapper.instance().resetLoading);
     expect(UIEvents.addListener)
       .toHaveBeenCalledWith(LoadingProvider.UNSET, wrapper.instance().unsetLoading);
   });
@@ -89,9 +91,11 @@ describe('LoadingProvider', () => {
   it('should remove event listeners within componentWillUnmount', () => {
     const wrapper = createWrapper();
     wrapper.unmount();
-    expect(UIEvents.removeListener).toHaveBeenCalledTimes(2);
+    expect(UIEvents.removeListener).toHaveBeenCalledTimes(3);
     expect(UIEvents.removeListener)
       .toHaveBeenCalledWith(LoadingProvider.SET, expect.any(Function));
+    expect(UIEvents.removeListener)
+      .toHaveBeenCalledWith(LoadingProvider.RESET, expect.any(Function));
     expect(UIEvents.removeListener)
       .toHaveBeenCalledWith(LoadingProvider.UNSET, expect.any(Function));
   });
@@ -101,6 +105,14 @@ describe('LoadingProvider', () => {
       LoadingProvider.setLoading(MOCKED_PATH);
       expect(UIEvents.emit).toHaveBeenCalledTimes(1);
       expect(UIEvents.emit).toHaveBeenCalledWith(LoadingProvider.SET, MOCKED_PATH);
+    });
+  });
+
+  describe('LoadingProvider.resetLoading()', () => {
+    it('should emit the RESET event', () => {
+      LoadingProvider.resetLoading(MOCKED_PATH);
+      expect(UIEvents.emit).toHaveBeenCalledTimes(1);
+      expect(UIEvents.emit).toHaveBeenCalledWith(LoadingProvider.RESET, MOCKED_PATH);
     });
   });
 
@@ -125,6 +137,25 @@ describe('LoadingProvider', () => {
       instance.setLoading(MOCKED_PATH);
       expect(loading.has(MOCKED_PATH)).toBe(true);
       expect(loading.get(MOCKED_PATH)).toBe(2);
+    });
+  });
+
+  describe('.resetLoading()', () => {
+    it('should resets the loading counter for a path', () => {
+      const instance = createWrapper().instance();
+      const { loading } = instance.state;
+      expect(loading.has(MOCKED_PATH)).toBe(false);
+
+      instance.resetLoading(MOCKED_PATH);
+      expect(loading.has(MOCKED_PATH)).toBe(false);
+
+      instance.setLoading(MOCKED_PATH);
+      instance.setLoading(MOCKED_PATH);
+      expect(loading.has(MOCKED_PATH)).toBe(true);
+      expect(loading.get(MOCKED_PATH)).toBe(2);
+
+      instance.resetLoading(MOCKED_PATH);
+      expect(loading.has(MOCKED_PATH)).toBe(false);
     });
   });
 

--- a/themes/theme-gmd/e2e/elements/de.js
+++ b/themes/theme-gmd/e2e/elements/de.js
@@ -69,7 +69,7 @@ export default {
   contextMenu: "[data-test-id='contextMenu']",
   contextMenuButton: "[data-test-id='contextMenuButton'] span",
   productWithManyProps4CartitemPrice: "[data-test-id='cartItem'] [data-test-id='minPrice: 0 price: 199 currency: EUR']",
-  productWithManyProps4CartSubTotal: "[data-test-id='subTotalCartTotal'] div:nth-child(2) span",
+  productWithManyProps4CartSubTotal: "[data-test-id='subTotalCartTotal'] div:nth-child(2)",
   shippingLabel: "[data-test-id='shippingCartTotal'] div:nth-child(1)",
   taxDisclaimerFooter: "[data-test-id='taxDisclaimer'] span",
   couponFieldInput: "[data-test-id='couponField'] input",


### PR DESCRIPTION
# Description
Cart fetching processes where recently optimized, so that for multiple in parallel running `fetchCart` requests only the last incoming response is further processes. This broke the loading indicator concept of the cart.

Before we've had a counter which was increased when a request was dispatched, and decreased when the response came in. A counter > 0 triggered the loading animation. The new cart request optimizations interfere with the counter concept.

This PR introduces the possibility to hard reset the loading counter within the underlying `LoadingProvider`, so that the indicator stops when the cart is treated as IDLE again.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
The issue can be easily reproduced within the app, but not within the browser. But you can use a tiny little trick:

Setup a little global helper function within a subscription which dispatches the `fetchCart` action. Now call it multiple times in quick succession. The cart shouldn't be stuck in loading state anymore.