### PR TITLE
AddToCart button from ui-shared checks for success before show checkmark

### DIFF
--- a/libraries/ui-shared/AddToCartButton/index.jsx
+++ b/libraries/ui-shared/AddToCartButton/index.jsx
@@ -55,13 +55,17 @@ class AddToCartButton extends Component {
    * - Wait 900ms.
    * - Show cart icon again.
    */
-  handleClick = () => {
+  handleClick = async () => {
     // Ignore clicks when check mark or loading spinner is shown or the button is disabled.
     if (this.state.showCheckmark || this.props.isLoading || this.props.isDisabled) {
       return;
     }
 
-    this.props.onClick();
+    const success = await this.props.onClick();
+
+    if (success === false) {
+      return;
+    }
 
     this.setState({
       showCheckmark: true,

--- a/libraries/ui-shared/AddToCartButton/spec.jsx
+++ b/libraries/ui-shared/AddToCartButton/spec.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 import AddToCartButton from './index';
 
 describe('<AddToCartButton />', () => {
-  it('should render in loading state and should not be clickable', () => {
-    const spy = jest.fn(() => new Promise(resolve => resolve()));
+  it('should render in loading state and should not be clickable', async () => {
+    const spy = jest.fn().mockResolvedValue(true);
 
     const wrapper = mount(<AddToCartButton
       onClick={spy}
@@ -12,14 +13,17 @@ describe('<AddToCartButton />', () => {
       isOrderable
       isDisabled={false}
     />);
-    wrapper.find('button').prop('onClick')();
 
-    expect(wrapper).toMatchSnapshot();
+    await act(async () => {
+      wrapper.find('button').simulate('click');
+    });
+
     expect(spy).toHaveBeenCalledTimes(0);
+    expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render with checkmark icon and should not be clickable the second time', () => {
-    const spy = jest.fn(() => new Promise(resolve => resolve()));
+  it('should render with checkmark icon and should not be clickable the second time', async () => {
+    const spy = jest.fn().mockResolvedValue(true);
     const wrapper = mount(<AddToCartButton
       onClick={spy}
       isLoading={false}
@@ -27,27 +31,34 @@ describe('<AddToCartButton />', () => {
       isDisabled={false}
     />);
 
-    wrapper.find('button').prop('onClick')();
-    wrapper.update();
+    await act(async () => {
+      await wrapper.find('button').simulate('click');
+      wrapper.update();
+    });
 
-    wrapper.find('button').prop('onClick')();
-    wrapper.update();
+    await act(async () => {
+      wrapper.find('button').simulate('click');
+      wrapper.update();
+    });
 
-    expect(wrapper).toMatchSnapshot();
     expect(spy).toHaveBeenCalledTimes(1);
+    expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render with cart icon and should be clickable', () => {
-    const spy = jest.fn(() => new Promise(resolve => resolve()));
+  it('should render with cart icon and should be clickable', async () => {
+    const spy = jest.fn().mockResolvedValue(true);
     const wrapper = mount(<AddToCartButton
       onClick={spy}
       isLoading={false}
       isOrderable
       isDisabled={false}
     />);
-    wrapper.find('button').prop('onClick')();
 
-    expect(wrapper).toMatchSnapshot();
+    await act(async () => {
+      wrapper.find('button').simulate('click');
+    });
+
     expect(spy).toHaveBeenCalledTimes(1);
+    expect(wrapper).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
# Description

AddToCart button from ui-shared now checks for success return value from passed onClick before checkmark gets shown.

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.
