### PR TITLE
Make cms icons configurable inside gmd navdrawer

### DIFF
--- a/themes/theme-gmd/components/NavDrawer/components/QuickLinks/index.jsx
+++ b/themes/theme-gmd/components/NavDrawer/components/QuickLinks/index.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { NavDrawer } from '@shopgate/pwa-ui-material';
+import camelCase from 'lodash/camelCase';
+import { themeConfig } from '@shopgate/engage';
+import { NavDrawer, DescriptionIcon, Icon } from '@shopgate/engage/components';
 import connect from './connector';
+
+const { icons } = themeConfig;
 
 /**
  * @param {Array} props.links An array of quicklinks.
@@ -10,14 +14,25 @@ import connect from './connector';
 const QuickLinks = ({ links, navigate }) => (
   (links && links.length > 0) && (
     <NavDrawer.Section>
-      {links.map(link => (
-        <NavDrawer.Item
-          aria-hidden
-          key={link.url}
-          label={link.label}
-          onClick={() => navigate(link.url, link.label)}
-        />
-      ))}
+      {links.map((link) => {
+        let icon = DescriptionIcon;
+
+        // Convert /page/some-link to pageSomeLink for custom icons
+        const path = camelCase(link.url);
+        if (icons[path]) {
+          icon = props => <Icon content={icons[path]} {...props} />;
+        }
+
+        return (
+          <NavDrawer.Item
+            aria-hidden
+            key={link.url}
+            label={link.label}
+            onClick={() => navigate(link.url, link.label)}
+            icon={icon}
+          />
+        );
+      })}
     </NavDrawer.Section>
   )
 );

--- a/themes/theme-gmd/components/NavDrawer/spec.jsx
+++ b/themes/theme-gmd/components/NavDrawer/spec.jsx
@@ -11,6 +11,15 @@ jest.mock('react-portal', () => (
     isOpened ? children : null
   )
 ));
+jest.mock('@shopgate/engage', () => ({
+  themeConfig: {},
+}));
+
+jest.mock('@shopgate/engage/components', () => ({
+  NavDrawer: jest.fn(),
+  DescriptionIcon: jest.fn(),
+  Icon: jest.fn(),
+}));
 
 // Mock the redux connect() method instead of providing a fake store.
 jest.mock('./connector', () => obj => obj);


### PR DESCRIPTION
# Description

Make cms icons configurable inside gmd navdrawer

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [X] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
