### PR TITLE
Reverted navigate prop of TabBar actions back to historyPush

### DIFF
--- a/themes/theme-ios11/components/TabBar/components/BrowseAction/index.jsx
+++ b/themes/theme-ios11/components/TabBar/components/BrowseAction/index.jsx
@@ -13,7 +13,7 @@ import styles from './style';
  */
 class TabBarBrowseAction extends Component {
   static propTypes = {
-    navigate: PropTypes.func.isRequired,
+    historyPush: PropTypes.func.isRequired,
     path: PropTypes.string.isRequired,
     ...TabBarAction.propTypes,
   };
@@ -24,7 +24,7 @@ class TabBarBrowseAction extends Component {
    * Handles the click action.
    */
   handleClick = () => {
-    this.props.navigate({ pathname: BROWSE_PATH });
+    this.props.historyPush({ pathname: BROWSE_PATH });
   };
 
   /**

--- a/themes/theme-ios11/components/TabBar/components/CartAction/index.jsx
+++ b/themes/theme-ios11/components/TabBar/components/CartAction/index.jsx
@@ -16,7 +16,7 @@ import styles from './style';
  */
 class TabBarCartAction extends Component {
   static propTypes = {
-    navigate: PropTypes.func.isRequired,
+    historyPush: PropTypes.func.isRequired,
     path: PropTypes.string.isRequired,
     ...TabBarAction.propTypes,
   };
@@ -27,7 +27,7 @@ class TabBarCartAction extends Component {
    * Handles the click action.
    */
   handleClick = () => {
-    this.props.navigate({ pathname: CART_PATH });
+    this.props.historyPush({ pathname: CART_PATH });
   };
 
   /**

--- a/themes/theme-ios11/components/TabBar/components/FavoritesAction/index.jsx
+++ b/themes/theme-ios11/components/TabBar/components/FavoritesAction/index.jsx
@@ -16,7 +16,7 @@ import styles from './style';
  */
 class TabBarFavoritesAction extends Component {
   static propTypes = {
-    navigate: PropTypes.func.isRequired,
+    historyPush: PropTypes.func.isRequired,
     path: PropTypes.string.isRequired,
     ...TabBarAction.propTypes,
   };
@@ -27,7 +27,7 @@ class TabBarFavoritesAction extends Component {
    * Handles the click action.
    */
   handleClick = () => {
-    this.props.navigate({ pathname: FAVORITES_PATH });
+    this.props.historyPush({ pathname: FAVORITES_PATH });
   };
 
   /**

--- a/themes/theme-ios11/components/TabBar/components/HomeAction/index.jsx
+++ b/themes/theme-ios11/components/TabBar/components/HomeAction/index.jsx
@@ -13,7 +13,7 @@ import styles from './style';
  */
 class TabBarHomeAction extends Component {
   static propTypes = {
-    navigate: PropTypes.func.isRequired,
+    historyPush: PropTypes.func.isRequired,
     path: PropTypes.string.isRequired,
     ...TabBarAction.propTypes,
   };
@@ -21,7 +21,7 @@ class TabBarHomeAction extends Component {
   static defaultProps = TabBarAction.defaultProps;
 
   handleClick = () => {
-    this.props.navigate({ pathname: INDEX_PATH });
+    this.props.historyPush({ pathname: INDEX_PATH });
   };
 
   /**

--- a/themes/theme-ios11/components/TabBar/components/MoreAction/index.jsx
+++ b/themes/theme-ios11/components/TabBar/components/MoreAction/index.jsx
@@ -13,7 +13,7 @@ import styles from './style';
  */
 class TabBarMoreAction extends Component {
   static propTypes = {
-    navigate: PropTypes.func.isRequired,
+    historyPush: PropTypes.func.isRequired,
     path: PropTypes.string.isRequired,
     ...TabBarAction.propTypes,
   };
@@ -24,7 +24,7 @@ class TabBarMoreAction extends Component {
    * Handles the click action.
    */
   handleClick = () => {
-    this.props.navigate({ pathname: MORE_PATH });
+    this.props.historyPush({ pathname: MORE_PATH });
   };
 
   /**

--- a/themes/theme-ios11/components/TabBar/components/actions.js
+++ b/themes/theme-ios11/components/TabBar/components/actions.js
@@ -9,6 +9,7 @@ export const navigate = params => (dispatch, getState) => {
   dispatch(historyPush({
     ...params,
     state: {
+      ...params.state,
       preventA11yFocus: isTabBarVisible(getState(), params.pathname),
     },
   }));

--- a/themes/theme-ios11/components/TabBar/components/connector.js
+++ b/themes/theme-ios11/components/TabBar/components/connector.js
@@ -5,7 +5,7 @@ import { navigate } from './actions';
  * @return {Object} The extended component props.
  */
 const mapDispatchToProps = {
-  navigate,
+  historyPush: navigate,
 };
 
 export default connect(null, mapDispatchToProps);


### PR DESCRIPTION
# Description
This pull request reverts the `navigate` prop of `TabBar` actions back to `historyPush`. Since the props are passed down to portals, the renaming would have been a breaking change.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.
