### PR TITLE
Added disabled state for add to cart button when ROPE products are not orderable

### DIFF
--- a/libraries/engage/locations/components/FulfillmentSelector/FulfillmentSelector.connector.js
+++ b/libraries/engage/locations/components/FulfillmentSelector/FulfillmentSelector.connector.js
@@ -5,6 +5,7 @@ import {
   makeIsFulfillmentSelectorDisabled,
   makeGetUserLocation,
   makeGetProductLocation,
+  makeGetUserLocationFulfillmentMethod,
 } from '../../selectors';
 import { storeFulfillmentMethod } from '../../action-creators';
 import { type OwnProps, type StateProps, type DispatchProps } from './FulfillmentSelector.types';
@@ -18,26 +19,20 @@ function makeMapStateToProps() {
   const getUserLocation = makeGetUserLocation();
   const getFulfillmentMethods = makeGetFulfillmentMethods();
   const isFulfillmentSelectorDisabled = makeIsFulfillmentSelectorDisabled();
-  const getProductLocation = makeGetProductLocation();
+  const getProductLocation = makeGetProductLocation(true);
+  const getUserLocationFulfillmentMethod = makeGetUserLocationFulfillmentMethod();
 
   /**
    * @param {Object} state The application state.
    * @param {Object} props The component props.
    * @returns {Object}
    */
-  return (state, props) => {
-    const { code: locationId } = getUserLocation(state);
-    const productLocation = getProductLocation(state, {
-      ...props,
-      locationId,
-    });
-
-    return {
-      fulfillmentMethods: getFulfillmentMethods(state, props),
-      location: productLocation || getUserLocation(state),
-      disabled: isFulfillmentSelectorDisabled(state, props),
-    };
-  };
+  return (state, props) => ({
+    fulfillmentMethods: getFulfillmentMethods(state, props),
+    userFulfillmentMethod: getUserLocationFulfillmentMethod(state, props),
+    location: getProductLocation(state, props) || getUserLocation(state),
+    disabled: isFulfillmentSelectorDisabled(state, props),
+  });
 }
 
 const mapDispatchToProps = {

--- a/libraries/engage/locations/components/FulfillmentSelector/FulfillmentSelector.jsx
+++ b/libraries/engage/locations/components/FulfillmentSelector/FulfillmentSelector.jsx
@@ -36,11 +36,16 @@ export const FulfillmentSelector = (props: Props) => {
     conditioner,
     disabled,
     storeFulfillmentMethod,
+    userFulfillmentMethod,
   } = props;
   const directShip = 'product.fulfillment_selector.direct_ship';
   const pickUp = 'product.fulfillment_selector.pick_up_in_store';
 
-  const [selection, setSelection] = useState(location.productInventory ? pickUp : directShip);
+  const [selection, setSelection] = useState(
+    userFulfillmentMethod === PRODUCT_FULFILLMENT_METHOD_IN_STORE_PICKUP
+      ? pickUp
+      : directShip
+  );
   const [selectedLocation, setSelectedLocation] = useState(null);
   const [isOpen, setIsOpen] = useState(false);
 

--- a/libraries/engage/locations/components/FulfillmentSelector/FulfillmentSelector.types.js
+++ b/libraries/engage/locations/components/FulfillmentSelector/FulfillmentSelector.types.js
@@ -10,6 +10,7 @@ export type StateProps = {
   fulfillmentMethods?: string[] | null;
   disabled?: boolean;
   location?: Location | null;
+  userFulfillmentMethod: string | null;
 }
 
 export type DispatchProps = {

--- a/libraries/engage/locations/components/FulfillmentSelector/FulfillmentSelectorAddToCart.connector.js
+++ b/libraries/engage/locations/components/FulfillmentSelector/FulfillmentSelectorAddToCart.connector.js
@@ -1,29 +1,22 @@
 import { connect } from 'react-redux';
 import { makeGetFulfillmentPaths } from '@shopgate/engage/core/config';
-import { makeGetUserLocation } from '../../selectors';
-import { PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP } from '../../constants';
+import { makeGetUserLocationFulfillmentMethod } from '../../selectors';
 
 /**
  * @return {Function}
  */
 function makeMapStateToProps() {
   const getFulfillmentPaths = makeGetFulfillmentPaths();
-  const getUserLocation = makeGetUserLocation();
+  const getUserLocationFulfillmentMethod = makeGetUserLocationFulfillmentMethod();
 
   /**
    * @param {Object} state The application state.
    * @returns {Object}
    */
-  return (state) => {
-    const {
-      fulfillmentMethod = PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP,
-    } = getUserLocation(state) || {};
-
-    return {
-      fulfillmentPaths: getFulfillmentPaths(state),
-      fulfillmentMethod,
-    };
-  };
+  return state => ({
+    fulfillmentPaths: getFulfillmentPaths(state),
+    userFulfillmentMethod: getUserLocationFulfillmentMethod(state),
+  });
 }
 
 export default connect(makeMapStateToProps);

--- a/libraries/engage/locations/components/FulfillmentSelector/FulfillmentSelectorAddToCart.jsx
+++ b/libraries/engage/locations/components/FulfillmentSelector/FulfillmentSelectorAddToCart.jsx
@@ -27,41 +27,43 @@ function promisifiedFulfillmentPathSelector() {
  * @param {Object} location The selected location.
  * @param {Conditioner} conditioner conditioner.
  * @param {string[]} fulfillmentPaths fulfillmentPaths
- * @param {string} fulfillmentMethod fulfillmentMethod
+ * @param {string} userFulfillmentMethod The currenly selected fulfillment method of the user.
  * @returns {JSX}
  */
 const FulfillmentSelectorAddToCart = ({
-  location, conditioner, fulfillmentPaths, fulfillmentMethod,
+  location, conditioner, fulfillmentPaths, userFulfillmentMethod,
 }) => {
   // Add to cart effect to validate inventory
   useEffect(() => {
     // Add most late conditioner
     conditioner.addConditioner('fulfillment-inventory', async () => {
       // Allow direct ship item
-      if (fulfillmentMethod === PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP) {
+      if (userFulfillmentMethod === PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP) {
         return true;
+      }
+
+      if (!isProductAvailable(location)) {
+        return false;
       }
 
       if (fulfillmentPaths.length > 1) {
         const selectedPath = await promisifiedFulfillmentPathSelector();
+
+        if (selectedPath === FULFILLMENT_PATH_MULTI_LINE_RESERVE) {
+          return true;
+        }
 
         if (selectedPath === FULFILLMENT_PATH_QUICK_RESERVE) {
           FulfillmentSheet.open(null, 1, selectedPath);
           return false;
         }
 
-        if (selectedPath === FULFILLMENT_PATH_MULTI_LINE_RESERVE) {
-          return isProductAvailable(location);
-        }
-
         return false;
       }
 
       if (!fulfillmentPaths.includes(FULFILLMENT_PATH_MULTI_LINE_RESERVE)) {
-        if (isProductAvailable(location)) {
-          // Open reservation form. Stop adding to a cart
-          FulfillmentSheet.open(null, 1);
-        }
+        // Open reservation form. Stop adding to a cart
+        FulfillmentSheet.open(null, 1);
         return false;
       }
 
@@ -69,20 +71,20 @@ const FulfillmentSelectorAddToCart = ({
     }, 100);
 
     return () => conditioner.removeConditioner('fulfillment-inventory');
-  }, [conditioner, location, fulfillmentPaths, fulfillmentMethod]);
+  }, [conditioner, location, fulfillmentPaths, userFulfillmentMethod]);
 
   return null;
 };
 
 FulfillmentSelectorAddToCart.propTypes = {
   conditioner: PropTypes.shape().isRequired,
-  fulfillmentMethod: PropTypes.string,
   fulfillmentPaths: PropTypes.arrayOf(PropTypes.string),
   location: PropTypes.shape(),
+  userFulfillmentMethod: PropTypes.string,
 };
 
 FulfillmentSelectorAddToCart.defaultProps = {
-  fulfillmentMethod: PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP,
+  userFulfillmentMethod: PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP,
   fulfillmentPaths: [],
   location: null,
 };

--- a/libraries/engage/locations/index.js
+++ b/libraries/engage/locations/index.js
@@ -36,6 +36,7 @@ export {
   makeGetUserLocation,
   makeGetLocation,
   makeGetProductLocation,
+  makeIsRopeProductOrderable,
 } from './selectors';
 
 // STREAMS

--- a/libraries/engage/locations/locations.types.js
+++ b/libraries/engage/locations/locations.types.js
@@ -92,6 +92,11 @@ export type UserLocationState = {
   | typeof PRODUCT_FULFILLMENT_METHOD_IN_STORE_PICKUP;
 }
 
+export type UserLocationFulfillmentMethod = typeof PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP
+  | typeof PRODUCT_FULFILLMENT_METHOD_IN_STORE_PICKUP;
+
+export type UserLocationLocationCode = string | null;
+
 export type UserFormInputState = {
   [string]: string | null;
 }

--- a/libraries/engage/locations/selectors/__tests__/index.spec.js
+++ b/libraries/engage/locations/selectors/__tests__/index.spec.js
@@ -1,15 +1,36 @@
 /* eslint-disable extra-rules/no-single-line-objects */
 import cloneDeep from 'lodash/cloneDeep';
 import set from 'lodash/set';
-import { makeGetLocation, makeGetProductLocation } from '../index';
+import {
+  PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP,
+  PRODUCT_FULFILLMENT_METHOD_IN_STORE_PICKUP,
+} from '../../constants';
+import {
+  makeGetUserLocation,
+  makeGetUserLocationFulfillmentMethod,
+  makeGetUserLocationCode,
+  makeGetLocation,
+  makeGetProductLocation,
+  makeIsRopeProductOrderable,
+} from '../index';
+import { isProductAvailable } from '../../helpers';
 
 jest.mock('@shopgate/engage/product', () => ({
   getProduct: jest.fn(),
 }));
 
+jest.mock('../../helpers', () => ({
+  isProductAvailable: jest.fn().mockReturnValue(true),
+}));
+
 describe('engage > locations > selectors', () => {
   const mockedState = {
     locations: {
+      userLocation: {
+        code: 'code 1',
+        name: 'ACME Store',
+        fulfillmentMethod: PRODUCT_FULFILLMENT_METHOD_IN_STORE_PICKUP,
+      },
       locationsById: {
         code1: {
           code: 'code1',
@@ -22,11 +43,70 @@ describe('engage > locations > selectors', () => {
           isFetching: false,
           expires: 5,
         },
+        sg2: {
+          locations: [{ code: 'code 1' }],
+          isFetching: false,
+          expires: 5,
+        },
       },
     },
   };
 
-  describe('getLocation()', () => {
+  describe('makeGetUserLocation()', () => {
+    let getUserLocation;
+
+    beforeEach(() => {
+      getUserLocation = makeGetUserLocation();
+    });
+
+    it('should return null when the locations state is empty', () => {
+      expect(getUserLocation({ locations: {} })).toBeNull();
+    });
+
+    it('should return null when the userLocation state is empty', () => {
+      expect(getUserLocation({ locations: { userLocation: null } })).toBeNull();
+    });
+
+    it('should return the userLocation state', () => {
+      expect(getUserLocation(mockedState)).toEqual(mockedState.locations.userLocation);
+    });
+  });
+
+  describe('makeGetUserLocationFulfillmentMethod()', () => {
+    let getUserLocationFulfillmentMethod;
+
+    beforeEach(() => {
+      getUserLocationFulfillmentMethod = makeGetUserLocationFulfillmentMethod();
+    });
+
+    it('should return "direct ship" when the state is empty', () => {
+      expect(getUserLocationFulfillmentMethod({})).toEqual(PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP);
+    });
+
+    it('should return "pickup in store" when it is set within the state', () => {
+      expect(getUserLocationFulfillmentMethod(mockedState))
+        .toEqual(PRODUCT_FULFILLMENT_METHOD_IN_STORE_PICKUP);
+    });
+  });
+
+  describe('makeGetUserLocationCode()', () => {
+    let getUserLocationCodeMethod;
+
+    beforeEach(() => {
+      getUserLocationCodeMethod = makeGetUserLocationCode();
+    });
+
+    it('should return null when the state is empty', () => {
+      expect(getUserLocationCodeMethod({})).toBeNull();
+    });
+
+    it('should return the user location code', () => {
+      expect(getUserLocationCodeMethod(mockedState))
+        .toEqual(mockedState.locations.userLocation.code);
+    });
+  });
+
+  describe('makeGetLocation()', () => {
     let getLocation;
 
     beforeEach(() => {
@@ -43,34 +123,113 @@ describe('engage > locations > selectors', () => {
       });
     });
   });
+
   describe('makeGetProductLocation()', () => {
     let getProductLocation;
 
-    beforeEach(() => {
-      getProductLocation = makeGetProductLocation();
-    });
+    describe('location code from props', () => {
+      beforeEach(() => {
+        getProductLocation = makeGetProductLocation();
+      });
 
-    it('should return null', () => {
-      expect(getProductLocation(mockedState, { locationId: 'SG1', productId: 'sg2' })).toBeNull();
-    });
+      it('should return null', () => {
+        expect(getProductLocation(mockedState, { locationId: 'SG1', productId: 'sg2' })).toBeNull();
+      });
 
-    it('should return location', () => {
-      expect(getProductLocation(mockedState, { locationId: 'SG1', productId: 'sg1' })).toEqual({
-        ...mockedState.locations.locationsByProductId.sg1.locations[0],
+      it('should return location', () => {
+        expect(getProductLocation(mockedState, { locationId: 'SG1', productId: 'sg1' })).toEqual({
+          ...mockedState.locations.locationsByProductId.sg1.locations[0],
+        });
+      });
+
+      it('should return null when fetching and location data is not available yet', () => {
+        const localState = cloneDeep(mockedState);
+        set(localState, 'locations.locationsByProductId.sg1.locations', undefined);
+        expect(getProductLocation(localState, { locationId: 'SG1', productId: 'sg1' })).toBeNull();
+      });
+
+      it('should return locations when locations are currently fetching', () => {
+        const localState = cloneDeep(mockedState);
+        set(localState, 'locations.locationsByProductId.sg1.isFetching', true);
+        expect(getProductLocation(localState, { locationId: 'SG1', productId: 'sg1' })).toEqual({
+          ...mockedState.locations.locationsByProductId.sg1.locations[0],
+        });
       });
     });
 
-    it('should return null when fetching and location data is not available yet', () => {
-      const localState = cloneDeep(mockedState);
-      set(localState, 'locations.locationsByProductId.sg1.locations', undefined);
-      expect(getProductLocation(localState, { locationId: 'SG1', productId: 'sg1' })).toBeNull();
+    describe('location code from user location', () => {
+      beforeEach(() => {
+        getProductLocation = makeGetProductLocation(true);
+      });
+
+      it('should return the product location for the userLocation code', () => {
+        expect(getProductLocation(mockedState, { locationId: 'SG1', productId: 'sg2' })).toEqual(
+          mockedState.locations.locationsByProductId.sg2.locations[0]
+        );
+      });
+
+      it('should return null when the code within the userLocation state is empty', () => {
+        const localState = cloneDeep(mockedState);
+        set(localState, 'locations.userLocation.code', null);
+        expect(getProductLocation(localState, { locationId: 'SG1', productId: 'sg1' })).toBeNull();
+      });
+    });
+  });
+
+  describe('makeIsRopeProductOrderable()', () => {
+    let isRopeProductOrderable;
+
+    describe('location code from props', () => {
+      beforeEach(() => {
+        isRopeProductOrderable = makeIsRopeProductOrderable();
+      });
+
+      it('should return true when "direct ship" is selected as user fulfillment method', () => {
+        const localState = cloneDeep(mockedState);
+        set(localState, 'locations.userLocation.fulfillmentMethod', PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP);
+        expect(isRopeProductOrderable(localState, { locationId: 'SG1', productId: 'sg1' })).toBe(true);
+      });
+
+      it('should return false when no maching location was found at the product', () => {
+        const localState = cloneDeep(mockedState);
+        set(localState, 'locations.locationsByProductId.sg1.locations', []);
+        expect(isRopeProductOrderable(localState, { locationId: 'SG1', productId: 'sg1' })).toBe(false);
+      });
+
+      it('should return false when the product is not available at the location', () => {
+        isProductAvailable.mockReturnValueOnce(false);
+        expect(isRopeProductOrderable(mockedState, { locationId: 'SG1', productId: 'sg1' })).toBe(false);
+      });
+
+      it('should return true when the product is available at the location', () => {
+        expect(isRopeProductOrderable(mockedState, { locationId: 'SG1', productId: 'sg1' })).toBe(true);
+      });
     });
 
-    it('should return locations when locations are currently fetching', () => {
-      const localState = cloneDeep(mockedState);
-      set(localState, 'locations.locationsByProductId.sg1.isFetching', true);
-      expect(getProductLocation(localState, { locationId: 'SG1', productId: 'sg1' })).toEqual({
-        ...mockedState.locations.locationsByProductId.sg1.locations[0],
+    describe('location code from user location', () => {
+      beforeEach(() => {
+        isRopeProductOrderable = makeIsRopeProductOrderable(true);
+      });
+
+      it('should return true when "direct ship" is selected as user fulfillment method', () => {
+        const localState = cloneDeep(mockedState);
+        set(localState, 'locations.userLocation.fulfillmentMethod', PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP);
+        expect(isRopeProductOrderable(localState, { locationId: 'SG2', productId: 'sg2' })).toBe(true);
+      });
+
+      it('should return false when no maching location was found at the product', () => {
+        const localState = cloneDeep(mockedState);
+        set(localState, 'locations.locationsByProductId.sg2.locations', []);
+        expect(isRopeProductOrderable(localState, { locationId: 'SG2', productId: 'sg2' })).toBe(false);
+      });
+
+      it('should return false when the product is not available at the location', () => {
+        isProductAvailable.mockReturnValueOnce(false);
+        expect(isRopeProductOrderable(mockedState, { locationId: 'SG2', productId: 'sg2' })).toBe(false);
+      });
+
+      it('should return true when the product is available at the location', () => {
+        expect(isRopeProductOrderable(mockedState, { locationId: 'SG2', productId: 'sg2' })).toBe(true);
       });
     });
   });

--- a/libraries/engage/locations/selectors/index.js
+++ b/libraries/engage/locations/selectors/index.js
@@ -1,6 +1,8 @@
 // @flow
 import { createSelector, type Selector } from 'reselect';
 import { getProduct } from '@shopgate/engage/product';
+import { isProductAvailable } from '../helpers';
+import { PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP } from '../constants';
 import { type State } from '../../types';
 import {
   type LocationsState,
@@ -9,6 +11,8 @@ import {
   type Location,
   type UserLocationState,
   type UserFormInputState,
+  type UserLocationFulfillmentMethod,
+  type UserLocationLocationCode,
 } from '../locations.types';
 
 /**
@@ -55,6 +59,56 @@ export function makeGetLocationsState(): Selector<State, LocationsByIdState> {
   return createSelector(
     getLocationsState,
     state => state.locationsById || {}
+  );
+}
+
+/**
+ * Creates the selector that retrieves the user location state.
+ * @returns {Function}
+ */
+export function makeGetUserLocation(): Selector<State, UserLocationState> {
+  return createSelector(
+    getLocationsState,
+    (locations) => {
+      if (!locations || !locations.userLocation) {
+        return null;
+      }
+
+      return locations.userLocation;
+    }
+  );
+}
+
+/**
+ * Creates the selector that retrieves the fulfillment method from the user location state.
+ * @returns {Function}
+ */
+export function makeGetUserLocationFulfillmentMethod(): Selector<
+  State,
+  UserLocationFulfillmentMethod
+  > {
+  const getUserLocation = makeGetUserLocation();
+  return createSelector(
+    getUserLocation,
+    (userLocation) => {
+      const { fulfillmentMethod = PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP } = userLocation || {};
+      return fulfillmentMethod;
+    }
+  );
+}
+
+/**
+ * Creates the selector that retrieves the location code from the user location state.
+ * @returns {Function}
+ */
+export function makeGetUserLocationCode(): Selector<State, UserLocationLocationCode> {
+  const getUserLocation = makeGetUserLocation();
+  return createSelector(
+    getUserLocation,
+    (userLocation) => {
+      const { code = null } = userLocation || {};
+      return code;
+    }
   );
 }
 
@@ -131,10 +185,16 @@ export function makeGetProductLocations(): Selector<State, Location[] | null> {
 
 /**
  * Creates the selector that returns the single product location.
+ * @param {boolean} useUserLocation Whether the location code is taken from the userLocation state.
  * @returns {Function}
  */
-export function makeGetProductLocation(): Selector<State, Location | null> {
+export function makeGetProductLocation(
+  useUserLocation: boolean = false
+): Selector<State, Location | null> {
   const getProductLocationsState = makeGetProductLocationsState();
+  const getLocationCodeSelector = useUserLocation
+    ? makeGetUserLocationCode()
+    : getLocationId;
 
   /**
    * Retrieves the locations for a specific product.
@@ -145,7 +205,7 @@ export function makeGetProductLocation(): Selector<State, Location | null> {
    */
   return createSelector(
     getProductLocationsState,
-    getLocationId,
+    getLocationCodeSelector,
     getProductId,
     (locationsState, locationId, productId) => {
       if (
@@ -157,7 +217,7 @@ export function makeGetProductLocation(): Selector<State, Location | null> {
         return null;
       }
 
-      return locationsState[productId].locations.find(l => l.code === locationId);
+      return locationsState[productId].locations.find(l => l.code === locationId) || null;
     }
   );
 }
@@ -244,23 +304,6 @@ export function makeIsFulfillmentSelectorDisabled(): Selector<State, boolean> {
 }
 
 /**
- * Creates the selector that retrieves the user location state.
- * @returns {Function}
- */
-export function makeGetUserLocation(): Selector<State, UserLocationState> {
-  return createSelector(
-    getLocationsState,
-    (locations) => {
-      if (!locations || !locations.userLocation) {
-        return null;
-      }
-
-      return locations.userLocation;
-    }
-  );
-}
-
-/**
  * Creates a selector that retrieves the user's reserve form input.
  * @returns {Function}
  */
@@ -273,6 +316,36 @@ export function makeGetUserFormInput(): Selector<State, UserFormInputState> {
       }
 
       return locations.userFormInput;
+    }
+  );
+}
+
+/**
+ * Creates a selector
+ * @param {boolean} useUserLocation Whether the location code is taken from the userLocation state.
+ * @returns {Function}
+ */
+export function makeIsRopeProductOrderable(
+  useUserLocation: boolean = false
+): Selector<State, boolean> {
+  const getUserLocationFulfillmentMethod = makeGetUserLocationFulfillmentMethod();
+  const getProductLocation = makeGetProductLocation(useUserLocation);
+
+  return createSelector(
+    getUserLocationFulfillmentMethod,
+    getProductLocation,
+    (userLocationFulfillmentMethod, productLocation) => {
+      if (
+        userLocationFulfillmentMethod === PRODUCT_FULFILLMENT_METHOD_DIRECT_SHIP
+      ) {
+        return true;
+      }
+
+      if (productLocation === null) {
+        return false;
+      }
+
+      return isProductAvailable(productLocation);
     }
   );
 }

--- a/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/components/CartButton/connector.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/components/CartButton/connector.js
@@ -30,7 +30,7 @@ function makeMapStateToProps() {
      * 2. Parent product can be not orderable but having orderable variants
      * 3. A ROPE fulfillment method is selected and the product is orderable at the location
      */
-    disabled: (!isProductOrderable(state, props) && !hasProductVariants(state, props)) ||
+    disabled: (!isProductOrderable(state, props) && !hasProductVariants(state, props)) &&
       !isRopeProductOrderable(state, props),
     loading: isProductPageLoading(state, props),
     userLocation: getUserLocation(state),

--- a/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/components/CartButton/connector.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/components/CartButton/connector.js
@@ -4,7 +4,11 @@ import {
   isProductOrderable,
 } from '@shopgate/pwa-common-commerce/product/selectors/product';
 import { isProductPageLoading } from '@shopgate/pwa-common-commerce/product/selectors/page';
-import { makeGetUserLocation, makeIsFulfillmentSelectorDisabled } from '@shopgate/engage/locations';
+import {
+  makeGetUserLocation,
+  makeIsFulfillmentSelectorDisabled,
+  makeIsRopeProductOrderable,
+} from '@shopgate/engage/locations';
 import { addProductToCart as addToCart } from './actions';
 
 /**
@@ -13,6 +17,7 @@ import { addProductToCart as addToCart } from './actions';
 function makeMapStateToProps() {
   const getUserLocation = makeGetUserLocation();
   const isFulfillmentSelectorDisabled = makeIsFulfillmentSelectorDisabled();
+  const isRopeProductOrderable = makeIsRopeProductOrderable(true);
 
   /**
    * @param {Object} state The current application state.
@@ -23,8 +28,10 @@ function makeMapStateToProps() {
     /**
      * 1. Product has no variants and not orderable
      * 2. Parent product can be not orderable but having orderable variants
+     * 3. A ROPE fulfillment method is selected and the product is orderable at the location
      */
-    disabled: !isProductOrderable(state, props) && !hasProductVariants(state, props),
+    disabled: (!isProductOrderable(state, props) && !hasProductVariants(state, props)) ||
+      !isRopeProductOrderable(state, props),
     loading: isProductPageLoading(state, props),
     userLocation: getUserLocation(state),
     hasFulfillmentMethods: !isFulfillmentSelectorDisabled(state, props),

--- a/themes/theme-ios11/pages/Product/components/AddToCartBar/connector.js
+++ b/themes/theme-ios11/pages/Product/components/AddToCartBar/connector.js
@@ -30,7 +30,7 @@ function makeMapStateToProps() {
      * 2. Parent product can be not orderable but having orderable variants
      * 3. A ROPE fulfillment method is selected and the product is orderable at the location
      */
-    disabled: (!isProductOrderable(state, props) && !hasProductVariants(state, props)) ||
+    disabled: (!isProductOrderable(state, props) && !hasProductVariants(state, props)) &&
       !isRopeProductOrderable(state, props),
     loading: isProductPageLoading(state, props),
     userLocation: getUserLocation(state),

--- a/themes/theme-ios11/pages/Product/components/AddToCartBar/connector.js
+++ b/themes/theme-ios11/pages/Product/components/AddToCartBar/connector.js
@@ -4,7 +4,11 @@ import {
   hasProductVariants,
 } from '@shopgate/pwa-common-commerce/product/selectors/product';
 import { isProductPageLoading } from '@shopgate/pwa-common-commerce/product/selectors/page';
-import { makeGetUserLocation, makeIsFulfillmentSelectorDisabled } from '@shopgate/engage/locations';
+import {
+  makeGetUserLocation,
+  makeIsFulfillmentSelectorDisabled,
+  makeIsRopeProductOrderable,
+} from '@shopgate/engage/locations';
 import { addProductToCart as addToCart } from './actions';
 
 /**
@@ -13,6 +17,7 @@ import { addProductToCart as addToCart } from './actions';
 function makeMapStateToProps() {
   const getUserLocation = makeGetUserLocation();
   const isFulfillmentSelectorDisabled = makeIsFulfillmentSelectorDisabled();
+  const isRopeProductOrderable = makeIsRopeProductOrderable(true);
 
   /**
    * @param {Object} state The current application state.
@@ -23,8 +28,10 @@ function makeMapStateToProps() {
     /**
      * 1. Product has no variants and not orderable
      * 2. Parent product can be not orderable but having orderable variants
+     * 3. A ROPE fulfillment method is selected and the product is orderable at the location
      */
-    disabled: !isProductOrderable(state, props) && !hasProductVariants(state, props),
+    disabled: (!isProductOrderable(state, props) && !hasProductVariants(state, props)) ||
+      !isRopeProductOrderable(state, props),
     loading: isProductPageLoading(state, props),
     userLocation: getUserLocation(state),
     hasFulfillmentMethods: !isFulfillmentSelectorDisabled(state, props),


### PR DESCRIPTION
# Description
This ticket introduces a disabled state for add to cart buttons when a ROPE fulfillment methods is selected, but the desired product is not orderable. Till now the buttons just didn't work in those situations, but did not show any visual feedback.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
