### PR TITLE
The Availability component within the ProductInfo is now hidden when the product has fulfillment methods assigned

### DIFF
--- a/libraries/engage/locations/subscriptions.js
+++ b/libraries/engage/locations/subscriptions.js
@@ -43,7 +43,7 @@ function locations(subscribe) {
 
       // Cart with ropis products
       const cartReceivedWithRopis$ = cartReceived$.filter(
-        ({ action: { cart: { cartItems } } }) => (
+        ({ action: { cart: { cartItems = [] } = {} } }) => (
           cartItems.some(item => (
             item.fulfillment && item.fulfillment.location && item.fulfillment.location.code
           ))

--- a/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/connector.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/connector.js
@@ -1,0 +1,22 @@
+import { connect } from 'react-redux';
+import { makeGetFulfillmentMethods } from '@shopgate/engage/locations';
+
+/**
+ * @param {Object} state The current application state.
+ * @param {Object} props The component props.
+ * @return {Object} The extended component props.
+ */
+function makeMapStateToProps() {
+  const getFulfillmentMethods = makeGetFulfillmentMethods();
+
+  /**
+   * @param {Object} state The application state.
+   * @param {Object} props The component props.
+   * @returns {Object}
+   */
+  return (state, props) => ({
+    showAvailablity: !getFulfillmentMethods(state, props),
+  });
+}
+
+export default connect(makeMapStateToProps);

--- a/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -24,12 +24,13 @@ import Tiers from '../Tiers';
 import TaxDisclaimer from '../TaxDisclaimer';
 import StockInfo from '../StockInfo';
 import * as styles from './style';
+import connect from './connector';
 
 /**
  * @param {Object} props The component props.
  * @returns {JSX}
  */
-const ProductInfo = ({ productId, options }) => (
+const ProductInfo = ({ productId, options, showAvailablity }) => (
   <Fragment>
     <Portal name={PRODUCT_INFO_BEFORE} />
     <Portal name={PRODUCT_INFO}>
@@ -55,9 +56,11 @@ const ProductInfo = ({ productId, options }) => (
             <div className={styles.productInfo}>
               {/* This feature is currently in BETA testing.
                 It should only be used for approved BETA Client Projects */}
-              <EffectivityDates productId={productId}>
-                <Availability productId={productId} />
-              </EffectivityDates>
+              {showAvailablity && (
+                <EffectivityDates productId={productId}>
+                  <Availability productId={productId} />
+                </EffectivityDates>
+              )}
             </div>
             <div className={styles.productInfo}>
               <StockInfo productId={productId} />
@@ -90,6 +93,7 @@ const ProductInfo = ({ productId, options }) => (
 ProductInfo.propTypes = {
   options: PropTypes.shape().isRequired,
   productId: PropTypes.string.isRequired,
+  showAvailablity: PropTypes.bool.isRequired,
 };
 
-export default memo(ProductInfo);
+export default connect(memo(ProductInfo));

--- a/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/connector.js
+++ b/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/connector.js
@@ -1,0 +1,22 @@
+import { connect } from 'react-redux';
+import { makeGetFulfillmentMethods } from '@shopgate/engage/locations';
+
+/**
+ * @param {Object} state The current application state.
+ * @param {Object} props The component props.
+ * @return {Object} The extended component props.
+ */
+function makeMapStateToProps() {
+  const getFulfillmentMethods = makeGetFulfillmentMethods();
+
+  /**
+   * @param {Object} state The application state.
+   * @param {Object} props The component props.
+   * @returns {Object}
+   */
+  return (state, props) => ({
+    showAvailablity: !getFulfillmentMethods(state, props),
+  });
+}
+
+export default connect(makeMapStateToProps);

--- a/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -24,12 +24,13 @@ import Tiers from '../Tiers';
 import TaxDisclaimer from '../TaxDisclaimer';
 import StockInfo from '../StockInfo';
 import * as styles from './style';
+import connect from './connector';
 
 /**
  * @param {Object} props The component props.
  * @returns {JSX}
  */
-const ProductInfo = ({ productId, options }) => (
+const ProductInfo = ({ productId, options, showAvailablity }) => (
   <Fragment>
     <Portal name={PRODUCT_INFO_BEFORE} />
     <Portal name={PRODUCT_INFO}>
@@ -55,9 +56,11 @@ const ProductInfo = ({ productId, options }) => (
             <div className={styles.productInfo}>
               {/* This feature is currently in BETA testing.
                 It should only be used for approved BETA Client Projects */}
-              <EffectivityDates productId={productId}>
-                <Availability productId={productId} />
-              </EffectivityDates>
+              {showAvailablity && (
+                <EffectivityDates productId={productId}>
+                  <Availability productId={productId} />
+                </EffectivityDates>
+              )}
             </div>
             <div className={styles.productInfo}>
               <StockInfo productId={productId} />
@@ -90,6 +93,7 @@ const ProductInfo = ({ productId, options }) => (
 ProductInfo.propTypes = {
   options: PropTypes.shape().isRequired,
   productId: PropTypes.string.isRequired,
+  showAvailablity: PropTypes.bool.isRequired,
 };
 
-export default memo(ProductInfo);
+export default connect(memo(ProductInfo));


### PR DESCRIPTION
# Description
When a product has fulfillment methods assigned, we show the availability of the (direct ship) product within the FulfillmentSelector. To avoid confusion caused by two availabilities, the component from the ProductInfo within the ProductHeader is now hidden in those situations.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
