### PR TITLE
Fixed broken image sliders on Chrome > 80

### DIFF
--- a/libraries/common/components/Swiper/styles.js
+++ b/libraries/common/components/Swiper/styles.js
@@ -3,6 +3,7 @@ import { css } from 'glamor';
 export const container = css({
   position: 'relative',
   maxHeight: '100%',
+  width: '100vw',
 }).toString();
 
 export const innerContainer = css({

--- a/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
@@ -80,7 +80,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
         >
           <div
             aria-hidden={null}
-            className="css-1hlki0z css-sa13d4"
+            className="css-u3lnhr css-sa13d4"
           >
             <ReactIdSwiper
               ContainerEl="div"
@@ -371,7 +371,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
         >
           <div
             aria-hidden={null}
-            className="css-1hlki0z css-sa13d4"
+            className="css-u3lnhr css-sa13d4"
           >
             <ReactIdSwiper
               ContainerEl="div"

--- a/themes/theme-gmd/widgets/ImageSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/widgets/ImageSlider/__snapshots__/spec.jsx.snap
@@ -55,7 +55,7 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
     >
       <div
         aria-hidden={null}
-        className="css-1hlki0z"
+        className="css-u3lnhr"
       >
         <ReactIdSwiper
           ContainerEl="div"
@@ -499,7 +499,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
     >
       <div
         aria-hidden={null}
-        className="css-1hlki0z"
+        className="css-u3lnhr"
       >
         <ReactIdSwiper
           ContainerEl="div"
@@ -787,7 +787,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
     >
       <div
         aria-hidden={null}
-        className="css-1hlki0z"
+        className="css-u3lnhr"
       >
         <ReactIdSwiper
           ContainerEl="div"

--- a/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
@@ -80,7 +80,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
         >
           <div
             aria-hidden={null}
-            className="css-1hlki0z css-sa13d4"
+            className="css-u3lnhr css-sa13d4"
           >
             <ReactIdSwiper
               ContainerEl="div"
@@ -371,7 +371,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
         >
           <div
             aria-hidden={null}
-            className="css-1hlki0z css-sa13d4"
+            className="css-u3lnhr css-sa13d4"
           >
             <ReactIdSwiper
               ContainerEl="div"

--- a/themes/theme-ios11/widgets/ImageSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/widgets/ImageSlider/__snapshots__/spec.jsx.snap
@@ -55,7 +55,7 @@ exports[`<ImageSliderWidget /> should map the correct image settings to the comp
     >
       <div
         aria-hidden={null}
-        className="css-1hlki0z"
+        className="css-u3lnhr"
       >
         <ReactIdSwiper
           ContainerEl="div"
@@ -503,7 +503,7 @@ exports[`<ImageSliderWidget /> should render the images with links 1`] = `
     >
       <div
         aria-hidden={null}
-        className="css-1hlki0z"
+        className="css-u3lnhr"
       >
         <ReactIdSwiper
           ContainerEl="div"
@@ -793,7 +793,7 @@ exports[`<ImageSliderWidget /> should render the slider with the correct number 
     >
       <div
         aria-hidden={null}
-        className="css-1hlki0z"
+        className="css-u3lnhr"
       >
         <ReactIdSwiper
           ContainerEl="div"


### PR DESCRIPTION
# Description

This ticket fixes an issue that caused broken image sliders at slides with 100% screen width. When the issue occurred, the slides where much too big and consumed multiple screen heights. The issue was introduced on Android with a Chrome / Android System WebView v80.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
