### PR TITLE
Fixed JavaScript error that could  occur when the AppBar was mounted but the related portal wasn't available yet

### DIFF
--- a/themes/theme-gmd/components/AppBar/presets/DefaultBar/index.jsx
+++ b/themes/theme-gmd/components/AppBar/presets/DefaultBar/index.jsx
@@ -131,6 +131,10 @@ class AppBarDefault extends PureComponent {
   setFocus = () => {
     const { target } = this.state;
 
+    if (!target) {
+      return;
+    }
+
     // Set the focus to the first focusable element for screen readers.
     const focusable = target.querySelector('button:not([aria-hidden="true"]), [tabindex]:not([tabindex="-1"])');
 

--- a/themes/theme-ios11/components/AppBar/presets/DefaultBar/index.jsx
+++ b/themes/theme-ios11/components/AppBar/presets/DefaultBar/index.jsx
@@ -57,7 +57,7 @@ class AppBarDefault extends PureComponent {
       this.setState({ target: target || null });
     }
 
-    if (this.props.setFocus) {
+    if (this.props.setFocus && target) {
       // Set the focus to the first focusable element for screen readers.
       const focusable = target.querySelector('button:not([aria-hidden="true"]), [tabindex]:not([tabindex="-1"])');
 


### PR DESCRIPTION
# Description
This pull request fixes the cause of a JavaScript error, which could occur when the `AppBar` was mounted, but its target portal wasn't available yet.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.
