### PR TITLE
Fixed duplication of new array config entries on reference resolving. Further improved the config resolve algorithm to also support concatenated configs using references and custom text.

### DIFF
--- a/libraries/common/helpers/config/index.js
+++ b/libraries/common/helpers/config/index.js
@@ -101,7 +101,7 @@ appConfig.theme = themeConfig;
  * @param {string} path Allows identification of the current elements to be compared
  * @param {*} prev Item that already exists in the config.
  * @param {*} next Item to be compared against.
- * @returns {boolean}
+ * @returns {boolean} Returns true if the items are considered equal and false if not
  */
 export const appConfigArrayItemComparator = (path, prev, next) => {
   // Replaces object paths with array indices to a structure with easy comparisons
@@ -128,6 +128,18 @@ export const appConfigArrayItemComparator = (path, prev, next) => {
   // => Custom defined array items must be handled using the given arrayComparator!
   return false;
 };
+
+/**
+ * Comparator which treats items to be equal arrays by the position of the item in the array.
+ * @param {string} [path] Unused param
+ * @param {*} [prev] Unused param
+ * @param {*} [next] Unused param
+ * @param {number} prevIndex Position of the prev item in the array which is currently compared
+ * @param {number} nextIndex Position of the next item in the array which is currently compared
+ * @returns {boolean} Returns true if the items are considered equal and false if not
+ */
+export const equalStructureComparator = (path, prev, next, prevIndex, nextIndex) =>
+  prevIndex === nextIndex;
 
 /**
  * Takes an object with app config values and safely injects it into the current app config.

--- a/libraries/engage/core/config/ThemeConfigResolver.js
+++ b/libraries/engage/core/config/ThemeConfigResolver.js
@@ -1,6 +1,9 @@
 /* eslint-disable class-methods-use-this */
 import get from 'lodash/get';
-import appConfig, { writeToConfig } from '@shopgate/pwa-common/helpers/config';
+import appConfig, {
+  writeToConfig,
+  equalStructureComparator,
+} from '@shopgate/pwa-common/helpers/config';
 
 /**
  * Parses a JSON object and resolves placeholders with values from the object.
@@ -9,11 +12,14 @@ export class ThemeConfigResolver {
   /**
    * @param {Object} config The configuration to resolve references for.
    * @param {string} [delimiter='$.'] What the replaceable starts with.
+   * @param {string} [endDelimiter='.$'] What the replaceable ends with. Useful within some strings.
    * @constructor
    */
-  constructor(config = {}, delimiter = '$.') {
+  constructor(config = {}, delimiter = '$.', endDelimiter = '.$') {
     this.config = config;
     this.delimiter = delimiter;
+    // Some references require an ending delimiter. E.g.: "size: $.theme.reference.value.$rem"
+    this.endDelimiter = endDelimiter;
   }
 
   /**
@@ -33,7 +39,9 @@ export class ThemeConfigResolver {
    */
   resolveAll() {
     this.config = appConfig.theme;
-    writeToConfig({ theme: this.resolve() });
+    console.log('BEFORE:', JSON.parse(JSON.stringify(appConfig.theme)));
+    writeToConfig({ theme: this.resolve() }, equalStructureComparator);
+    console.log('AFTER', JSON.parse(JSON.stringify(appConfig.theme)));
   }
 
   /**
@@ -103,17 +111,36 @@ export class ThemeConfigResolver {
   processString(input) {
     // Replace all variable references in the given string if any exist
     let value = input;
+    let replacementValue;
     const preRegex = new RegExp(`.*${
       // Escape delimiter to use within another reg exp.
       this.delimiter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     }`, 'g');
     const postRegex = new RegExp(/[^a-zA-Z0-9_$.].*$/, 'g');
-    while (value.includes(this.delimiter)) {
-      // Get next reference
-      const path = value.replace(preRegex, '').replace(postRegex, '');
+    const partials = value.split(this.delimiter).map((partial, index) => {
+      // The first entry can never contain references
+      if (index === 0) {
+        return partial;
+      }
 
-      // replace reference (including its delimiter) with the actual value
-      value = value.replace(`${this.delimiter}${path}`, get(this.config, path));
+      const partialValue = `${this.delimiter}${partial}`;
+      return partialValue.split(this.endDelimiter).map((s, i) => {
+        // Can only have two parts with the first being either a path or plain text
+        if (i > 0) {
+          return s;
+        }
+
+        // Replace reference if this part contains one
+        const path = s.replace(preRegex, '').replace(postRegex, '');
+        replacementValue = get(this.config, path);
+        return s.replace(`${this.delimiter}${path}`, replacementValue);
+      }).join('');
+    });
+    value = partials.join('');
+
+    // Keep the original type if it's not a combined value
+    if (replacementValue !== undefined && replacementValue.toString() === value) {
+      return replacementValue;
     }
 
     return value;

--- a/libraries/engage/core/config/ThemeConfigResolver.js
+++ b/libraries/engage/core/config/ThemeConfigResolver.js
@@ -39,9 +39,7 @@ export class ThemeConfigResolver {
    */
   resolveAll() {
     this.config = appConfig.theme;
-    console.log('BEFORE:', JSON.parse(JSON.stringify(appConfig.theme)));
     writeToConfig({ theme: this.resolve() }, equalStructureComparator);
-    console.log('AFTER', JSON.parse(JSON.stringify(appConfig.theme)));
   }
 
   /**


### PR DESCRIPTION
# Description

Fixed duplication of new array config entries on reference resolving. Further improved the config resolve algorithm to also support concatenated configs using references and custom text.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Add a custom theme setting which contains an error. The entries should not be duplicated anymore. Then use a reference like "textSize: $.typography.lineHeight.$em". This should then resolve to "textSize: 1.5em".
