### PR TITLE
Added new position for RelationsSlider and filter properties by code

### DIFF
--- a/libraries/commerce/product/helpers/index.js
+++ b/libraries/commerce/product/helpers/index.js
@@ -22,7 +22,9 @@ export const filterProperties = (properties) => {
   }
 
   return properties.filter(({ label, code }) => {
-    const inList = appConfig.productPropertiesFilter.properties.indexOf(label || code) !== -1;
+    const inList = !!appConfig.productPropertiesFilter.properties.find(
+      p => p === code || p === label
+    );
 
     if (appConfig.productPropertiesFilter.type === PROPERTIES_FILTER_WHITELIST) {
       // Show item if allowed in whitelist

--- a/libraries/commerce/product/helpers/index.js
+++ b/libraries/commerce/product/helpers/index.js
@@ -21,8 +21,8 @@ export const filterProperties = (properties) => {
     return properties;
   }
 
-  return properties.filter(({ label }) => {
-    const inList = appConfig.productPropertiesFilter.properties.indexOf(label) !== -1;
+  return properties.filter(({ label, code }) => {
+    const inList = appConfig.productPropertiesFilter.properties.indexOf(label || code) !== -1;
 
     if (appConfig.productPropertiesFilter.type === PROPERTIES_FILTER_WHITELIST) {
       // Show item if allowed in whitelist

--- a/themes/theme-gmd/pages/Product/components/Content/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Content/index.jsx
@@ -215,6 +215,11 @@ class ProductContent extends PureComponent {
                 variantId={variantId}
               />
             </Section>
+            {/*
+              This feature is currently in BETA testing.
+              It should only be used for approved BETA Client Projects
+            */}
+            <RelationsSlider desiredPosition="properties" />
             <Section title="product.sections.ratings">
               <Reviews productId={productId} />
             </Section>

--- a/themes/theme-ios11/pages/Product/components/Content/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Content/index.jsx
@@ -217,6 +217,11 @@ class ProductContent extends PureComponent {
               variantId={variantId}
             />
           </Section>
+          {/*
+              This feature is currently in BETA testing.
+              It should only be used for approved BETA Client Projects
+            */}
+          <RelationsSlider desiredPosition="properties" />
           <Section title="product.sections.ratings">
             <Reviews productId={productId} />
           </Section>


### PR DESCRIPTION
# Description

- Added new position for RelationsSlider
- Filter product properties by code if they don't have a label

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.
