### PR TITLE
Removed duplicate headline in reserve sheet

### DIFF
--- a/libraries/engage/locations/components/ReserveForm/ReserveForm.jsx
+++ b/libraries/engage/locations/components/ReserveForm/ReserveForm.jsx
@@ -72,9 +72,6 @@ function ReserveForm() {
 
   return (
     <form onSubmit={handleSubmit} className={form}>
-      <p className={formHeading}>
-        {i18n.text('locations.create_order')}
-      </p>
       <fieldset className={fieldset}>
         <TextField
           name="firstName"

--- a/themes/theme-gmd/locale/de-DE.json
+++ b/themes/theme-gmd/locale/de-DE.json
@@ -128,7 +128,6 @@
     "fri": "Freitag",
     "sat": "Samstag",
     "sun": "Sonntag",
-    "create_order": "Reservierungsauftrag aufgeben",
     "place_reservation": "Reservierung absenden",
     "firstName": "Vorname",
     "lastName": "Nachname",

--- a/themes/theme-gmd/locale/en-US.json
+++ b/themes/theme-gmd/locale/en-US.json
@@ -128,7 +128,6 @@
     "fri": "Friday",
     "sat": "Saturday",
     "sun": "Sunday",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",

--- a/themes/theme-gmd/locale/es-ES.json
+++ b/themes/theme-gmd/locale/es-ES.json
@@ -127,7 +127,6 @@
     "fri": "Viernes",
     "sat": "Sábado",
     "sun": "Domingo",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",

--- a/themes/theme-gmd/locale/fr-FR.json
+++ b/themes/theme-gmd/locale/fr-FR.json
@@ -127,7 +127,6 @@
     "fri": "Vendredi",
     "sat": "Samedi",
     "sun": "Dimanche",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",

--- a/themes/theme-gmd/locale/it-IT.json
+++ b/themes/theme-gmd/locale/it-IT.json
@@ -127,7 +127,6 @@
     "fri": "Venerdì",
     "sat": "Sabato",
     "sun": "Domenica",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",

--- a/themes/theme-gmd/locale/nl-NL.json
+++ b/themes/theme-gmd/locale/nl-NL.json
@@ -127,7 +127,6 @@
     "fri": "Vrijdag",
     "sat": "Zaterdag",
     "sun": "Zondag",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",

--- a/themes/theme-gmd/locale/pt-PT.json
+++ b/themes/theme-gmd/locale/pt-PT.json
@@ -127,7 +127,6 @@
     "fri": "Sexta-feira",
     "sat": "Sábado",
     "sun": "Domingo",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",

--- a/themes/theme-ios11/locale/de-DE.json
+++ b/themes/theme-ios11/locale/de-DE.json
@@ -131,7 +131,6 @@
     "fri": "Freitag",
     "sat": "Samstag",
     "sun": "Sonntag",
-    "create_order": "Reservierungsauftrag aufgeben",
     "place_reservation": "Reservierung absenden",
     "firstName": "Vorname",
     "lastName": "Nachname",

--- a/themes/theme-ios11/locale/en-US.json
+++ b/themes/theme-ios11/locale/en-US.json
@@ -131,7 +131,6 @@
     "fri": "Friday",
     "sat": "Saturday",
     "sun": "Sunday",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",

--- a/themes/theme-ios11/locale/es-ES.json
+++ b/themes/theme-ios11/locale/es-ES.json
@@ -130,7 +130,6 @@
     "fri": "Viernes",
     "sat": "Sábado",
     "sun": "Domingo",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",

--- a/themes/theme-ios11/locale/fr-FR.json
+++ b/themes/theme-ios11/locale/fr-FR.json
@@ -130,7 +130,6 @@
     "fri": "Vendredi",
     "sat": "Samedi",
     "sun": "Dimanche",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",

--- a/themes/theme-ios11/locale/it-IT.json
+++ b/themes/theme-ios11/locale/it-IT.json
@@ -130,7 +130,6 @@
     "fri": "Venerdì",
     "sat": "Sabato",
     "sun": "Domenica",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",

--- a/themes/theme-ios11/locale/nl-NL.json
+++ b/themes/theme-ios11/locale/nl-NL.json
@@ -130,7 +130,6 @@
     "fri": "Vrijdag",
     "sat": "Zaterdag",
     "sun": "Zondag",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",

--- a/themes/theme-ios11/locale/pt-PT.json
+++ b/themes/theme-ios11/locale/pt-PT.json
@@ -124,7 +124,6 @@
     "fri": "Sexta-feira",
     "sat": "Sábado",
     "sun": "Domingo",
-    "create_order": "Create reservation order",
     "place_reservation": "Submit Reservation",
     "firstName": "First Name",
     "lastName": "Last Name",


### PR DESCRIPTION
# Description

Removed the duplicated headline in the reservation sheet as it already contained a headline from the sheet header.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [x] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
