### PR TITLE
Added new device info selector factories to determine information about supported identity services

### DIFF
--- a/libraries/common/selectors/client.js
+++ b/libraries/common/selectors/client.js
@@ -52,6 +52,31 @@ export const getDeviceInformation = createSelector(
 );
 
 /**
+ * Creates the `getSupportedIdentityServices()` selector.
+ * @returns {Function}
+ */
+export function makeGetSupportedIdentityServices() {
+  return createSelector(
+    getDeviceInformation,
+    info => info.supportedIdentityServices || []
+  );
+}
+
+/**
+ * Creates the `supportsIdentityService()` selector.
+ * @param {string} service The identity service to check.
+ * @returns {Function}
+ */
+export function makeSupportsIdentityService(service) {
+  const getSupportedIdentityServices = makeGetSupportedIdentityServices();
+
+  return createSelector(
+    getSupportedIdentityServices,
+    services => services.includes(service)
+  );
+}
+
+/**
  * Checks if the currently stored lib version is one that supports the scanner.
  * @param {Object} state The application state.
  * @returns {boolean}

--- a/libraries/common/selectors/client.js
+++ b/libraries/common/selectors/client.js
@@ -57,7 +57,7 @@ export const getDeviceInformation = createSelector(
  */
 export function makeGetSupportedIdentityServices() {
   return createSelector(
-    getDeviceInformation,
+    getClientInformation,
     info => info.supportedIdentityServices || []
   );
 }

--- a/libraries/common/selectors/client.spec.js
+++ b/libraries/common/selectors/client.spec.js
@@ -12,6 +12,8 @@ import {
   getIsConnected,
   getClientConnectivityNetwork,
   getClientConnectivityType,
+  makeGetSupportedIdentityServices,
+  makeSupportsIdentityService,
 } from './client';
 
 import {
@@ -56,6 +58,7 @@ describe('Client selectors', () => {
           ver: '11.0',
         },
       },
+      supportedIdentityServices: ['apple', 'facebook'],
     };
 
     /**
@@ -224,6 +227,19 @@ describe('Client selectors', () => {
       it('should return the iPhone X insets on an iPhone X', () => {
         const result = getPageInsets(createMockState(mockedStateIPhoneX));
         expect(result).toEqual(PAGE_INSETS_IPHONE_X);
+      });
+    });
+
+    describe('supportedIdentityServices()', () => {
+      it('should return identity services', () => {
+        const selector = makeGetSupportedIdentityServices();
+        const result = selector(createMockState(mockedStateIPhoneX));
+        expect(result).toEqual(mockedStateIPhoneX.supportedIdentityServices);
+      });
+      it('should support identity service apple', () => {
+        const selector = makeSupportsIdentityService('apple');
+        const result = selector(createMockState(mockedStateIPhoneX));
+        expect(result).toEqual(true);
       });
     });
   });


### PR DESCRIPTION
# Description

In order to use "Sign In With Apple" or "Facebook Connect" properly, we need to check if the app supports the desired identity service (login methods). We can find this information in the client information state. Selectors to retrieve this information have been added to the core packages.

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
