### PR TITLE
Make iOS tabbar labels visibility configurable

### DIFF
--- a/libraries/engage/core/hooks/useWidgetSettings.js
+++ b/libraries/engage/core/hooks/useWidgetSettings.js
@@ -10,6 +10,6 @@ import { getWidgetSettings } from '../config/getWidgetSettings';
  * @returns {Object}
  */
 export function useWidgetSettings(widgetId, index = 0) {
-  const { pattern: pagePattern } = useRoute();
+  const { pattern: pagePattern } = useRoute() || {};
   return getWidgetSettings(pagePattern, widgetId, index);
 }

--- a/themes/theme-ios11/components/TabBar/components/TabBarAction/index.jsx
+++ b/themes/theme-ios11/components/TabBar/components/TabBarAction/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { useWidgetSettings } from '@shopgate/engage/core';
 import Button from '@shopgate/pwa-common/components/Button';
 import I18n from '@shopgate/pwa-common/components/I18n';
 import style from './style';
@@ -11,6 +12,7 @@ import style from './style';
  * @returns {JSX}
  */
 const TabBarAction = (props) => {
+  const { showLabels = true } = useWidgetSettings('@shopgate/engage/components/TabBar');
   const Icon = props.icon;
 
   const className = classNames(
@@ -31,7 +33,7 @@ const TabBarAction = (props) => {
     >
       {Icon}
       <div className={style.label} data-test-id={props.label}>
-        <I18n.Text string={props.label} />
+        {showLabels && <I18n.Text string={props.label} />}
       </div>
       {props.children}
     </Button>

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -198,7 +198,7 @@
       "destination": "frontend",
       "params": {
         "type": "json",
-        "label": "The theme configuration for Engage GMD theme."
+        "label": "The theme configuration for Engage IOS theme."
       },
       "default": {
         "settings": {
@@ -243,6 +243,9 @@
             "buttonCartBadgeShadow": "0 1px 1px rgba(0, 0, 0, 0.25)",
             "buttonTextColor": "$.colors.accent",
             "buttonTextColorDisabled": "$.colors.shade4"
+          },
+          "@shopgate/engage/components/TabBar": {
+            "showLabels": true
           },
           "@shopgate/engage/product/ProductGrid": {
             "columns": 2


### PR DESCRIPTION
# Description

Make iOS tabbar labels visibility configurable

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [X] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
