### PR TITLE
Replace the StringReplacePlugin with a environment variable.

### DIFF
--- a/libraries/tracking/subscriptions/setup.js
+++ b/libraries/tracking/subscriptions/setup.js
@@ -57,8 +57,8 @@ export default function setup(subscribe) {
     }
 
     try {
-      // eslint-disable-next-line no-undef, global-require, import/no-dynamic-require
-      const extensionsIndex = require(`${__THEME_PATH__}/extensions/tracking`).default;
+      // eslint-disable-next-line global-require, import/no-dynamic-require
+      const extensionsIndex = require(`${process.env.THEME_PATH}/extensions/tracking`).default;
       const trackingExtensions = componentsConfig.tracking || {};
 
       Object.keys(trackingExtensions).forEach((key) => {

--- a/utils/webpack/webpack.config.js
+++ b/utils/webpack/webpack.config.js
@@ -75,6 +75,7 @@ const config = {
         COMPONENTS_CONFIG: JSON.stringify(getComponentsSettings(themePath)),
         THEME_CONFIG: JSON.stringify(themeConfig),
         THEME: JSON.stringify(process.env.theme),
+        THEME_PATH: JSON.stringify(themePath),
         // @deprecated Replaced by LOCALE and LOCALE_FILE - kept for now for theme compatibility.
         LANG: JSON.stringify(isoLang),
         LOCALE: JSON.stringify(isoLang),


### PR DESCRIPTION
# Description

In order to getting rid of the StringReplacePlugin, the tracking core setup now uses a environment variable.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
