### PR TITLE
Fix for fast opening image gallery before getProductImages response is there

### DIFF
--- a/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/connector.js
+++ b/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/connector.js
@@ -21,7 +21,7 @@ const mapStateToProps = (state, props) => ({
  * @returns {boolean}
  */
 const areStatePropsEqual = (next, prev) => {
-  if (!prev.images && next.images) {
+  if (!prev.images.length && next.images.length) {
     return false;
   }
 

--- a/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/connector.js
+++ b/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/connector.js
@@ -21,7 +21,7 @@ const mapStateToProps = (state, props) => ({
  * @returns {boolean}
  */
 const areStatePropsEqual = (next, prev) => {
-  if (!prev.images && next.images) {
+  if (!prev.images.length && next.images.length) {
     return false;
   }
 


### PR DESCRIPTION
# Description

Fix for fast opening image gallery before getProductImages response is there

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.
