### PR TITLE
Fix cta colors from theme config

### DIFF
--- a/libraries/common/helpers/config/theme.js
+++ b/libraries/common/helpers/config/theme.js
@@ -24,14 +24,6 @@ export function buildThemeConfig(appConfig) {
 
   const { colors = {}, theme = {} } = appConfig;
 
-  // Force cta colors
-  if (!colors.cta && colors.primary) {
-    colors.cta = colors.primary;
-  }
-  if (!colors.ctaContrast && colors.primaryContrast) {
-    colors.ctaContrast = colors.primaryContrast;
-  }
-
   const oldTheme = process.env.THEME_CONFIG || defaultConfig;
 
   const themeConfig = { ...theme };
@@ -49,6 +41,14 @@ export function buildThemeConfig(appConfig) {
       materialShadow: theme.shadows.material,
     },
   });
+
+  // Force cta colors
+  if (!themeConfig.colors.cta && themeConfig.colors.primary) {
+    themeConfig.colors.cta = themeConfig.colors.primary;
+  }
+  if (!themeConfig.colors.ctaContrast && themeConfig.colors.primaryContrast) {
+    themeConfig.colors.ctaContrast = themeConfig.colors.primaryContrast;
+  }
 
   return themeConfig;
 }

--- a/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/components/CartButton/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/CTAButtons/components/CartButton/index.jsx
@@ -54,7 +54,7 @@ class CartButton extends Component {
       return colors.light;
     }
 
-    return (this.props.disabled && !this.props.loading) ? colors.shade5 : colors.primary;
+    return (this.props.disabled && !this.props.loading) ? colors.shade5 : colors.cta;
   }
 
   /**
@@ -64,7 +64,7 @@ class CartButton extends Component {
     if (this.props.loading) {
       return (
         <IndicatorCircle
-          color={colors.primaryContrast}
+          color={colors.ctaContrast}
           strokeWidth={4}
           paused={false}
         />


### PR DESCRIPTION
# Description

Cta colors from theme config are now used correctly and not overridden. AddToCart button in theme-gmd is now using the cta colors instead of the primary color

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.
