### PR TITLE
Improved a11y labels of price range filter chips

### DIFF
--- a/themes/theme-gmd/components/FilterBar/components/Content/components/FilterChips/index.jsx
+++ b/themes/theme-gmd/components/FilterBar/components/Content/components/FilterChips/index.jsx
@@ -90,12 +90,13 @@ class FilterChips extends Component {
           const [minimum, maximum] = filter.value;
           const priceMin = Math.floor(minimum / 100);
           const priceMax = Math.ceil(maximum / 100);
-          const pricesFormatted = [
-            i18n.price(priceMin, appConfig.currency, false),
-            '-',
-            i18n.price(priceMax, appConfig.currency, false),
-          ].join(' ');
-          const labelValue = `${filter.label}: ${pricesFormatted}`;
+          const fromPrice = i18n.price(priceMin, appConfig.currency, false);
+          const toPrice = i18n.price(priceMax, appConfig.currency, false);
+          const pricesFormatted = `${fromPrice} - ${toPrice}`;
+          const labelValue = i18n.text('price.range', {
+            fromPrice,
+            toPrice,
+          });
           const removeLabel = i18n.text('filter.remove', { filter: labelValue });
           const editLabel = i18n.text('filter.edit', { filter: labelValue });
 

--- a/themes/theme-ios11/components/FilterBar/components/Content/components/FilterChips/index.jsx
+++ b/themes/theme-ios11/components/FilterBar/components/Content/components/FilterChips/index.jsx
@@ -90,12 +90,13 @@ class FilterChips extends Component {
           const [minimum, maximum] = filter.value;
           const priceMin = Math.floor(minimum / 100);
           const priceMax = Math.ceil(maximum / 100);
-          const pricesFormatted = [
-            i18n.price(priceMin, appConfig.currency, false),
-            '-',
-            i18n.price(priceMax, appConfig.currency, false),
-          ].join(' ');
-          const labelValue = `${filter.label}: ${pricesFormatted}`;
+          const fromPrice = i18n.price(priceMin, appConfig.currency, false);
+          const toPrice = i18n.price(priceMax, appConfig.currency, false);
+          const pricesFormatted = `${fromPrice} - ${toPrice}`;
+          const labelValue = i18n.text('price.range', {
+            fromPrice,
+            toPrice,
+          });
           const removeLabel = i18n.text('filter.remove', { filter: labelValue });
           const editLabel = i18n.text('filter.edit', { filter: labelValue });
 


### PR DESCRIPTION
# Description
This ticket improves the a11y labels of price range filter chips, so that they are reliable read as a price range.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
