### PR TITLE
Fixed issues with long cached and wrong checkout related urls

### DIFF
--- a/libraries/common/reducers/url/index.js
+++ b/libraries/common/reducers/url/index.js
@@ -4,7 +4,7 @@ import {
   ERROR_URL,
 } from '../../constants/ActionTypes';
 
-const URL_LIFETIME = 31536000000; // 1 year in milliseconds
+const URL_LIFETIME = 300000; // 5 minutes in milliseconds
 const defaultState = {};
 
 /**

--- a/libraries/common/store/index.js
+++ b/libraries/common/store/index.js
@@ -15,7 +15,7 @@ import logger from './middelwares/logger';
  * The current version of the state created by this reducer.
  * @type {string}
  */
-const STATE_VERSION = 'v1';
+const STATE_VERSION = 'v2';
 const storeKey = `shopgate-connect_${shopNumber}-${themeName}_${STATE_VERSION}`;
 
 /**

--- a/libraries/common/subscriptions/helpers/handleLinks.js
+++ b/libraries/common/subscriptions/helpers/handleLinks.js
@@ -109,7 +109,12 @@ export const isShopLink = (location) => {
   }
 
   // Dissect the hostname form the given location.
-  const { hostname } = new URL(location);
+  let hostname;
+  try {
+    ({ hostname } = new URL(location));
+  } catch (e) {
+    return false;
+  }
 
   // Check for an exact match against the shop CNAME.
   if (hostname === appConfig.shopCNAME.toLowerCase()) {

--- a/libraries/common/subscriptions/helpers/handleLinks.spec.js
+++ b/libraries/common/subscriptions/helpers/handleLinks.spec.js
@@ -34,6 +34,7 @@ describe('handleLinks helpers', () => {
       'http://example.com',
       'https://example.com',
       'https://example.com/page/cms',
+      '?foo=bar',
     ];
 
     positives.forEach((href) => {

--- a/libraries/common/subscriptions/router.js
+++ b/libraries/common/subscriptions/router.js
@@ -1,3 +1,4 @@
+import queryString from 'query-string';
 import {
   router,
   ACTION_POP,
@@ -29,6 +30,17 @@ export default function routerSubscriptions(subscribe) {
     const {
       action, dispatch, getState, events,
     } = params;
+
+    /**
+     * Triggers a connectivity error toast message
+     */
+    const showConnectivityError = () => {
+      events.emit(ToastProvider.ADD, {
+        id: 'navigate.error',
+        message: 'error.general',
+      });
+    };
+
     const { params: { action: historyAction, silent, state: routeState } } = action;
 
     switch (historyAction) {
@@ -63,11 +75,7 @@ export default function routerSubscriptions(subscribe) {
 
     // Abort navigation when the internet connection got lost.
     if (!getIsConnected(state)) {
-      events.emit(ToastProvider.ADD, {
-        id: 'navigate.error',
-        message: 'error.general',
-      });
-
+      showConnectivityError();
       return;
     }
 
@@ -136,6 +144,14 @@ export default function routerSubscriptions(subscribe) {
       }
 
       location = redirect;
+    }
+
+    const parsed = queryString.parseUrl(location);
+
+    if (!parsed.url) {
+      // The URL is not valid - show a toast message
+      showConnectivityError();
+      return;
     }
 
     // Override the location if is Shop link is found.

--- a/libraries/common/subscriptions/router.spec.js
+++ b/libraries/common/subscriptions/router.spec.js
@@ -335,6 +335,41 @@ describe('Router subscriptions', () => {
       expect(LoadingProvider.unsetLoading).toHaveBeenCalledWith(protectorRoute);
     });
 
+    it('should abort navigation when the url is invalid', async () => {
+      const params = {
+        action: ACTION_PUSH,
+        pathname: '?foo=bar',
+      };
+
+      await expect(callback(createCallbackPayload({ params }))).resolves.toBe();
+      testExpectedCall(events.emit);
+      expect(events.emit).toHaveBeenCalledWith(ToastProvider.ADD, {
+        id: 'navigate.error',
+        message: 'error.general',
+      });
+    });
+
+    it('should abort navigation when the redirect url is invalid', async () => {
+      /**
+       * @return {Promise}
+       */
+      const redirectHandler = () => Promise.resolve('?foo=bar');
+
+      redirects.set('/some_route', redirectHandler);
+
+      const params = {
+        action: ACTION_PUSH,
+        pathname: '/some_route',
+      };
+
+      await expect(callback(createCallbackPayload({ params }))).resolves.toBe();
+      testExpectedCall(events.emit);
+      expect(events.emit).toHaveBeenCalledWith(ToastProvider.ADD, {
+        id: 'navigate.error',
+        message: 'error.general',
+      });
+    });
+
     it('should convert shop links as expected', async () => {
       mockedShopCNAME = 'm.awesomeshop.com';
 


### PR DESCRIPTION
# Description

This pull request reduces the expiry time of url state entries, which where added without a specific expiry date. Those entries will now only be stored for 5 minutes by now.
Additionally it contains a fix for navigation attempts to invalid urls. Users will now see a toast message instead of a white page.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Add an invalid link to an HTML widget like `<a href="?foo=bar">Invalid</a>`. Without the adjustments of this ticket, you'll run into a white page.
