### PR TITLE
 Changed the translation system to prevent the app from crashing for invalid translation messages.

### DIFF
--- a/libraries/common/helpers/i18n/getTranslator.js
+++ b/libraries/common/helpers/i18n/getTranslator.js
@@ -30,7 +30,7 @@ const getMessageFromCache = (locales, langCode, key) => {
     return messageCache[hash];
   }
 
-  const message = getPath(locales, key, key);
+  const message = getPath(locales, key);
   if (typeof message !== 'string' || message.length === 0) {
     return pureReturn(key);
   }

--- a/libraries/common/helpers/i18n/getTranslator.js
+++ b/libraries/common/helpers/i18n/getTranslator.js
@@ -35,11 +35,16 @@ const getMessageFromCache = (locales, langCode, key) => {
     return pureReturn(key);
   }
 
-  messageCache[hash] = new IntlMessageFormat(
-    message,
-    langCode,
-    getPath(locales, 'formats')
-  );
+  // Prevent the app from crashing when strings (like product names) don't comply with the format
+  try {
+    messageCache[hash] = new IntlMessageFormat(
+      message,
+      langCode,
+      getPath(locales, 'formats')
+    );
+  } catch (e) {
+    messageCache[hash] = pureReturn(key);
+  }
 
   return messageCache[hash];
 };


### PR DESCRIPTION
# Description

 Changed the translation system to prevent the app from crashing for invalid translation messages.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Try translating a string that contains something like `\\\'`. This should not crash anymore.
