### PR TITLE
Fixed sort filter entries text color

### DIFF
--- a/themes/theme-gmd/components/FilterBar/components/Content/components/Sort/style.js
+++ b/themes/theme-gmd/components/FilterBar/components/Content/components/Sort/style.js
@@ -47,6 +47,7 @@ const selectItem = css({
   overflow: 'hidden',
   textAlign: 'left',
   width: '100%',
+  color: colors.dark,
   ':first-child': {
     marginTop: variables.gap.big / 2,
   },

--- a/themes/theme-ios11/components/FilterBar/components/Content/components/Sort/style.js
+++ b/themes/theme-ios11/components/FilterBar/components/Content/components/Sort/style.js
@@ -1,7 +1,7 @@
 import { css } from 'glamor';
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 
-const { variables, shadows } = themeConfig;
+const { variables, colors, shadows } = themeConfig;
 
 const button = css({
   color: 'inherit',
@@ -45,6 +45,7 @@ const selectItem = css({
   overflow: 'hidden',
   textAlign: 'left',
   width: '100%',
+  color: colors.dark,
   ':first-child': {
     marginTop: variables.gap.big / 2,
   },


### PR DESCRIPTION
# Description
This ticket fixes a styling bug of the sort filter entries. When other filters where selected, the entries of the sort dropdown where not readable anymore, since their text color was white.

The bug was caused by a refactoring of the SelectBoxItem component where a `button` element was transformed into an `li`. Other than buttons li elements inherit the color of their parent elements which is white in the described situation.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Configure a filter for a category or search results and open the sort order drop down. The text should be readable again.
