### PR TITLE
Removed SnackBar button from a11y tree

### DIFF
--- a/libraries/ui-material/SnackBar/index.jsx
+++ b/libraries/ui-material/SnackBar/index.jsx
@@ -98,7 +98,7 @@ class SnackBar extends Component {
     };
 
     return (
-      <div className={styles.container} aria-live="assertive" role="status">
+      <div className={styles.container}>
         <Spring
           from={{ top: 80 }}
           to={{ top: 0 }}
@@ -111,7 +111,7 @@ class SnackBar extends Component {
             <div className={styles.wrapper} style={props} data-footer-inset-update-ignore="true">
               <div className={styles.box} {...boxProps}>
                 <Ellipsis rows={2}>
-                  <I18n.Text className={styles.label} string={message || ''} params={messageParams} />
+                  <I18n.Text className={styles.label} string={message || ''} params={messageParams} aria-live="assertive" role="status" />
                 </Ellipsis>
                 {(action && actionLabel) && (
                   <button


### PR DESCRIPTION
# Description
This ticket is about to hide the the button of the SnackBar component from the a11y tree. Android TalkBack didn't respect the `aria-hidden` attribute which was assigned to the button component, and so the screen reader was reading the "undo" button from the drawer which comes visible when an item was removed from the favourite list.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

