### PR TITLE
Make TaxDisclaimer configurable

### DIFF
--- a/libraries/ui-shared/Price/index.jsx
+++ b/libraries/ui-shared/Price/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import I18n from '@shopgate/pwa-common/components/I18n';
 import showTaxDisclaimer from '@shopgate/pwa-common-commerce/market/helpers/showTaxDisclaimer';
+import { useWidgetSettings } from '@shopgate/engage/core/hooks/useWidgetSettings';
 import styles from './style';
 
 /**
@@ -17,6 +18,14 @@ import styles from './style';
  * @return {JSX}
  */
 const Price = (props, context) => {
+  const {
+    show,
+    hint,
+  } = useWidgetSettings('@shopgate/engage/components/TaxDisclaimer');
+
+  // use widget setting if set to true/false, otherwise use market logic
+  const showDisclaimer = typeof show === 'boolean' ? show : showTaxDisclaimer;
+
   const containerClasses = classNames(
     styles.container,
     props.className,
@@ -68,8 +77,10 @@ const Price = (props, context) => {
           />
         )}
       </span>
-      {props.taxDisclaimer && showTaxDisclaimer ? (
-        <div role="text" className={styles.disclaimer} aria-label={__('product.tax_disclaimer')}>*</div>
+      {props.taxDisclaimer && showDisclaimer ? (
+        <div role="text" className={styles.disclaimer} aria-label={__('product.tax_disclaimer')}>
+          {hint || '*'}
+        </div>
       ) : null}
     </div>
   );

--- a/libraries/ui-shared/TaxDisclaimer/__snapshots__/spec.jsx.snap
+++ b/libraries/ui-shared/TaxDisclaimer/__snapshots__/spec.jsx.snap
@@ -1,20 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<TaxDisclaimer /> should display null 1`] = `
-<Fragment>
-  <Portal
-    name="product.tax-disclaimer.before"
-    props={null}
-  />
-  <Portal
-    name="product.tax-disclaimer"
-    props={null}
-  />
-  <Portal
-    name="product.tax-disclaimer.after"
-    props={null}
-  />
-</Fragment>
+<SurroundPortals
+  portalName="product.tax-disclaimer"
+  portalProps={
+    Object {
+      "showTaxDisclaimer": false,
+    }
+  }
+/>
 `;
 
 exports[`<TaxDisclaimer /> should display the component 1`] = `

--- a/libraries/ui-shared/TaxDisclaimer/__snapshots__/spec.jsx.snap
+++ b/libraries/ui-shared/TaxDisclaimer/__snapshots__/spec.jsx.snap
@@ -18,30 +18,24 @@ exports[`<TaxDisclaimer /> should display null 1`] = `
 `;
 
 exports[`<TaxDisclaimer /> should display the component 1`] = `
-<Fragment>
-  <Portal
-    name="product.tax-disclaimer.before"
-    props={null}
-  />
-  <Portal
-    name="product.tax-disclaimer"
-    props={null}
+<SurroundPortals
+  portalName="product.tax-disclaimer"
+  portalProps={
+    Object {
+      "showTaxDisclaimer": true,
+    }
+  }
+>
+  <div
+    aria-hidden={true}
+    data-test-id="taxDisclaimer"
   >
-    <div
-      aria-hidden={true}
-      data-test-id="taxDisclaimer"
-    >
-      <Translate
-        className="css-fazkyv"
-        params={Object {}}
-        role={null}
-        string="product.tax_disclaimer"
-      />
-    </div>
-  </Portal>
-  <Portal
-    name="product.tax-disclaimer.after"
-    props={null}
-  />
-</Fragment>
+    <Translate
+      className="css-fazkyv"
+      params={Object {}}
+      role={null}
+      string="product.tax_disclaimer"
+    />
+  </div>
+</SurroundPortals>
 `;

--- a/libraries/ui-shared/TaxDisclaimer/index.jsx
+++ b/libraries/ui-shared/TaxDisclaimer/index.jsx
@@ -1,30 +1,38 @@
-import React, { Fragment } from 'react';
-import Portal from '@shopgate/pwa-common/components/Portal';
+import React from 'react';
+import SurroundPortals from '@shopgate/pwa-common/components/SurroundPortals';
 import {
   PRODUCT_TAX_DISCLAIMER,
-  PRODUCT_TAX_DISCLAIMER_AFTER,
-  PRODUCT_TAX_DISCLAIMER_BEFORE,
 } from '@shopgate/pwa-common-commerce/product/constants/Portals';
 import I18n from '@shopgate/pwa-common/components/I18n';
 import showTaxDisclaimer from '@shopgate/pwa-common-commerce/market/helpers/showTaxDisclaimer';
+import { useWidgetSettings } from '@shopgate/engage/core/hooks/useWidgetSettings';
 import styles from './style';
 
 /**
  * TaxDisclaimer component.
  * @returns {Function}
  */
-const TaxDisclaimer = () => (
-  <Fragment>
-    <Portal name={PRODUCT_TAX_DISCLAIMER_BEFORE} />
-    <Portal name={PRODUCT_TAX_DISCLAIMER}>
-      {showTaxDisclaimer && (
-        <div data-test-id="taxDisclaimer" aria-hidden>
-          <I18n.Text className={styles} string="product.tax_disclaimer" />
-        </div>
+const TaxDisclaimer = () => {
+  const {
+    show,
+    text,
+  } = useWidgetSettings('@shopgate/engage/components/TaxDisclaimer');
+
+  // use widget setting if set to true/false, otherwise use market logic
+  const showDisclaimer = typeof show === 'boolean' ? show : showTaxDisclaimer;
+
+  return (
+    <SurroundPortals
+      portalName={PRODUCT_TAX_DISCLAIMER}
+      portalProps={{ showTaxDisclaimer: showDisclaimer }}
+    >
+      {showDisclaimer && (
+      <div data-test-id="taxDisclaimer" aria-hidden>
+        <I18n.Text className={styles} string={text || 'product.tax_disclaimer'} />
+      </div>
       )}
-    </Portal>
-    <Portal name={PRODUCT_TAX_DISCLAIMER_AFTER} />
-  </Fragment>
-);
+    </SurroundPortals>
+  );
+};
 
 export default TaxDisclaimer;

--- a/libraries/ui-shared/TaxDisclaimer/spec.jsx
+++ b/libraries/ui-shared/TaxDisclaimer/spec.jsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import I18n from '@shopgate/pwa-common/components/I18n';
 
+jest.mock('@shopgate/engage/core/hooks/useWidgetSettings', () => ({
+  useWidgetSettings: jest.fn().mockReturnValue({
+    show: null,
+    hint: '*',
+    text: null,
+  }),
+}));
+
 describe('<TaxDisclaimer />', () => {
   afterEach(() => {
     jest.resetModules();

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -261,6 +261,11 @@
           },
           "@shopgate/engage/reviews": {
             "prefillAuthor": true
+          },
+          "@shopgate/engage/components/TaxDisclaimer": {
+            "show": null,
+            "hint": "*",
+            "text": null
           }
         },
         "typography": {

--- a/themes/theme-gmd/pages/Cart/components/Footer/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/Cart/components/Footer/__snapshots__/spec.jsx.snap
@@ -2,8 +2,8 @@
 
 exports[`<Footer /> should render as expected when all items are supposed to be shown 1`] = `
 <Footer
+  hasCartItems={true}
   showCouponsHint={true}
-  showTaxDisclaimer={true}
 >
   <CouponsHint>
     <Translate
@@ -21,55 +21,97 @@ exports[`<Footer /> should render as expected when all items are supposed to be 
     </Translate>
   </CouponsHint>
   <TaxDisclaimer>
-    <Portal
-      name="product.tax-disclaimer.before"
-      props={null}
-    />
-    <Portal
-      name="product.tax-disclaimer"
-      props={null}
-    />
-    <Portal
-      name="product.tax-disclaimer.after"
-      props={null}
-    />
+    <SurroundPortals
+      portalName="product.tax-disclaimer"
+      portalProps={
+        Object {
+          "showTaxDisclaimer": false,
+        }
+      }
+    >
+      <Portal
+        name="product.tax-disclaimer.before"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+      <Portal
+        name="product.tax-disclaimer"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+      <Portal
+        name="product.tax-disclaimer.after"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+    </SurroundPortals>
   </TaxDisclaimer>
 </Footer>
 `;
 
 exports[`<Footer /> should render as expected when no items are supposed to be shown 1`] = `
 <Footer
+  hasCartItems={false}
   showCouponsHint={false}
-  showTaxDisclaimer={false}
 />
 `;
 
 exports[`<Footer /> should render as expected when only the tax disclaimer is supposed to be shown 1`] = `
 <Footer
+  hasCartItems={true}
   showCouponsHint={false}
-  showTaxDisclaimer={true}
 >
   <TaxDisclaimer>
-    <Portal
-      name="product.tax-disclaimer.before"
-      props={null}
-    />
-    <Portal
-      name="product.tax-disclaimer"
-      props={null}
-    />
-    <Portal
-      name="product.tax-disclaimer.after"
-      props={null}
-    />
+    <SurroundPortals
+      portalName="product.tax-disclaimer"
+      portalProps={
+        Object {
+          "showTaxDisclaimer": false,
+        }
+      }
+    >
+      <Portal
+        name="product.tax-disclaimer.before"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+      <Portal
+        name="product.tax-disclaimer"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+      <Portal
+        name="product.tax-disclaimer.after"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+    </SurroundPortals>
   </TaxDisclaimer>
 </Footer>
 `;
 
 exports[`<Footer /> should render as expected when only the the coupons hint is supposed to be shown 1`] = `
 <Footer
+  hasCartItems={false}
   showCouponsHint={true}
-  showTaxDisclaimer={false}
 >
   <CouponsHint>
     <Translate

--- a/themes/theme-gmd/pages/Cart/components/Footer/connector.js
+++ b/themes/theme-gmd/pages/Cart/components/Footer/connector.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state) => {
 
   return {
     showCouponsHint: hasCartItems && !hasCouponSupport(state),
-    showTaxDisclaimer: hasCartItems && showTaxDisclaimer,
+    hasCartItems,
   };
 };
 

--- a/themes/theme-gmd/pages/Cart/components/Footer/index.jsx
+++ b/themes/theme-gmd/pages/Cart/components/Footer/index.jsx
@@ -9,16 +9,16 @@ import connect from './connector';
  * @param {Object} props The component props.
  * @return {JSX}
  */
-const Footer = ({ showTaxDisclaimer, showCouponsHint }) => (
+const Footer = ({ hasCartItems, showCouponsHint }) => (
   <Fragment>
     {showCouponsHint && <CouponsHint />}
-    {showTaxDisclaimer && <TaxDisclaimer />}
+    {hasCartItems && <TaxDisclaimer />}
   </Fragment>
 );
 
 Footer.propTypes = {
+  hasCartItems: PropTypes.bool.isRequired,
   showCouponsHint: PropTypes.bool.isRequired,
-  showTaxDisclaimer: PropTypes.bool.isRequired,
 };
 
 export default connect(Footer);

--- a/themes/theme-gmd/pages/Cart/components/Footer/spec.jsx
+++ b/themes/theme-gmd/pages/Cart/components/Footer/spec.jsx
@@ -9,28 +9,28 @@ jest.mock('./connector', () => obj => obj);
 
 describe('<Footer />', () => {
   it('should render as expected when all items are supposed to be shown', () => {
-    const wrapper = mount(<Footer showCouponsHint showTaxDisclaimer />);
+    const wrapper = mount(<Footer showCouponsHint hasCartItems />);
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(CouponsHint).length).toBe(1);
     expect(wrapper.find(TaxDisclaimer).length).toBe(1);
   });
 
   it('should render as expected when no items are supposed to be shown', () => {
-    const wrapper = mount(<Footer showCouponsHint={false} showTaxDisclaimer={false} />);
+    const wrapper = mount(<Footer showCouponsHint={false} hasCartItems={false} />);
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(CouponsHint).length).toBe(0);
     expect(wrapper.find(TaxDisclaimer).length).toBe(0);
   });
 
   it('should render as expected when only the the coupons hint is supposed to be shown', () => {
-    const wrapper = mount(<Footer showCouponsHint showTaxDisclaimer={false} />);
+    const wrapper = mount(<Footer showCouponsHint hasCartItems={false} />);
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(CouponsHint).length).toBe(1);
     expect(wrapper.find(TaxDisclaimer).length).toBe(0);
   });
 
   it('should render as expected when only the tax disclaimer is supposed to be shown', () => {
-    const wrapper = mount(<Footer showCouponsHint={false} showTaxDisclaimer />);
+    const wrapper = mount(<Footer showCouponsHint={false} hasCartItems />);
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(CouponsHint).length).toBe(0);
     expect(wrapper.find(TaxDisclaimer).length).toBe(1);

--- a/themes/theme-gmd/pages/Cart/components/Item/components/Product/components/Layout/index.jsx
+++ b/themes/theme-gmd/pages/Cart/components/Item/components/Product/components/Layout/index.jsx
@@ -5,7 +5,7 @@ import {
 } from '@shopgate/engage/components';
 import { CART_ITEM_IMAGE } from '@shopgate/engage/cart';
 import { showTaxDisclaimer } from '@shopgate/engage/market';
-import { bin2hex } from '@shopgate/engage/core';
+import { bin2hex, useWidgetSettings } from '@shopgate/engage/core';
 import { ProductImage, ITEM_PATH } from '@shopgate/engage/product';
 import QuantityPicker from './components/QuantityPicker';
 import Title from './components/Title';
@@ -18,55 +18,63 @@ import styles from './style';
  * @param {Object} context The component context.
  * @returns {JSX}
  */
-const Layout = (props, context) => (
-  <Grid className={styles.item}>
-    <Grid.Item className={styles.content} grow={1}>
-      <Link tagName="a" href={`${ITEM_PATH}/${bin2hex(props.product.id)}`}>
-        <Title
-          handleRemove={props.handleDelete}
-          toggleEditMode={props.toggleEditMode}
-          value={props.product.name}
-        />
-      </Link>
-      <Grid className={styles.info}>
-        <Grid.Item grow={1} className={styles.properties}>
-          <ProductProperties properties={props.product.properties} lineClamp={2} />
-        </Grid.Item>
-        <Grid.Item grow={1} className={styles.price}>
-          <ProductPrice
-            currency={props.currency}
-            defaultPrice={props.product.price.default}
-            specialPrice={props.product.price.special}
+const Layout = (props, context) => {
+  const {
+    show,
+  } = useWidgetSettings('@shopgate/engage/components/TaxDisclaimer');
+  // use widget setting if set to true/false, otherwise use market logic
+  const showDisclaimer = typeof show === 'boolean' ? show : showTaxDisclaimer;
+
+  return (
+    <Grid className={styles.item}>
+      <Grid.Item className={styles.content} grow={1}>
+        <Link tagName="a" href={`${ITEM_PATH}/${bin2hex(props.product.id)}`}>
+          <Title
+            handleRemove={props.handleDelete}
+            toggleEditMode={props.toggleEditMode}
+            value={props.product.name}
           />
-          {props.product.price.info && (
-          <PriceInfo className={styles.priceInfo} text={props.product.price.info} />
+        </Link>
+        <Grid className={styles.info}>
+          <Grid.Item grow={1} className={styles.properties}>
+            <ProductProperties properties={props.product.properties} lineClamp={2} />
+          </Grid.Item>
+          <Grid.Item grow={1} className={styles.price}>
+            <ProductPrice
+              currency={props.currency}
+              defaultPrice={props.product.price.default}
+              specialPrice={props.product.price.special}
+            />
+            {props.product.price.info && (
+              <PriceInfo className={styles.priceInfo} text={props.product.price.info} />
+            )}
+          </Grid.Item>
+          {showDisclaimer && (
+            <Grid.Item
+              className={styles.disclaimerSpacer}
+              grow={0}
+              shrink={0}
+            />
           )}
-        </Grid.Item>
-        {showTaxDisclaimer && (
-        <Grid.Item
-          className={styles.disclaimerSpacer}
-          grow={0}
-          shrink={0}
+        </Grid>
+      </Grid.Item>
+      {/** DOM reversed for a11y navigation */}
+      <Grid.Item className={styles.leftColumn}>
+        <div className={styles.image} aria-hidden>
+          <SurroundPortals portalName={CART_ITEM_IMAGE} portalProps={context}>
+            <ProductImage src={props.product.featuredImageUrl} />
+          </SurroundPortals>
+        </div>
+        <QuantityPicker
+          quantity={props.quantity}
+          editMode={props.editMode}
+          onChange={props.handleUpdate}
+          onToggleEditMode={props.toggleEditMode}
         />
-        )}
-      </Grid>
-    </Grid.Item>
-    {/** DOM reversed for a11y navigation */}
-    <Grid.Item className={styles.leftColumn}>
-      <div className={styles.image} aria-hidden>
-        <SurroundPortals portalName={CART_ITEM_IMAGE} portalProps={context}>
-          <ProductImage src={props.product.featuredImageUrl} />
-        </SurroundPortals>
-      </div>
-      <QuantityPicker
-        quantity={props.quantity}
-        editMode={props.editMode}
-        onChange={props.handleUpdate}
-        onToggleEditMode={props.toggleEditMode}
-      />
-    </Grid.Item>
-  </Grid>
-);
+      </Grid.Item>
+    </Grid>
+  );
+};
 
 Layout.propTypes = {
   currency: PropTypes.string.isRequired,

--- a/themes/theme-gmd/pages/Product/components/Header/components/TaxDisclaimer/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/TaxDisclaimer/index.jsx
@@ -1,13 +1,20 @@
 import React, { memo } from 'react';
 import Grid from '@shopgate/pwa-common/components/Grid';
 import showTaxDisclaimer from '@shopgate/pwa-common-commerce/market/helpers/showTaxDisclaimer';
+import { useWidgetSettings } from '@shopgate/engage/core/hooks/useWidgetSettings';
 import styles from './style';
 
 /**
  * @returns {JSX}
  */
 const TaxDisclaimer = () => {
-  if (!showTaxDisclaimer) {
+  const {
+    show,
+  } = useWidgetSettings('@shopgate/engage/components/TaxDisclaimer');
+  // use widget setting if set to true/false, otherwise use market logic
+  const showDisclaimer = typeof show === 'boolean' ? show : showTaxDisclaimer;
+
+  if (!showDisclaimer) {
     return null;
   }
 

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -255,6 +255,11 @@
           },
           "@shopgate/engage/reviews": {
             "prefillAuthor": true
+          },
+          "@shopgate/engage/components/TaxDisclaimer": {
+            "show": null,
+            "hint": "*",
+            "text": null
           }
         },
         "typography": {

--- a/themes/theme-ios11/pages/Cart/components/Footer/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Cart/components/Footer/__snapshots__/spec.jsx.snap
@@ -2,8 +2,8 @@
 
 exports[`<Footer /> should render as expected when all items are supposed to be shown 1`] = `
 <Footer
+  hasCartItems={true}
   showCouponsHint={true}
-  showTaxDisclaimer={true}
 >
   <CouponsHint>
     <Translate
@@ -21,55 +21,97 @@ exports[`<Footer /> should render as expected when all items are supposed to be 
     </Translate>
   </CouponsHint>
   <TaxDisclaimer>
-    <Portal
-      name="product.tax-disclaimer.before"
-      props={null}
-    />
-    <Portal
-      name="product.tax-disclaimer"
-      props={null}
-    />
-    <Portal
-      name="product.tax-disclaimer.after"
-      props={null}
-    />
+    <SurroundPortals
+      portalName="product.tax-disclaimer"
+      portalProps={
+        Object {
+          "showTaxDisclaimer": false,
+        }
+      }
+    >
+      <Portal
+        name="product.tax-disclaimer.before"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+      <Portal
+        name="product.tax-disclaimer"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+      <Portal
+        name="product.tax-disclaimer.after"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+    </SurroundPortals>
   </TaxDisclaimer>
 </Footer>
 `;
 
 exports[`<Footer /> should render as expected when no items are supposed to be shown 1`] = `
 <Footer
+  hasCartItems={false}
   showCouponsHint={false}
-  showTaxDisclaimer={false}
 />
 `;
 
 exports[`<Footer /> should render as expected when only the tax disclaimer is supposed to be shown 1`] = `
 <Footer
+  hasCartItems={true}
   showCouponsHint={false}
-  showTaxDisclaimer={true}
 >
   <TaxDisclaimer>
-    <Portal
-      name="product.tax-disclaimer.before"
-      props={null}
-    />
-    <Portal
-      name="product.tax-disclaimer"
-      props={null}
-    />
-    <Portal
-      name="product.tax-disclaimer.after"
-      props={null}
-    />
+    <SurroundPortals
+      portalName="product.tax-disclaimer"
+      portalProps={
+        Object {
+          "showTaxDisclaimer": false,
+        }
+      }
+    >
+      <Portal
+        name="product.tax-disclaimer.before"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+      <Portal
+        name="product.tax-disclaimer"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+      <Portal
+        name="product.tax-disclaimer.after"
+        props={
+          Object {
+            "showTaxDisclaimer": false,
+          }
+        }
+      />
+    </SurroundPortals>
   </TaxDisclaimer>
 </Footer>
 `;
 
 exports[`<Footer /> should render as expected when only the the coupons hint is supposed to be shown 1`] = `
 <Footer
+  hasCartItems={false}
   showCouponsHint={true}
-  showTaxDisclaimer={false}
 >
   <CouponsHint>
     <Translate

--- a/themes/theme-ios11/pages/Cart/components/Footer/connector.js
+++ b/themes/theme-ios11/pages/Cart/components/Footer/connector.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state) => {
 
   return {
     showCouponsHint: hasCartItems && !hasCouponSupport(state),
-    showTaxDisclaimer: hasCartItems && showTaxDisclaimer,
+    hasCartItems,
   };
 };
 

--- a/themes/theme-ios11/pages/Cart/components/Footer/index.jsx
+++ b/themes/theme-ios11/pages/Cart/components/Footer/index.jsx
@@ -9,16 +9,16 @@ import connect from './connector';
  * @param {Object} props The component props.
  * @return {JSX}
  */
-const Footer = ({ showTaxDisclaimer, showCouponsHint }) => (
+const Footer = ({ hasCartItems, showCouponsHint }) => (
   <Fragment>
     {showCouponsHint && <CouponsHint />}
-    {showTaxDisclaimer && <TaxDisclaimer />}
+    {hasCartItems && <TaxDisclaimer />}
   </Fragment>
 );
 
 Footer.propTypes = {
+  hasCartItems: PropTypes.bool.isRequired,
   showCouponsHint: PropTypes.bool.isRequired,
-  showTaxDisclaimer: PropTypes.bool.isRequired,
 };
 
 export default connect(Footer);

--- a/themes/theme-ios11/pages/Cart/components/Footer/spec.jsx
+++ b/themes/theme-ios11/pages/Cart/components/Footer/spec.jsx
@@ -9,28 +9,28 @@ jest.mock('./connector', () => obj => obj);
 
 describe('<Footer />', () => {
   it('should render as expected when all items are supposed to be shown', () => {
-    const wrapper = mount(<Footer showCouponsHint showTaxDisclaimer />);
+    const wrapper = mount(<Footer showCouponsHint hasCartItems />);
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(CouponsHint).length).toBe(1);
     expect(wrapper.find(TaxDisclaimer).length).toBe(1);
   });
 
   it('should render as expected when no items are supposed to be shown', () => {
-    const wrapper = mount(<Footer showCouponsHint={false} showTaxDisclaimer={false} />);
+    const wrapper = mount(<Footer showCouponsHint={false} hasCartItems={false} />);
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(CouponsHint).length).toBe(0);
     expect(wrapper.find(TaxDisclaimer).length).toBe(0);
   });
 
   it('should render as expected when only the the coupons hint is supposed to be shown', () => {
-    const wrapper = mount(<Footer showCouponsHint showTaxDisclaimer={false} />);
+    const wrapper = mount(<Footer showCouponsHint hasCartItems={false} />);
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(CouponsHint).length).toBe(1);
     expect(wrapper.find(TaxDisclaimer).length).toBe(0);
   });
 
   it('should render as expected when only the tax disclaimer is supposed to be shown', () => {
-    const wrapper = mount(<Footer showCouponsHint={false} showTaxDisclaimer />);
+    const wrapper = mount(<Footer showCouponsHint={false} hasCartItems />);
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(CouponsHint).length).toBe(0);
     expect(wrapper.find(TaxDisclaimer).length).toBe(1);

--- a/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/index.jsx
+++ b/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/index.jsx
@@ -5,7 +5,7 @@ import {
 } from '@shopgate/engage/components';
 import { CART_ITEM_IMAGE } from '@shopgate/engage/cart';
 import { showTaxDisclaimer } from '@shopgate/engage/market';
-import { bin2hex } from '@shopgate/engage/core';
+import { bin2hex, useWidgetSettings } from '@shopgate/engage/core';
 import { ProductImage, ITEM_PATH } from '@shopgate/engage/product';
 import QuantityPicker from './components/QuantityPicker';
 import Title from './components/Title';
@@ -18,55 +18,63 @@ import styles from './style';
  * @param {Object} context The component context.
  * @returns {JSX}
  */
-const Layout = (props, context) => (
-  <Grid className={styles.item}>
-    <Grid.Item className={styles.content} grow={1}>
-      <Link tagName="a" href={`${ITEM_PATH}/${bin2hex(props.product.id)}`}>
-        <Title
-          handleRemove={props.handleDelete}
-          toggleEditMode={props.toggleEditMode}
-          value={props.product.name}
-        />
-      </Link>
-      <Grid className={styles.info}>
-        <Grid.Item grow={1} className={styles.properties}>
-          <ProductProperties properties={props.product.properties} lineClamp={2} />
-        </Grid.Item>
-        <Grid.Item grow={1} className={styles.price}>
-          <ProductPrice
-            currency={props.currency}
-            defaultPrice={props.product.price.default}
-            specialPrice={props.product.price.special}
+const Layout = (props, context) => {
+  const {
+    show,
+  } = useWidgetSettings('@shopgate/engage/components/TaxDisclaimer');
+  // use widget setting if set to true/false, otherwise use market logic
+  const showDisclaimer = typeof show === 'boolean' ? show : showTaxDisclaimer;
+
+  return (
+    <Grid className={styles.item}>
+      <Grid.Item className={styles.content} grow={1}>
+        <Link tagName="a" href={`${ITEM_PATH}/${bin2hex(props.product.id)}`}>
+          <Title
+            handleRemove={props.handleDelete}
+            toggleEditMode={props.toggleEditMode}
+            value={props.product.name}
           />
-          {props.product.price.info && (
-            <PriceInfo className={styles.priceInfo} text={props.product.price.info} />
+        </Link>
+        <Grid className={styles.info}>
+          <Grid.Item grow={1} className={styles.properties}>
+            <ProductProperties properties={props.product.properties} lineClamp={2} />
+          </Grid.Item>
+          <Grid.Item grow={1} className={styles.price}>
+            <ProductPrice
+              currency={props.currency}
+              defaultPrice={props.product.price.default}
+              specialPrice={props.product.price.special}
+            />
+            {props.product.price.info && (
+              <PriceInfo className={styles.priceInfo} text={props.product.price.info} />
+            )}
+          </Grid.Item>
+          {showDisclaimer && (
+            <Grid.Item
+              className={styles.disclaimerSpacer}
+              grow={0}
+              shrink={0}
+            />
           )}
-        </Grid.Item>
-        {showTaxDisclaimer && (
-          <Grid.Item
-            className={styles.disclaimerSpacer}
-            grow={0}
-            shrink={0}
-          />
-        )}
-      </Grid>
-    </Grid.Item>
-    {/** DOM reversed for a11y navigation */}
-    <Grid.Item className={styles.leftColumn}>
-      <div className={styles.image} aria-hidden>
-        <SurroundPortals portalName={CART_ITEM_IMAGE} portalProps={context}>
-          <ProductImage src={props.product.featuredImageUrl} />
-        </SurroundPortals>
-      </div>
-      <QuantityPicker
-        quantity={props.quantity}
-        editMode={props.editMode}
-        onChange={props.handleUpdate}
-        onToggleEditMode={props.toggleEditMode}
-      />
-    </Grid.Item>
-  </Grid>
-);
+        </Grid>
+      </Grid.Item>
+      {/** DOM reversed for a11y navigation */}
+      <Grid.Item className={styles.leftColumn}>
+        <div className={styles.image} aria-hidden>
+          <SurroundPortals portalName={CART_ITEM_IMAGE} portalProps={context}>
+            <ProductImage src={props.product.featuredImageUrl} />
+          </SurroundPortals>
+        </div>
+        <QuantityPicker
+          quantity={props.quantity}
+          editMode={props.editMode}
+          onChange={props.handleUpdate}
+          onToggleEditMode={props.toggleEditMode}
+        />
+      </Grid.Item>
+    </Grid>
+  );
+};
 
 Layout.propTypes = {
   currency: PropTypes.string.isRequired,

--- a/themes/theme-ios11/pages/Product/components/Header/components/TaxDisclaimer/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/TaxDisclaimer/index.jsx
@@ -1,13 +1,20 @@
 import React, { memo } from 'react';
 import Grid from '@shopgate/pwa-common/components/Grid';
 import showTaxDisclaimer from '@shopgate/pwa-common-commerce/market/helpers/showTaxDisclaimer';
+import { useWidgetSettings } from '@shopgate/engage/core/hooks/useWidgetSettings';
 import styles from './style';
 
 /**
  * @returns {JSX}
  */
 const TaxDisclaimer = () => {
-  if (!showTaxDisclaimer) {
+  const {
+    show,
+  } = useWidgetSettings('@shopgate/engage/components/TaxDisclaimer');
+  // use widget setting if set to true/false, otherwise use market logic
+  const showDisclaimer = typeof show === 'boolean' ? show : showTaxDisclaimer;
+
+  if (!showDisclaimer) {
     return null;
   }
 


### PR DESCRIPTION
# Description

Introducing a new theme config `@shopgate/engage/components/TaxDisclaimer` to configure TaxDisclaimer

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.
