### PR TITLE
Fixed the wrong ordering of fields rendered by the FormBuilder, when no sortIndex is provided.

### DIFF
--- a/libraries/ui-shared/Form/Builder/index.jsx
+++ b/libraries/ui-shared/Form/Builder/index.jsx
@@ -156,13 +156,9 @@ class Builder extends Component {
    * @returns {number}
    */
   elementSortFunc = (element1, element2) => {
-    // Keep relative sort order when no specific sort order was set for both
-    if (element2.sortOrder === undefined) {
-      return 1;
-    }
-
-    if (element1.sortOrder === undefined) {
-      return -1;
+    // Keep current sort order when no specific sort order was set for both
+    if (element1.sortOrder === undefined || element2.sortOrder === undefined) {
+      return 0;
     }
 
     // Sort in ascending order of sortOrder otherwise

--- a/libraries/ui-shared/Form/Builder/index.jsx
+++ b/libraries/ui-shared/Form/Builder/index.jsx
@@ -158,11 +158,11 @@ class Builder extends Component {
   elementSortFunc = (element1, element2) => {
     // Keep relative sort order when no specific sort order was set for both
     if (element2.sortOrder === undefined) {
-      return -1;
+      return 1;
     }
 
     if (element1.sortOrder === undefined) {
-      return 1;
+      return -1;
     }
 
     // Sort in ascending order of sortOrder otherwise

--- a/libraries/ui-shared/Form/Builder/spec.jsx
+++ b/libraries/ui-shared/Form/Builder/spec.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable extra-rules/no-single-line-objects */
 import React from 'react';
 import { mount } from 'enzyme';
 import FormBuilder from '.';
@@ -263,4 +264,28 @@ describe('<FormBuilder />', () => {
       }, true);
     });
   });
+
+  describe('FormBuilder::elementSortFunc', () => {
+    const builder = new FormBuilder({
+      validationErrors: [{}],
+      config: { fields: {} },
+      handleUpdate: jest.fn(),
+    });
+
+    const field1 = { id: 'foo', label: 'foo' };
+    const field2 = { id: 'foo2', label: 'foo2' };
+
+    it('should keep sortOrder for undefined', () => {
+      expect([field2, field1].sort(builder.elementSortFunc)).toEqual([field2, field1]);
+    });
+    it('should sort elements', () => {
+      const fields = [{ ...field1, sortOrder: 2 }, { ...field2, sortOrder: 1 }];
+      expect(fields.sort(builder.elementSortFunc)).toEqual(fields.reverse());
+    });
+    it('should keep sortOrder', () => {
+      const fields = [{ ...field2, sortOrder: 1 }, { ...field1, sortOrder: 2 }];
+      expect(fields.sort(builder.elementSortFunc)).toEqual([...fields]);
+    });
+  });
 });
+/* eslint-enable extra-rules/no-single-line-objects */


### PR DESCRIPTION
# Description

Fixed the wrong ordering of fields rendered by the FormBuilder, when no sortIndex is provided.

## Type of change

Please add an "x" into the option that is relevant:

- [X] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
