### PR TITLE
APPS-818 add support for appPermission ACCESS_BACKGROUND_LOCATION

### DIFF
--- a/libraries/core/constants/AppPermissions.js
+++ b/libraries/core/constants/AppPermissions.js
@@ -6,6 +6,8 @@ export const PERMISSION_ID_CAMERA = 'camera';
 
 // Only available on Android
 export const PERMISSION_ID_PHONE = 'phone';
+export const PERMISSION_ID_BACKGROUND_LOCATION = 'background_location';
+
 // Only available in iOS
 export const PERMISSION_ID_PUSH = 'push';
 // Only available on iOS
@@ -13,6 +15,7 @@ export const PERMISSION_ID_BACKGROUND_APP_REFRESH = 'backgroundAppRefresh';
 
 export const availablePermissionsIds = [
   PERMISSION_ID_BACKGROUND_APP_REFRESH,
+  PERMISSION_ID_BACKGROUND_LOCATION,
   PERMISSION_ID_CAMERA,
   PERMISSION_ID_LOCATION,
   PERMISSION_ID_PHONE,


### PR DESCRIPTION
# Description

Adding support to request the app permission `ACCESS_BACKGROUND_LOCATION` on Android

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
