### PR TITLE
Update routes portals collection when extension config, containing routes, is changed

### DIFF
--- a/libraries/common/helpers/portals/__tests__/routePortals.js
+++ b/libraries/common/helpers/portals/__tests__/routePortals.js
@@ -1,0 +1,71 @@
+import collection from '../portalCollection';
+import { APP_ROUTES } from '../../../constants/Portals';
+
+jest.mock('../../config', () => ({
+  componentsConfig: {
+    portals: {
+      route1: {
+        path: 'route1.jsx',
+        target: 'app.routes',
+      },
+      component1: {
+        path: 'component1.jsx',
+        target: 'view.before',
+      },
+      route2: {
+        path: 'route2.jsx',
+        target: 'app.routes',
+      },
+    },
+  },
+}));
+
+describe('helpers/portals/routePortals.js', () => {
+  let routePortals;
+
+  const portals = {
+    route1: jest.fn(() => 'route1 content'),
+    route2: jest.fn(() => null),
+    route10: jest.fn(() => 'route10 content'),
+    route20: jest.fn(() => null),
+  };
+
+  jest.spyOn(collection, 'getPortals').mockReturnValue(portals);
+
+  it('should read from static config', () => {
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      routePortals = require('../routePortals').default;
+    });
+
+    expect(routePortals).toEqual([
+      'route1 content',
+    ]);
+  });
+
+  it('should read from registered config', () => {
+    jest.spyOn(collection, 'getConfig').mockReturnValue({
+      route10: {
+        path: 'route10.jsx',
+        target: APP_ROUTES,
+      },
+      component10: {
+        path: 'component10.jsx',
+        target: 'view.before',
+      },
+      route20: {
+        path: 'route20.jsx',
+        target: APP_ROUTES,
+      },
+    });
+
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      routePortals = require('../routePortals').default;
+    });
+
+    expect(routePortals).toEqual([
+      'route10 content',
+    ]);
+  });
+});

--- a/libraries/common/helpers/portals/routePortals.js
+++ b/libraries/common/helpers/portals/routePortals.js
@@ -1,11 +1,12 @@
-import { componentsConfig as config } from '../config';
+import { componentsConfig } from '../config';
 import collection from './portalCollection';
 import { APP_ROUTES } from '../../constants/Portals';
 
 const portals = collection.getPortals();
+const config = collection.getConfig() || componentsConfig.portals;
 
-const routes = Object.keys(config.portals).map((component) => {
-  if (config.portals[component].target !== APP_ROUTES) {
+const routes = Object.keys(config).map((component) => {
+  if (config[component].target !== APP_ROUTES) {
     return null;
   }
   return portals[component]();


### PR DESCRIPTION
# Description

Update routes portals collection when extension config, containing routes, is changed.

## Type of change

Please add an "x" into the option that is relevant:

- [X] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
