### PR TITLE
Corrected version of the theme-config extension and added a config to enable the beta mode

### DIFF
--- a/extensions/@shopgate-theme-config/extension-config.json
+++ b/extensions/@shopgate-theme-config/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.1.1",
   "id": "@shopgate/theme-config",
   "components": [
     {
@@ -9,6 +9,16 @@
     }
   ],
   "configuration": {
+    "beta": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "json",
+        "label": "Enables or disables the beta features of the themes.",
+        "required": false
+      }
+    },
     "themeIos": {
       "type": "admin",
       "destination": "frontend",

--- a/extensions/@shopgate-theme-config/frontend/index.js
+++ b/extensions/@shopgate-theme-config/frontend/index.js
@@ -11,6 +11,10 @@ import nmaConfig from './config';
 
 // Write predefined configs, first: Deep merge with page and widget array item identity check.
 const config = configCommon;
+
+// Enable or disable beta mode for the themes if configured in NMA
+config.beta = !!nmaConfig.beta;
+
 if (themeName.includes('ios')) {
   assignObjectDeep(config, configIos, true, appConfigArrayItemComparator, '$');
 } else {

--- a/extensions/@shopgate-theme-config/frontend/package.json
+++ b/extensions/@shopgate-theme-config/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate/theme-config",
-  "version": "6.10.0",
+  "version": "1.1.1",
   "description": "Provides the theme configurations for Catalog 2.0",
   "license": "Apache-2.0",
   "devDependencies": {

--- a/utils/webpack/package.json
+++ b/utils/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate/webpack",
-  "version": "6.9.1",
+  "version": "6.10.0",
   "description": "The webpack configuration for Shopgate's Engage.",
   "main": "webpack.config.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Description

Corrected version of the theme-config extension and added a config to enable the beta mode

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.
