### PR TITLE
A11y: Enhanced hidden price range filter inputs with a currency symbol

### DIFF
--- a/libraries/engage/filter/components/PriceSlider/components/Label/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/filter/components/PriceSlider/components/Label/__snapshots__/spec.jsx.snap
@@ -63,7 +63,15 @@ exports[`PriceSlider: <Label /> should render 1`] = `
       </span>
     </Placeholder>
   </Translate>
+  <span
+    aria-hidden={true}
+    hidden={true}
+    id="price-slider-currency-label"
+  >
+    $
+  </span>
   <input
+    aria-describedby="price-slider-currency-label"
     aria-label="price.range_from"
     className={
       Object {
@@ -84,6 +92,7 @@ exports[`PriceSlider: <Label /> should render 1`] = `
     value={25}
   />
   <input
+    aria-describedby="price-slider-currency-label"
     aria-label="price.range_to"
     className={
       Object {

--- a/libraries/engage/filter/components/PriceSlider/components/Label/index.jsx
+++ b/libraries/engage/filter/components/PriceSlider/components/Label/index.jsx
@@ -67,6 +67,11 @@ function Label(props) {
     }
   }
 
+  const currencySymbol = Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format('0').replace('0.00', '');
+
   return (
     <div className={styles.editableContainer}>
       <span className={styles.srOnly}>
@@ -87,6 +92,9 @@ function Label(props) {
           </span>
         </I18n.Placeholder>
       </I18n.Text>
+      <span aria-hidden hidden id="price-slider-currency-label">
+        {currencySymbol}
+      </span>
       <input
         type="text"
         id="priceMin"
@@ -100,6 +108,7 @@ function Label(props) {
         }}
         className={styles.editableField}
         aria-label={i18n.text('price.range_from')}
+        aria-describedby="price-slider-currency-label"
       />
       <input
         type="text"
@@ -114,6 +123,7 @@ function Label(props) {
         }}
         className={styles.editableField}
         aria-label={i18n.text('price.range_to')}
+        aria-describedby="price-slider-currency-label"
       />
     </div>
   );


### PR DESCRIPTION
# Description
This ticket adds a currency symbol label to the hidden inputs of the price range filter, so that users notice that they edit a price.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
