### PR TITLE
Cart reservation groups now show the store name instead of its address

### DIFF
--- a/libraries/engage/cart/components/CartItems/CartItemGroupReservation.jsx
+++ b/libraries/engage/cart/components/CartItems/CartItemGroupReservation.jsx
@@ -28,7 +28,7 @@ const FulfillmentLocation = ({ location }) => (
               <div className={title}>
                 {i18n.text('locations.method.ropis')}
               </div>
-              {`${location.address.street}, ${location.address.city}`}
+              {location.name}
             </div>
           </div>
         )}


### PR DESCRIPTION
# Description
This ticket is about to change the heading of cart reservation groups. From now on the store name is shown instead of its address.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
