### PR TITLE
Fixed onClick handers for custom SearchSuggestionItem components within the iOS 11 theme

### DIFF
--- a/libraries/common/components/Input/components/SimpleInput.jsx
+++ b/libraries/common/components/Input/components/SimpleInput.jsx
@@ -116,16 +116,18 @@ class SimpleInput extends Component {
 
   /**
    * Internal focus event handler.
+   * @param {Object} e The event object.
    */
-  handleFocus = () => {
+  handleFocus = (e) => {
     this.setState({ isFocused: true });
-    this.props.onFocusChange(true);
+    this.props.onFocusChange(true, e);
   };
 
   /**
    * Internal blur event handler.
+   * @param {Object} e The event object.
    */
-  handleBlur = () => {
+  handleBlur = (e) => {
     const newState = {
       isFocused: false,
     };
@@ -137,7 +139,7 @@ class SimpleInput extends Component {
 
     this.setState(newState);
 
-    this.props.onFocusChange(false);
+    this.props.onFocusChange(false, e);
   };
 
   /**

--- a/themes/theme-ios11/pages/Browse/components/SearchField/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/__snapshots__/spec.jsx.snap
@@ -170,7 +170,7 @@ exports[`<Content /> Check search field should render with initial search query 
           </div>
           <div>
             <button
-              className="css-1ctsi2c css-gyrv08"
+              className="css-jd9rhj css-gyrv08"
               onClick={[Function]}
               type="button"
             >
@@ -324,7 +324,7 @@ exports[`<Content /> Check search field should show suggestions when focused 1`]
           </div>
           <div>
             <button
-              className="css-1ctsi2c"
+              className="css-jd9rhj"
               onClick={[Function]}
               type="button"
             >

--- a/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/__snapshots__/spec.jsx.snap
@@ -4,7 +4,6 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
 <SuggestionList
   bottomHeight={10}
   fetching={false}
-  forwardedRef={null}
   onClick={[Function]}
   suggestions={
     Array [
@@ -162,7 +161,6 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
 <SuggestionList
   bottomHeight={10}
   fetching={true}
-  forwardedRef={null}
   onClick={[Function]}
   suggestions={
     Array [
@@ -320,7 +318,6 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
 <SuggestionList
   bottomHeight={10}
   fetching={false}
-  forwardedRef={null}
   onClick={[Function]}
   suggestions={
     Array [
@@ -486,172 +483,165 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
     }
   }
 >
-  <ForwardRef(WithForwardedRef(Connect(SuggestionList)))
+  <Connect(SuggestionList)
     bottomHeight={10}
     onClick={[Function]}
   >
-    <Connect(SuggestionList)
+    <SuggestionList
       bottomHeight={10}
-      forwardedRef={null}
+      dispatch={[Function]}
+      fetching={false}
       onClick={[Function]}
+      suggestions={
+        Array [
+          "foo",
+          "foo bar",
+          "foo bar buz",
+          "foo bar buz quz",
+        ]
+      }
+      visible={false}
     >
-      <SuggestionList
-        bottomHeight={10}
-        dispatch={[Function]}
-        fetching={false}
-        forwardedRef={null}
-        onClick={[Function]}
-        suggestions={
-          Array [
-            "foo",
-            "foo bar",
-            "foo bar buz",
-            "foo bar buz quz",
-          ]
-        }
-        visible={false}
-      >
-        <SurroundPortals
-          portalName="search.suggestions"
-          portalProps={
-            Object {
-              "onClick": [Function],
-              "suggestions": Array [
-                "foo",
-                "foo bar",
-                "foo bar buz",
-                "foo bar buz quz",
-              ],
-            }
+      <SurroundPortals
+        portalName="search.suggestions"
+        portalProps={
+          Object {
+            "onClick": [Function],
+            "suggestions": Array [
+              "foo",
+              "foo bar",
+              "foo bar buz",
+              "foo bar buz quz",
+            ],
           }
+        }
+      >
+        <div
+          className="css-7w6rep css-90ryaa css-6zy2pv"
         >
-          <div
-            className="css-7w6rep css-90ryaa css-6zy2pv"
+          <SurroundPortals
+            key="foo"
+            portalName="search.suggestion-item"
+            portalProps={
+              Object {
+                "className": "css-crua9x",
+                "onClick": [Function],
+                "suggestion": "foo",
+              }
+            }
           >
-            <SurroundPortals
-              key="foo"
-              portalName="search.suggestion-item"
-              portalProps={
-                Object {
-                  "className": "css-crua9x",
-                  "onClick": [Function],
-                  "suggestion": "foo",
-                }
-              }
+            <button
+              className="css-crua9x"
+              data-test-id="searchSuggestion foo"
+              onClick={[Function]}
+              type="button"
+              value="foo"
             >
-              <button
-                className="css-crua9x"
-                data-test-id="searchSuggestion foo"
-                onClick={[Function]}
-                type="button"
-                value="foo"
-              >
-                <SurroundPortals
-                  portalName="search.suggestion-item-content"
-                  portalProps={
-                    Object {
-                      "suggestion": "foo",
-                    }
+              <SurroundPortals
+                portalName="search.suggestion-item-content"
+                portalProps={
+                  Object {
+                    "suggestion": "foo",
                   }
-                >
-                  foo
-                </SurroundPortals>
-              </button>
-            </SurroundPortals>
-            <SurroundPortals
-              key="foo bar"
-              portalName="search.suggestion-item"
-              portalProps={
-                Object {
-                  "className": "css-crua9x",
-                  "onClick": [Function],
-                  "suggestion": "foo bar",
                 }
-              }
-            >
-              <button
-                className="css-crua9x"
-                data-test-id="searchSuggestion foo bar"
-                onClick={[Function]}
-                type="button"
-                value="foo bar"
               >
-                <SurroundPortals
-                  portalName="search.suggestion-item-content"
-                  portalProps={
-                    Object {
-                      "suggestion": "foo bar",
-                    }
+                foo
+              </SurroundPortals>
+            </button>
+          </SurroundPortals>
+          <SurroundPortals
+            key="foo bar"
+            portalName="search.suggestion-item"
+            portalProps={
+              Object {
+                "className": "css-crua9x",
+                "onClick": [Function],
+                "suggestion": "foo bar",
+              }
+            }
+          >
+            <button
+              className="css-crua9x"
+              data-test-id="searchSuggestion foo bar"
+              onClick={[Function]}
+              type="button"
+              value="foo bar"
+            >
+              <SurroundPortals
+                portalName="search.suggestion-item-content"
+                portalProps={
+                  Object {
+                    "suggestion": "foo bar",
                   }
-                >
-                  foo bar
-                </SurroundPortals>
-              </button>
-            </SurroundPortals>
-            <SurroundPortals
-              key="foo bar buz"
-              portalName="search.suggestion-item"
-              portalProps={
-                Object {
-                  "className": "css-crua9x",
-                  "onClick": [Function],
-                  "suggestion": "foo bar buz",
                 }
-              }
-            >
-              <button
-                className="css-crua9x"
-                data-test-id="searchSuggestion foo bar buz"
-                onClick={[Function]}
-                type="button"
-                value="foo bar buz"
               >
-                <SurroundPortals
-                  portalName="search.suggestion-item-content"
-                  portalProps={
-                    Object {
-                      "suggestion": "foo bar buz",
-                    }
+                foo bar
+              </SurroundPortals>
+            </button>
+          </SurroundPortals>
+          <SurroundPortals
+            key="foo bar buz"
+            portalName="search.suggestion-item"
+            portalProps={
+              Object {
+                "className": "css-crua9x",
+                "onClick": [Function],
+                "suggestion": "foo bar buz",
+              }
+            }
+          >
+            <button
+              className="css-crua9x"
+              data-test-id="searchSuggestion foo bar buz"
+              onClick={[Function]}
+              type="button"
+              value="foo bar buz"
+            >
+              <SurroundPortals
+                portalName="search.suggestion-item-content"
+                portalProps={
+                  Object {
+                    "suggestion": "foo bar buz",
                   }
-                >
-                  foo bar buz
-                </SurroundPortals>
-              </button>
-            </SurroundPortals>
-            <SurroundPortals
-              key="foo bar buz quz"
-              portalName="search.suggestion-item"
-              portalProps={
-                Object {
-                  "className": "css-crua9x",
-                  "onClick": [Function],
-                  "suggestion": "foo bar buz quz",
                 }
-              }
-            >
-              <button
-                className="css-crua9x"
-                data-test-id="searchSuggestion foo bar buz quz"
-                onClick={[Function]}
-                type="button"
-                value="foo bar buz quz"
               >
-                <SurroundPortals
-                  portalName="search.suggestion-item-content"
-                  portalProps={
-                    Object {
-                      "suggestion": "foo bar buz quz",
-                    }
+                foo bar buz
+              </SurroundPortals>
+            </button>
+          </SurroundPortals>
+          <SurroundPortals
+            key="foo bar buz quz"
+            portalName="search.suggestion-item"
+            portalProps={
+              Object {
+                "className": "css-crua9x",
+                "onClick": [Function],
+                "suggestion": "foo bar buz quz",
+              }
+            }
+          >
+            <button
+              className="css-crua9x"
+              data-test-id="searchSuggestion foo bar buz quz"
+              onClick={[Function]}
+              type="button"
+              value="foo bar buz quz"
+            >
+              <SurroundPortals
+                portalName="search.suggestion-item-content"
+                portalProps={
+                  Object {
+                    "suggestion": "foo bar buz quz",
                   }
-                >
-                  foo bar buz quz
-                </SurroundPortals>
-              </button>
-            </SurroundPortals>
-          </div>
-        </SurroundPortals>
-      </SuggestionList>
-    </Connect(SuggestionList)>
-  </ForwardRef(WithForwardedRef(Connect(SuggestionList)))>
+                }
+              >
+                foo bar buz quz
+              </SurroundPortals>
+            </button>
+          </SurroundPortals>
+        </div>
+      </SurroundPortals>
+    </SuggestionList>
+  </Connect(SuggestionList)>
 </Provider>
 `;

--- a/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/__snapshots__/spec.jsx.snap
@@ -4,6 +4,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 1`]
 <SuggestionList
   bottomHeight={10}
   fetching={false}
+  forwardedRef={null}
   onClick={[Function]}
   suggestions={
     Array [
@@ -161,6 +162,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 2`]
 <SuggestionList
   bottomHeight={10}
   fetching={true}
+  forwardedRef={null}
   onClick={[Function]}
   suggestions={
     Array [
@@ -318,6 +320,7 @@ exports[`<SuggestionList /> should not update while suggestions are fetching 3`]
 <SuggestionList
   bottomHeight={10}
   fetching={false}
+  forwardedRef={null}
   onClick={[Function]}
   suggestions={
     Array [
@@ -483,165 +486,172 @@ exports[`<SuggestionList /> should render a list of suggestions 1`] = `
     }
   }
 >
-  <Connect(SuggestionList)
+  <ForwardRef(WithForwardedRef(Connect(SuggestionList)))
     bottomHeight={10}
     onClick={[Function]}
   >
-    <SuggestionList
+    <Connect(SuggestionList)
       bottomHeight={10}
-      dispatch={[Function]}
-      fetching={false}
+      forwardedRef={null}
       onClick={[Function]}
-      suggestions={
-        Array [
-          "foo",
-          "foo bar",
-          "foo bar buz",
-          "foo bar buz quz",
-        ]
-      }
-      visible={false}
     >
-      <SurroundPortals
-        portalName="search.suggestions"
-        portalProps={
-          Object {
-            "onClick": [Function],
-            "suggestions": Array [
-              "foo",
-              "foo bar",
-              "foo bar buz",
-              "foo bar buz quz",
-            ],
-          }
+      <SuggestionList
+        bottomHeight={10}
+        dispatch={[Function]}
+        fetching={false}
+        forwardedRef={null}
+        onClick={[Function]}
+        suggestions={
+          Array [
+            "foo",
+            "foo bar",
+            "foo bar buz",
+            "foo bar buz quz",
+          ]
         }
+        visible={false}
       >
-        <div
-          className="css-7w6rep css-90ryaa css-6zy2pv"
+        <SurroundPortals
+          portalName="search.suggestions"
+          portalProps={
+            Object {
+              "onClick": [Function],
+              "suggestions": Array [
+                "foo",
+                "foo bar",
+                "foo bar buz",
+                "foo bar buz quz",
+              ],
+            }
+          }
         >
-          <SurroundPortals
-            key="foo"
-            portalName="search.suggestion-item"
-            portalProps={
-              Object {
-                "className": "css-crua9x",
-                "onClick": [Function],
-                "suggestion": "foo",
-              }
-            }
+          <div
+            className="css-7w6rep css-90ryaa css-6zy2pv"
           >
-            <button
-              className="css-crua9x"
-              data-test-id="searchSuggestion foo"
-              onClick={[Function]}
-              type="button"
-              value="foo"
-            >
-              <SurroundPortals
-                portalName="search.suggestion-item-content"
-                portalProps={
-                  Object {
-                    "suggestion": "foo",
-                  }
+            <SurroundPortals
+              key="foo"
+              portalName="search.suggestion-item"
+              portalProps={
+                Object {
+                  "className": "css-crua9x",
+                  "onClick": [Function],
+                  "suggestion": "foo",
                 }
-              >
-                foo
-              </SurroundPortals>
-            </button>
-          </SurroundPortals>
-          <SurroundPortals
-            key="foo bar"
-            portalName="search.suggestion-item"
-            portalProps={
-              Object {
-                "className": "css-crua9x",
-                "onClick": [Function],
-                "suggestion": "foo bar",
               }
-            }
-          >
-            <button
-              className="css-crua9x"
-              data-test-id="searchSuggestion foo bar"
-              onClick={[Function]}
-              type="button"
-              value="foo bar"
             >
-              <SurroundPortals
-                portalName="search.suggestion-item-content"
-                portalProps={
-                  Object {
-                    "suggestion": "foo bar",
-                  }
-                }
+              <button
+                className="css-crua9x"
+                data-test-id="searchSuggestion foo"
+                onClick={[Function]}
+                type="button"
+                value="foo"
               >
-                foo bar
-              </SurroundPortals>
-            </button>
-          </SurroundPortals>
-          <SurroundPortals
-            key="foo bar buz"
-            portalName="search.suggestion-item"
-            portalProps={
-              Object {
-                "className": "css-crua9x",
-                "onClick": [Function],
-                "suggestion": "foo bar buz",
+                <SurroundPortals
+                  portalName="search.suggestion-item-content"
+                  portalProps={
+                    Object {
+                      "suggestion": "foo",
+                    }
+                  }
+                >
+                  foo
+                </SurroundPortals>
+              </button>
+            </SurroundPortals>
+            <SurroundPortals
+              key="foo bar"
+              portalName="search.suggestion-item"
+              portalProps={
+                Object {
+                  "className": "css-crua9x",
+                  "onClick": [Function],
+                  "suggestion": "foo bar",
+                }
               }
-            }
-          >
-            <button
-              className="css-crua9x"
-              data-test-id="searchSuggestion foo bar buz"
-              onClick={[Function]}
-              type="button"
-              value="foo bar buz"
             >
-              <SurroundPortals
-                portalName="search.suggestion-item-content"
-                portalProps={
-                  Object {
-                    "suggestion": "foo bar buz",
-                  }
-                }
+              <button
+                className="css-crua9x"
+                data-test-id="searchSuggestion foo bar"
+                onClick={[Function]}
+                type="button"
+                value="foo bar"
               >
-                foo bar buz
-              </SurroundPortals>
-            </button>
-          </SurroundPortals>
-          <SurroundPortals
-            key="foo bar buz quz"
-            portalName="search.suggestion-item"
-            portalProps={
-              Object {
-                "className": "css-crua9x",
-                "onClick": [Function],
-                "suggestion": "foo bar buz quz",
+                <SurroundPortals
+                  portalName="search.suggestion-item-content"
+                  portalProps={
+                    Object {
+                      "suggestion": "foo bar",
+                    }
+                  }
+                >
+                  foo bar
+                </SurroundPortals>
+              </button>
+            </SurroundPortals>
+            <SurroundPortals
+              key="foo bar buz"
+              portalName="search.suggestion-item"
+              portalProps={
+                Object {
+                  "className": "css-crua9x",
+                  "onClick": [Function],
+                  "suggestion": "foo bar buz",
+                }
               }
-            }
-          >
-            <button
-              className="css-crua9x"
-              data-test-id="searchSuggestion foo bar buz quz"
-              onClick={[Function]}
-              type="button"
-              value="foo bar buz quz"
             >
-              <SurroundPortals
-                portalName="search.suggestion-item-content"
-                portalProps={
-                  Object {
-                    "suggestion": "foo bar buz quz",
-                  }
-                }
+              <button
+                className="css-crua9x"
+                data-test-id="searchSuggestion foo bar buz"
+                onClick={[Function]}
+                type="button"
+                value="foo bar buz"
               >
-                foo bar buz quz
-              </SurroundPortals>
-            </button>
-          </SurroundPortals>
-        </div>
-      </SurroundPortals>
-    </SuggestionList>
-  </Connect(SuggestionList)>
+                <SurroundPortals
+                  portalName="search.suggestion-item-content"
+                  portalProps={
+                    Object {
+                      "suggestion": "foo bar buz",
+                    }
+                  }
+                >
+                  foo bar buz
+                </SurroundPortals>
+              </button>
+            </SurroundPortals>
+            <SurroundPortals
+              key="foo bar buz quz"
+              portalName="search.suggestion-item"
+              portalProps={
+                Object {
+                  "className": "css-crua9x",
+                  "onClick": [Function],
+                  "suggestion": "foo bar buz quz",
+                }
+              }
+            >
+              <button
+                className="css-crua9x"
+                data-test-id="searchSuggestion foo bar buz quz"
+                onClick={[Function]}
+                type="button"
+                value="foo bar buz quz"
+              >
+                <SurroundPortals
+                  portalName="search.suggestion-item-content"
+                  portalProps={
+                    Object {
+                      "suggestion": "foo bar buz quz",
+                    }
+                  }
+                >
+                  foo bar buz quz
+                </SurroundPortals>
+              </button>
+            </SurroundPortals>
+          </div>
+        </SurroundPortals>
+      </SuggestionList>
+    </Connect(SuggestionList)>
+  </ForwardRef(WithForwardedRef(Connect(SuggestionList)))>
 </Provider>
 `;

--- a/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/index.jsx
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/index.jsx
@@ -7,7 +7,6 @@ import {
   SEARCH_SUGGESTION_ITEM,
   SEARCH_SUGGESTION_ITEM_CONTENT,
 } from '@shopgate/engage/search';
-import { withForwardedRef } from '@shopgate/engage/core';
 import connect from './connector';
 import styles from './style';
 
@@ -19,7 +18,6 @@ class SuggestionList extends Component {
     bottomHeight: PropTypes.number.isRequired,
     onClick: PropTypes.func.isRequired,
     fetching: PropTypes.bool,
-    forwardedRef: PropTypes.shape(),
     suggestions: PropTypes.arrayOf(PropTypes.string),
     visible: PropTypes.bool,
   }
@@ -27,7 +25,6 @@ class SuggestionList extends Component {
   static defaultProps = {
     suggestions: [],
     fetching: false,
-    forwardedRef: null,
     visible: false,
   }
 
@@ -36,7 +33,8 @@ class SuggestionList extends Component {
    * @return {boolean}
    */
   shouldComponentUpdate(nextProps) {
-    return nextProps.fetching === false && nextProps.suggestions;
+    return (nextProps.fetching === false && nextProps.suggestions) ||
+      (this.props.visible !== nextProps.visible);
   }
 
   /**
@@ -44,7 +42,7 @@ class SuggestionList extends Component {
    */
   render() {
     const {
-      onClick, suggestions, bottomHeight, visible, forwardedRef,
+      onClick, suggestions, bottomHeight, visible,
     } = this.props;
 
     if (!suggestions) {
@@ -65,7 +63,6 @@ class SuggestionList extends Component {
             styles.bottom(bottomHeight),
             { [styles.hidden]: !visible }
           )}
-          ref={forwardedRef}
         >
           {suggestions.map(suggestion => (
             <SurroundPortals
@@ -101,4 +98,4 @@ class SuggestionList extends Component {
 
 export { SuggestionList as UnwrappedSuggestionList };
 
-export default withForwardedRef(connect(SuggestionList));
+export default connect(SuggestionList);

--- a/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/index.jsx
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/components/SuggestionList/index.jsx
@@ -7,6 +7,7 @@ import {
   SEARCH_SUGGESTION_ITEM,
   SEARCH_SUGGESTION_ITEM_CONTENT,
 } from '@shopgate/engage/search';
+import { withForwardedRef } from '@shopgate/engage/core';
 import connect from './connector';
 import styles from './style';
 
@@ -18,6 +19,7 @@ class SuggestionList extends Component {
     bottomHeight: PropTypes.number.isRequired,
     onClick: PropTypes.func.isRequired,
     fetching: PropTypes.bool,
+    forwardedRef: PropTypes.shape(),
     suggestions: PropTypes.arrayOf(PropTypes.string),
     visible: PropTypes.bool,
   }
@@ -25,6 +27,7 @@ class SuggestionList extends Component {
   static defaultProps = {
     suggestions: [],
     fetching: false,
+    forwardedRef: null,
     visible: false,
   }
 
@@ -41,7 +44,7 @@ class SuggestionList extends Component {
    */
   render() {
     const {
-      onClick, suggestions, bottomHeight, visible,
+      onClick, suggestions, bottomHeight, visible, forwardedRef,
     } = this.props;
 
     if (!suggestions) {
@@ -62,6 +65,7 @@ class SuggestionList extends Component {
             styles.bottom(bottomHeight),
             { [styles.hidden]: !visible }
           )}
+          ref={forwardedRef}
         >
           {suggestions.map(suggestion => (
             <SurroundPortals
@@ -97,4 +101,4 @@ class SuggestionList extends Component {
 
 export { SuggestionList as UnwrappedSuggestionList };
 
-export default connect(SuggestionList);
+export default withForwardedRef(connect(SuggestionList));

--- a/themes/theme-ios11/pages/Browse/components/SearchField/style.js
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/style.js
@@ -48,7 +48,7 @@ const labelHidden = css({
 }).toString();
 
 const button = css({
-  lineHeight: '36px',
+  lineHeight: '34px',
   color: colors.accent,
   paddingTop: 0,
   paddingLeft: 16,


### PR DESCRIPTION
- extensions can now replace the search suggestion items with working click handlers

# Description
This ticket fixes an issue that prevented fully working click handlers of extension replacements for SearchSuggestionItem components within the iOS 11 theme. It also should fix React errors about state updates within unmounted components when a search is initiated by pressing the "Enter" button.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Attach an extension like the one from [this](https://github.com/shopgate/pwa/issues/804#issuecomment-525300355) issue report. Clicking a search suggestion item should now initiate a search.
