### PR TITLE
Improved auth routes system for initial page

### DIFF
--- a/libraries/commerce/favorites/selectors/index.js
+++ b/libraries/commerce/favorites/selectors/index.js
@@ -118,9 +118,15 @@ export const isInitialLoading = createSelector(
  */
 export const getFavoritesCount = createSelector(
   getFavoritesProducts,
-  products => Object
-    .values(products.byList)
-    .reduce((prev, list) => prev + list.ids.length, 0)
+  (products) => {
+    if (!products?.byList) {
+      return 0;
+    }
+
+    return Object
+      .values(products.byList)
+      .reduce((prev, list) => prev + list.ids.length, 0);
+  }
 );
 
 /**

--- a/libraries/commerce/scanner/subscriptions/index.spec.js
+++ b/libraries/commerce/scanner/subscriptions/index.spec.js
@@ -13,9 +13,6 @@ jest.mock('@shopgate/pwa-core/classes/Scanner', () => ({
   addListener: jest.fn(),
   start: jest.fn(),
 }));
-jest.mock('@shopgate/pwa-common/streams/app', () => ({
-  appDidStart$: jest.fn(),
-}));
 jest.mock('../action-creators/scannerFinished', () => jest.fn());
 jest.mock('../actions/handleBarCode');
 jest.mock('../actions/handleQrCode');

--- a/libraries/common/components/Router/connector.js
+++ b/libraries/common/components/Router/connector.js
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+import { isUserLoggedIn } from '../../selectors/user';
+
+/**
+ * @param {Object} state The current application state.
+ * @return {Object} The extended component props.
+ */
+const mapStateToProps = state => ({
+  isUserLoggedIn: isUserLoggedIn(state),
+});
+
+export default connect(mapStateToProps);

--- a/libraries/common/constants/user.js
+++ b/libraries/common/constants/user.js
@@ -1,1 +1,2 @@
 export const DEFAULT_LOGIN_STRATEGY = 'basic';
+export const EVENT_USER_INITIALIZED = 'EVENT_USER_INITIALIZED';

--- a/libraries/common/streams/user.js
+++ b/libraries/common/streams/user.js
@@ -8,6 +8,7 @@ import {
   RECEIVE_USER,
   ERROR_USER,
 } from '../constants/ActionTypes';
+import { appDidStart$ } from './app';
 import { main$ } from './main';
 
 /**
@@ -58,6 +59,14 @@ export const userDidUpdate$ = main$
     (action.type === SUCCESS_LOGOUT) ||
     (action.type === ERROR_USER)
   ));
+
+/**
+ * Gets triggered when we have a stable login state of the user. Since user data is persisted,
+ * some parts of the code might not rely on the redux states.
+ * @type {Observable}
+ */
+export const userDidInitialize$ = appDidStart$.switchMap(() =>
+  main$.filter(({ action }) => action.type === RECEIVE_USER || action.type === ERROR_USER)).first();
 
 /**
  * Gets triggered when we received the user data.

--- a/libraries/common/subscriptions/user.js
+++ b/libraries/common/subscriptions/user.js
@@ -11,11 +11,13 @@ import {
   userLoginResponse$,
   userDidLogin$,
   userDidLogout$,
+  userDidInitialize$,
   legacyConnectRegisterDidFail$,
 } from '../streams';
 import showModal from '../actions/modal/showModal';
 import { LOGIN_PATH } from '../constants/RoutePaths';
 import { LEGACY_URL_CONNECT_REGISTER } from '../constants/Registration';
+import { EVENT_USER_INITIALIZED } from '../constants/user';
 
 /**
  * User subscriptions.
@@ -26,6 +28,10 @@ export default function user(subscribe) {
    * Gets triggered when ever the user data need to be updated.
    */
   const userNeedsUpdate$ = appDidStart$.merge(userDidLogin$);
+
+  subscribe(userDidInitialize$, ({ events }) => {
+    events.emit(EVENT_USER_INITIALIZED);
+  });
 
   subscribe(userWillLogin$, () => {
     LoadingProvider.setLoading(LOGIN_PATH);

--- a/libraries/engage/cart/cart.selectors.js
+++ b/libraries/engage/cart/cart.selectors.js
@@ -3,7 +3,7 @@ import {
   hasProductVariants,
   isProductOrderable,
 } from '@shopgate/pwa-common-commerce/product/selectors/product';
-import { makeIsProductActive, makeIsBaseProductActive } from '@shopgate/engage/product';
+import { makeIsProductActive, makeIsBaseProductActive } from '@shopgate/engage/product/selectors/product';
 import {
   makeIsRopeProductOrderable,
   getPreferredLocation,

--- a/libraries/engage/locations/helpers/createOrder.js
+++ b/libraries/engage/locations/helpers/createOrder.js
@@ -6,8 +6,8 @@ import {
 import appConfig from '@shopgate/pwa-common/helpers/config';
 import {
   getCurrency, getCartItems, getSubTotal, getGrandTotal,
-} from '@shopgate/engage/cart';
-import { getProductDataById } from '@shopgate/engage/product';
+} from '@shopgate/pwa-common-commerce/cart/selectors';
+import { getProductDataById } from '@shopgate/engage/product/selectors/product';
 import {
   getPreferredLocation,
   getExternalCustomerNumberForOrder,

--- a/libraries/engage/product/components/ProductProperties/ProductProperties.jsx
+++ b/libraries/engage/product/components/ProductProperties/ProductProperties.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { PRODUCT_PROPERTIES } from '@shopgate/pwa-common-commerce/product/constants/Portals';
-import { SurroundPortals } from '../../../components';
+import SurroundPortals from '@shopgate/pwa-common/components/SurroundPortals';
 import Content from './Content';
 import connect from './connector';
 

--- a/libraries/tracking/subscriptions/checkout.spec.js
+++ b/libraries/tracking/subscriptions/checkout.spec.js
@@ -2,10 +2,6 @@ import getCart from '../selectors/cart';
 import * as helpers from '../helpers';
 import subscription from './checkout';
 
-jest.mock('@shopgate/pwa-common/streams/app', () => ({
-  appDidStart$: jest.fn(),
-}));
-
 jest.mock('../selectors/cart', () => state => state);
 
 jest.mock('@shopgate/pwa-core/commands/registerEvents', () => jest.fn());

--- a/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemDetails/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemDetails/__snapshots__/spec.jsx.snap
@@ -59,6 +59,12 @@ exports[`<ItemDetails /> should render with minimal props 1`] = `
     <EffectivityDates
       productId="1234"
     />
+    <Availability
+      className=""
+      showWhenAvailable={false}
+      state="ok"
+      text="product.available.not"
+    />
     <div
       className="css-193sdzn"
     >

--- a/themes/theme-gmd/components/Search/index.jsx
+++ b/themes/theme-gmd/components/Search/index.jsx
@@ -21,7 +21,11 @@ class Search extends Component {
     fetchSuggestions: PropTypes.func.isRequired,
     historyPush: PropTypes.func.isRequired,
     historyReplace: PropTypes.func.isRequired,
-    route: PropTypes.shape().isRequired,
+    route: PropTypes.shape(),
+  }
+
+  static defaultProps = {
+    route: null,
   }
 
   /**
@@ -76,7 +80,13 @@ class Search extends Component {
    * @param {boolean} visible The next visible state.
    */
   toggle = (visible = true) => {
-    const { route: { query } } = this.props;
+    const { route } = this.props;
+
+    if (!route) {
+      return;
+    }
+
+    const { query } = route;
 
     const wasVisible = this.state.visible;
 

--- a/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemDetails/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemDetails/__snapshots__/spec.jsx.snap
@@ -27,6 +27,12 @@ exports[`<ItemDetails /> should render with minimal props 1`] = `
   <EffectivityDates
     productId="1234"
   />
+  <Availability
+    className=""
+    showWhenAvailable={false}
+    state="ok"
+    text="product.available.not"
+  />
   <ItemPrice
     display={null}
     price={Object {}}

--- a/themes/theme-ios11/components/TabBar/selectors.js
+++ b/themes/theme-ios11/components/TabBar/selectors.js
@@ -31,6 +31,10 @@ const getTabBarState = state => state.ui.tabBar;
 export const getActiveTab = createSelector(
   getHistoryPathname,
   (pathname) => {
+    if (!pathname) {
+      return TAB_NONE;
+    }
+
     switch (true) {
       case pathname === INDEX_PATH:
         return TAB_HOME;

--- a/themes/theme-ios11/pages/More/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/pages/More/__snapshots__/index.spec.jsx.snap
@@ -722,6 +722,60 @@ exports[`<More /> should render as expected when the user is logged in 1`] = `
                           }
                         }
                       >
+                        <MoreMenuItem
+                          className={null}
+                          href="/account"
+                          label="navigation.manage"
+                          onClick={null}
+                          testId="accountButton"
+                        >
+                          <Connect(Link)
+                            className="css-1hj8a57"
+                            href="/account"
+                          >
+                            <Link
+                              aria-hidden={null}
+                              aria-label={null}
+                              className="css-1hj8a57"
+                              disabled={false}
+                              historyPush={[Function]}
+                              historyReplace={[Function]}
+                              href="/account"
+                              replace={false}
+                              role="link"
+                              state={Object {}}
+                              tabIndex={null}
+                              tag="div"
+                              target={null}
+                            >
+                              <div
+                                aria-hidden={null}
+                                aria-label={null}
+                                className="css-9auwkz css-1hj8a57"
+                                data-test-id="link: /account"
+                                href={null}
+                                onClick={[Function]}
+                                role="link"
+                                tabIndex={null}
+                              >
+                                <Translate
+                                  className={null}
+                                  params={Object {}}
+                                  role={null}
+                                  string="navigation.manage"
+                                  transform={null}
+                                >
+                                  <span
+                                    className={null}
+                                    role={null}
+                                  >
+                                    navigation.manage
+                                  </span>
+                                </Translate>
+                              </div>
+                            </Link>
+                          </Connect(Link)>
+                        </MoreMenuItem>
                         <Portal
                           name="nav-menu.logout.before"
                           props={


### PR DESCRIPTION
# Description
This ticket is about to improve the Engage auth routes system for the initial page. Till now protected routes could be opened without seeing the login page when the url was known and entered to the browser address bar.

This is changed now by modifications of the Router component. Initial router rendering is now postponed till the login status of the user can unequivocally determined when the initial route is a protected one. In those cases the initial route will be replaced by the login page when the user is not logged in.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

