### PR TITLE
Removed unused setting from gmd extension-config

### DIFF
--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -418,17 +418,6 @@
         "key": "value"
       }
     },
-    "scanner": {
-      "type": "admin",
-      "destination": "frontend",
-      "default": {
-        "showSearchFieldIcon": true
-      },
-      "params": {
-        "type": "json",
-        "label": "Scanner settings: icon on/off, etc"
-      }
-    },
     "favorites": {
       "type": "admin",
       "destination": "frontend",


### PR DESCRIPTION
# Description
This ticket removes the scanner setting from the theme-gmd extension-config. It's only used within theme-ios11, and was added by accident.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.
