### PR TITLE
Removed scanner icon from a11y tree at iOS browse page

### DIFF
--- a/themes/theme-ios11/pages/Browse/components/SearchField/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/__snapshots__/spec.jsx.snap
@@ -129,6 +129,7 @@ exports[`<Content /> Check search field should render with initial search query 
                 props={null}
               >
                 <button
+                  aria-hidden={true}
                   className="css-10ml0si"
                   onClick={[Function]}
                   type="button"

--- a/themes/theme-ios11/pages/Browse/components/SearchField/index.jsx
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/index.jsx
@@ -229,7 +229,7 @@ class SearchField extends Component {
       <Fragment>
         <Portal name={SCANNER_ICON_BEFORE} />
         <Portal name={SCANNER_ICON}>
-          <button className={styles.scannerIcon} onClick={this.props.openScanner} type="button">
+          <button className={styles.scannerIcon} onClick={this.props.openScanner} type="button" aria-hidden>
             <BarcodeScannerIcon />
           </button>
         </Portal>


### PR DESCRIPTION
# Description
This PR removes the scanner icon from the a11y tree of the search bar of the iOS browse page.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
