### PR TITLE
A11y: Live messages are cleared after reading

### DIFF
--- a/libraries/common/components/ProductCharacteristics/index.jsx
+++ b/libraries/common/components/ProductCharacteristics/index.jsx
@@ -111,7 +111,6 @@ class ProductCharacteristics extends Component {
         ref.current.focus();
         const option = ref.current.innerText;
         broadcastLiveMessage('product.pick_option_first', {
-          force: true,
           params: { option },
         });
 

--- a/libraries/engage/a11y/components/LiveMessenger/__tests__/helpers.spec.js
+++ b/libraries/engage/a11y/components/LiveMessenger/__tests__/helpers.spec.js
@@ -12,6 +12,8 @@ jest.mock('../../../../core', () => ({
   },
 }));
 
+jest.useFakeTimers();
+
 describe('LiveMessenger helpers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -23,11 +25,11 @@ describe('LiveMessenger helpers', () => {
       type: LIVE_MESSAGE_TYPE_POLITE,
       params: null,
       id: null,
-      force: false,
     };
 
     it('should not broadcast without a message', () => {
       broadcastLiveMessage();
+      jest.runAllTimers();
       expect(UIEvents.emit).not.toHaveBeenCalled();
     });
 
@@ -35,6 +37,10 @@ describe('LiveMessenger helpers', () => {
       broadcastLiveMessage(message);
       expect(UIEvents.emit).toHaveBeenCalledTimes(1);
       expect(UIEvents.emit).toHaveBeenCalledWith(EVENT_LIVE_MESSAGE, message, defaultOptions);
+
+      jest.runAllTimers();
+      expect(UIEvents.emit).toHaveBeenCalledTimes(2);
+      expect(UIEvents.emit).toHaveBeenCalledWith(EVENT_LIVE_MESSAGE, '', defaultOptions);
     });
 
     it('should broadcast with some options', () => {
@@ -48,28 +54,13 @@ describe('LiveMessenger helpers', () => {
       expect(UIEvents.emit).toHaveBeenCalledTimes(1);
       expect(UIEvents.emit).toHaveBeenCalledWith(EVENT_LIVE_MESSAGE, message, {
         ...options,
-        force: false,
       });
-    });
 
-    it('should broadcast an empty message when the FORCE option is set', (done) => {
-      const options = {
-        force: true,
-      };
-
-      broadcastLiveMessage(message, options);
-      setTimeout(() => {
-        expect(UIEvents.emit).toHaveBeenCalledTimes(2);
-        expect(UIEvents.emit).toHaveBeenCalledWith(EVENT_LIVE_MESSAGE, '', {
-          ...defaultOptions,
-          force: true,
-        });
-        expect(UIEvents.emit).toHaveBeenCalledWith(EVENT_LIVE_MESSAGE, message, {
-          ...defaultOptions,
-          force: true,
-        });
-        done();
-      }, 0);
+      jest.runAllTimers();
+      expect(UIEvents.emit).toHaveBeenCalledTimes(2);
+      expect(UIEvents.emit).toHaveBeenCalledWith(EVENT_LIVE_MESSAGE, '', {
+        ...options,
+      });
     });
   });
 });

--- a/libraries/engage/a11y/components/LiveMessenger/helpers.js
+++ b/libraries/engage/a11y/components/LiveMessenger/helpers.js
@@ -16,7 +16,6 @@ export function broadcastLiveMessage(message, options = {}) {
     type: LIVE_MESSAGE_TYPE_POLITE,
     params: null,
     id: null,
-    force: false,
   };
 
   if (!message) {
@@ -28,15 +27,10 @@ export function broadcastLiveMessage(message, options = {}) {
     ...options,
   };
 
-  if (params.force) {
-    // Clear the text first, so that the message will be read in any case.
-    UIEvents.emit(EVENT_LIVE_MESSAGE, '', params);
-
-    setTimeout(() => {
-      UIEvents.emit(EVENT_LIVE_MESSAGE, message, params);
-    }, 0);
-    return;
-  }
-
   UIEvents.emit(EVENT_LIVE_MESSAGE, message, params);
+
+  setTimeout(() => {
+    // Clear the live area after a short time, so that the screen reader can't focus the element.
+    UIEvents.emit(EVENT_LIVE_MESSAGE, '', params);
+  }, 100);
 }

--- a/libraries/engage/product/components/ProductCharacteristics/index.jsx
+++ b/libraries/engage/product/components/ProductCharacteristics/index.jsx
@@ -109,7 +109,6 @@ class ProductCharacteristics extends Component {
         ref.current.focus();
         const option = ref.current.innerText;
         broadcastLiveMessage('product.pick_option_first', {
-          force: true,
           params: { option },
         });
 

--- a/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/index.jsx
+++ b/themes/theme-gmd/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/index.jsx
@@ -72,7 +72,6 @@ class CTAButtons extends Component {
 
     broadcastLiveMessage('product.adding_item', {
       params: { count: 1 },
-      force: true,
     });
   };
 

--- a/themes/theme-gmd/pages/Favorites/subscriptions.js
+++ b/themes/theme-gmd/pages/Favorites/subscriptions.js
@@ -20,6 +20,6 @@ export default function favorites(subscribe) {
   });
 
   subscribe(favoritesWillAddItem$, () => {
-    broadcastLiveMessage('favorites.added', { force: true });
+    broadcastLiveMessage('favorites.added');
   });
 }

--- a/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/components/CartButton/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/components/CartButton/index.jsx
@@ -103,7 +103,6 @@ class CartButton extends Component {
 
       broadcastLiveMessage('product.adding_item', {
         params: { count: this.context.quantity },
-        force: true,
       });
     });
   }

--- a/themes/theme-gmd/pages/Product/components/Options/components/TextOption/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Options/components/TextOption/index.jsx
@@ -72,7 +72,7 @@ class TextOption extends PureComponent {
       return true;
     }
 
-    broadcastLiveMessage('product.fill_out_required_input_first', { force: true });
+    broadcastLiveMessage('product.fill_out_required_input_first');
     this.ref.scrollIntoView({ behavior: 'smooth' });
     this.setState({ highlight: true });
     return false;

--- a/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/index.jsx
+++ b/themes/theme-ios11/pages/Favorites/components/FavoritesList/components/Item/components/CTAButtons/index.jsx
@@ -72,7 +72,6 @@ class CTAButtons extends Component {
 
     broadcastLiveMessage('product.adding_item', {
       params: { count: 1 },
-      force: true,
     });
   };
 

--- a/themes/theme-ios11/pages/Favorites/subscriptions.js
+++ b/themes/theme-ios11/pages/Favorites/subscriptions.js
@@ -20,6 +20,6 @@ export default function favorites(subscribe) {
   });
 
   subscribe(favoritesWillAddItem$, () => {
-    broadcastLiveMessage('favorites.added', { force: true });
+    broadcastLiveMessage('favorites.added');
   });
 }

--- a/themes/theme-ios11/pages/Product/components/AddToCartBar/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/AddToCartBar/index.jsx
@@ -135,7 +135,6 @@ class AddToCartBar extends Component {
 
       broadcastLiveMessage('product.adding_item', {
         params: { count: this.context.quantity },
-        force: true,
       });
 
       if (this.moreButtonRef.current) {

--- a/themes/theme-ios11/pages/Product/components/Options/components/TextOption/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Options/components/TextOption/index.jsx
@@ -72,7 +72,7 @@ class TextOption extends PureComponent {
       return true;
     }
 
-    broadcastLiveMessage('product.fill_out_required_input_first', { force: true });
+    broadcastLiveMessage('product.fill_out_required_input_first');
     this.ref.scrollIntoView({ behavior: 'smooth' });
     this.setState({ highlight: true });
     return false;


### PR DESCRIPTION
# Description
Screen readers where able to focus the LiveMessenger components after a text was set for the first time. This pull request takes care, that the component is always cleared after a text was read, so that the screen reader doesn't recognize it anymore. 

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
