### PR TITLE
Introduced a className prop to the Media component of the themes to enable custom component widths via classes

### DIFF
--- a/libraries/common/components/Swiper/styles.js
+++ b/libraries/common/components/Swiper/styles.js
@@ -3,6 +3,7 @@ import { css } from 'glamor';
 export const container = css({
   position: 'relative',
   maxHeight: '100%',
+  // This needs to be 100vw to compensate a chrome 80 bug - see related ticket / pr.
   width: '100vw',
 }).toString();
 

--- a/libraries/engage/product/components/MediaSlider/index.jsx
+++ b/libraries/engage/product/components/MediaSlider/index.jsx
@@ -18,7 +18,7 @@ const typeRenders = {
  * @returns {JSX}
  */
 const MediaSlider = ({
-  navigate, featuredMedia, media, 'aria-hidden': ariaHidden, renderPlaceholder,
+  navigate, featuredMedia, media, 'aria-hidden': ariaHidden, renderPlaceholder, className,
 }) => {
   let currentSlide = 0;
 
@@ -51,6 +51,7 @@ const MediaSlider = ({
             onSlideChange={setCurrentSlide}
             disabled={media.length === 1}
             controls={media.some(m => m.type === MEDIA_TYPE_VIDEO)}
+            className={className}
             aria-hidden={ariaHidden}
           >
             {media.map((singleMedia) => {
@@ -71,6 +72,7 @@ const MediaSlider = ({
 MediaSlider.propTypes = {
   navigate: PropTypes.func.isRequired,
   'aria-hidden': PropTypes.bool,
+  className: PropTypes.string,
   featuredMedia: PropTypes.shape({
     type: PropTypes.string,
     code: PropTypes.string,
@@ -90,6 +92,7 @@ MediaSlider.propTypes = {
 
 MediaSlider.defaultProps = {
   'aria-hidden': null,
+  className: null,
   featuredMedia: null,
   media: null,
   renderPlaceholder: featuredMedia => (<MediaImage {...featuredMedia} />),

--- a/libraries/engage/product/components/ProductImage/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/product/components/ProductImage/__snapshots__/spec.jsx.snap
@@ -7,6 +7,7 @@ exports[`<ProductImage /> should apply an inner shadow to the image if turned of
 >
   <div
     aria-hidden={null}
+    className={null}
   >
     <Image
       alt={null}
@@ -74,6 +75,7 @@ exports[`<ProductImage /> should not apply an inner shadow to the image if turne
 >
   <div
     aria-hidden={null}
+    className={null}
   >
     <Image
       alt={null}
@@ -216,6 +218,7 @@ exports[`<ProductImage /> should render the image without a placeholder 1`] = `
 >
   <div
     aria-hidden={null}
+    className={null}
   >
     <Image
       alt={null}

--- a/libraries/engage/product/components/ProductImage/index.jsx
+++ b/libraries/engage/product/components/ProductImage/index.jsx
@@ -115,7 +115,7 @@ class ProductImage extends Component {
    * @returns {JSX}
    */
   render() {
-    const { noBackground } = this.props;
+    const { noBackground, className } = this.props;
     let { showInnerShadow } = this.props.widgetSettings;
 
     if (typeof showInnerShadow === 'undefined') {
@@ -129,6 +129,7 @@ class ProductImage extends Component {
           <div
             className={classnames(styles.placeholderContainer, {
               [styles.innerShadow]: showInnerShadow,
+              [className]: !!className,
             })}
             aria-hidden={this.props['aria-hidden']}
           >
@@ -143,7 +144,7 @@ class ProductImage extends Component {
     // Return the actual image.
     return (
       <SurroundPortals portalName={PORTAL_PRODUCT_IMAGE}>
-        <div aria-hidden={this.props['aria-hidden']}>
+        <div aria-hidden={this.props['aria-hidden']} className={className}>
           <Image
             {...this.props}
             className={showInnerShadow ? styles.innerShadow : ''}

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -46,6 +46,7 @@ const getImagesByIndex = (images) => {
 class ProductImageSlider extends Component {
   static propTypes = {
     'aria-hidden': PropTypes.bool,
+    className: PropTypes.string,
     images: PropTypes.arrayOf(PropTypes.shape()),
     navigate: PropTypes.func,
     product: PropTypes.shape(),
@@ -53,12 +54,11 @@ class ProductImageSlider extends Component {
 
   static defaultProps = {
     'aria-hidden': null,
+    className: null,
     images: null,
     product: null,
     navigate: () => { },
   };
-
-  currentSlide = 0;
 
   /**
    * @param {Object} nextProps the next props
@@ -84,12 +84,16 @@ class ProductImageSlider extends Component {
     this.currentSlide = currentSlide;
   };
 
+  currentSlide = 0;
+
   /**
    * Renders the product image slider component.
    * @returns {JSX}
    */
   render() {
-    const { product, images, 'aria-hidden': ariaHidden } = this.props;
+    const {
+      product, images, 'aria-hidden': ariaHidden, className,
+    } = this.props;
     let content;
     let imagesByIndex = [];
 
@@ -106,6 +110,7 @@ class ProductImageSlider extends Component {
             indicators
             onSlideChange={this.handleSlideChange}
             disabled={imagesByIndex.length === 1}
+            className={className}
           >
             {imagesByIndex.map(imagesInIndex => (
               <Swiper.Item key={`${product.id}-${imagesInIndex[0]}`}>
@@ -121,6 +126,7 @@ class ProductImageSlider extends Component {
       content = (
         <ProductImage
           src={product ? product.featuredImageUrl : null}
+          className={className}
           forcePlaceholder={!product}
           resolutions={fallbackResolutions}
         />

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductMediaSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductMediaSlider/index.jsx
@@ -11,17 +11,20 @@ const ProductMediaSlider = ({
   productId,
   featuredMediaBaseProduct,
   featuredMediaCharacteristics,
+  className,
 }) => (
   <MediaSlider
     productId={productId}
+    className={className}
     renderPlaceholder={(featuredMedia) => {
       const props = featuredMediaCharacteristics || featuredMedia || featuredMediaBaseProduct;
-      return (<MediaImage {...props} />);
+      return (<MediaImage {...props} className={className} />);
     }}
   />
 );
 
 ProductMediaSlider.propTypes = {
+  className: PropTypes.string,
   featuredMediaBaseProduct: PropTypes.shape({
     type: PropTypes.string,
     code: PropTypes.string,
@@ -41,6 +44,7 @@ ProductMediaSlider.propTypes = {
 };
 
 ProductMediaSlider.defaultProps = {
+  className: null,
   featuredMediaCharacteristics: null,
   featuredMediaBaseProduct: null,
   productId: null,

--- a/themes/theme-gmd/pages/Product/components/Media/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/index.jsx
@@ -11,12 +11,15 @@ import { ProductContext } from '../../context';
  * The product media component.
  * @returns {JSX}
  */
-const Media = ({ 'aria-hidden': ariaHidden }) => (
+const Media = ({ 'aria-hidden': ariaHidden, className }) => (
   <ProductContext.Consumer>
     {({ productId, variantId, characteristics }) => (
       <SurroundPortals
         portalName={PORTAL_PRODUCT_MEDIA_SECTION}
-        portalProps={{ productId, variantId }}
+        portalProps={{
+          productId,
+          variantId,
+        }}
       >
         {/* MediaSlider feature is currently in BETA testing.
               It should only be used for approved BETA Client Projects */}
@@ -26,12 +29,14 @@ const Media = ({ 'aria-hidden': ariaHidden }) => (
             variantId={variantId}
             characteristics={characteristics}
             aria-hidden={ariaHidden}
+            className={className}
           />
         ) : (
           <ProductImageSlider
             productId={productId}
             variantId={variantId}
             aria-hidden={ariaHidden}
+            className={className}
           />
         )}
       </SurroundPortals>
@@ -41,10 +46,12 @@ const Media = ({ 'aria-hidden': ariaHidden }) => (
 
 Media.propTypes = {
   'aria-hidden': PropTypes.bool,
+  className: PropTypes.string,
 };
 
 Media.defaultProps = {
   'aria-hidden': null,
+  className: null,
 };
 
 export default Media;

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -46,6 +46,7 @@ const getImagesByIndex = (images) => {
 class ProductImageSlider extends Component {
   static propTypes = {
     'aria-hidden': PropTypes.bool,
+    className: PropTypes.string,
     images: PropTypes.arrayOf(PropTypes.shape()),
     navigate: PropTypes.func,
     product: PropTypes.shape(),
@@ -53,12 +54,11 @@ class ProductImageSlider extends Component {
 
   static defaultProps = {
     'aria-hidden': null,
+    className: null,
     images: null,
     product: null,
     navigate: () => { },
   };
-
-  currentSlide = 0;
 
   /**
    * @param {Object} nextProps the next props
@@ -84,12 +84,16 @@ class ProductImageSlider extends Component {
     this.currentSlide = currentSlide;
   };
 
+  currentSlide = 0;
+
   /**
    * Renders the product image slider component.
    * @returns {JSX}
    */
   render() {
-    const { product, images, 'aria-hidden': ariaHidden } = this.props;
+    const {
+      product, images, 'aria-hidden': ariaHidden, className,
+    } = this.props;
     let content;
     let imagesByIndex = [];
 
@@ -106,6 +110,7 @@ class ProductImageSlider extends Component {
             indicators
             onSlideChange={this.handleSlideChange}
             disabled={imagesByIndex.length === 1}
+            className={className}
           >
             {imagesByIndex.map(imagesInIndex => (
               <Swiper.Item key={`${product.id}-${imagesInIndex[0]}`}>
@@ -121,6 +126,7 @@ class ProductImageSlider extends Component {
       content = (
         <ProductImage
           src={product ? product.featuredImageUrl : null}
+          className={className}
           forcePlaceholder={!product}
           resolutions={fallbackResolutions}
         />

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductMediaSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductMediaSlider/index.jsx
@@ -11,17 +11,20 @@ const ProductMediaSlider = ({
   productId,
   featuredMediaBaseProduct,
   featuredMediaCharacteristics,
+  className,
 }) => (
   <MediaSlider
     productId={productId}
+    className={className}
     renderPlaceholder={(featuredMedia) => {
       const props = featuredMediaCharacteristics || featuredMedia || featuredMediaBaseProduct;
-      return (<MediaImage {...props} />);
+      return (<MediaImage {...props} className={className} />);
     }}
   />
 );
 
 ProductMediaSlider.propTypes = {
+  className: PropTypes.string,
   featuredMediaBaseProduct: PropTypes.shape({
     type: PropTypes.string,
     code: PropTypes.string,
@@ -41,6 +44,7 @@ ProductMediaSlider.propTypes = {
 };
 
 ProductMediaSlider.defaultProps = {
+  className: null,
   featuredMediaCharacteristics: null,
   featuredMediaBaseProduct: null,
   productId: null,

--- a/themes/theme-ios11/pages/Product/components/Media/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/index.jsx
@@ -11,12 +11,15 @@ import { ProductContext } from '../../context';
  * The product media component.
  * @returns {JSX}
  */
-const Media = ({ 'aria-hidden': ariaHidden }) => (
+const Media = ({ 'aria-hidden': ariaHidden, className }) => (
   <ProductContext.Consumer>
     {({ productId, variantId, characteristics }) => (
       <SurroundPortals
         portalName={PORTAL_PRODUCT_MEDIA_SECTION}
-        portalProps={{ productId, variantId }}
+        portalProps={{
+          productId,
+          variantId,
+        }}
       >
         {/* MediaSlider feature is currently in BETA testing.
               It should only be used for approved BETA Client Projects */}
@@ -26,12 +29,14 @@ const Media = ({ 'aria-hidden': ariaHidden }) => (
             variantId={variantId}
             characteristics={characteristics}
             aria-hidden={ariaHidden}
+            className={className}
           />
         ) : (
           <ProductImageSlider
             productId={productId}
             variantId={variantId}
             aria-hidden={ariaHidden}
+            className={className}
           />
         )}
       </SurroundPortals>
@@ -41,10 +46,12 @@ const Media = ({ 'aria-hidden': ariaHidden }) => (
 
 Media.propTypes = {
   'aria-hidden': PropTypes.bool,
+  className: PropTypes.string,
 };
 
 Media.defaultProps = {
   'aria-hidden': null,
+  className: null,
 };
 
 export default Media;


### PR DESCRIPTION
# Description

This ticket is about to provide a `className` prop to the Media components within the themes. The class is added to the first rendered DOM node, and can be used to set / override the width of the Media component content (usually `100vw`).

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
