### PR TITLE
Renamed priceLocale extension config key to currencyLocale

### DIFF
--- a/libraries/engage/core/helpers/__tests__/i18n.spec.js
+++ b/libraries/engage/core/helpers/__tests__/i18n.spec.js
@@ -47,7 +47,7 @@ describe('i18n', () => {
     i18n.init({
       locales: {},
       lang: 'en-US',
-      priceLocale: 'en-IL',
+      currencyLocale: 'en-IL',
     });
 
     expect(i18n.price(1000, 'EUR', 2)).toBe('€1,000.00');

--- a/libraries/engage/core/helpers/i18n.js
+++ b/libraries/engage/core/helpers/i18n.js
@@ -31,14 +31,14 @@ const I18n = () => {
   };
 
   return {
-    init({ locales, lang, priceLocale = null }) {
+    init({ locales, lang, currencyLocale = null }) {
       if (didInit) {
         logger.warn('Looks like i18n locales are already inited. Changing locales now may lead to inconsistent translations.');
       }
       didInit = true;
 
       this.text = getTranslator(locales, lang);
-      this.price = getPriceFormatter(priceLocale || lang);
+      this.price = getPriceFormatter(currencyLocale || lang);
       this.date = getDateFormatter(lang);
       this.time = getTimeFormatter(lang);
       this.number = getNumberFormatter(lang);

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -78,7 +78,7 @@
       "type": "admin",
       "destination": "frontend",
       "default": {
-        "price": null
+        "currency": null
       },
       "params": {
         "type": "json",

--- a/themes/theme-gmd/index.jsx
+++ b/themes/theme-gmd/index.jsx
@@ -19,12 +19,12 @@ import reducers from './pages/reducers';
 import subscribers from './pages/subscribers';
 import Pages from './pages';
 
-const { locales: { price: priceLocale = null } = {} } = appConfig;
+const { locales: { currency: currencyLocale = null } = {} } = appConfig;
 
 i18n.init({
   locales,
   lang: process.env.LOCALE,
-  priceLocale,
+  currencyLocale,
 });
 
 smoothscroll.polyfill();

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -78,7 +78,7 @@
       "type": "admin",
       "destination": "frontend",
       "default": {
-        "price": null
+        "currency": null
       },
       "params": {
         "type": "json",

--- a/themes/theme-ios11/index.jsx
+++ b/themes/theme-ios11/index.jsx
@@ -19,12 +19,12 @@ import reducers from './pages/reducers';
 import subscribers from './pages/subscribers';
 import Pages from './pages';
 
-const { locales: { price: priceLocale = null } = {} } = appConfig;
+const { locales: { currency: currencyLocale = null } = {} } = appConfig;
 
 i18n.init({
   locales,
   lang: process.env.LOCALE,
-  priceLocale,
+  currencyLocale,
 });
 
 smoothscroll.polyfill();


### PR DESCRIPTION
# Description
Out product owner gave some feedback about the priceLocale extension config key. Due to this feedback to key was renamed to currencyLocale.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.
