### PR TITLE
app footer bar sticks to keyboard on android devices

### DIFF
--- a/themes/theme-ios11/pages/Browse/components/SearchField/index.jsx
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/index.jsx
@@ -16,10 +16,10 @@ import {
 import SearchIcon from '@shopgate/pwa-ui-shared/icons/MagnifierIcon';
 import BarcodeScannerIcon from '@shopgate/pwa-ui-shared/icons/BarcodeScannerIcon';
 import { router } from '@virtuous/conductor';
+import TabBar from 'Components/TabBar';
 import SuggestionList from './components/SuggestionList';
 import connect from './connector';
 import styles from './style';
-import TabBar from '../../../../components/TabBar';
 
 const SUGGESTIONS_MIN = 1;
 
@@ -138,16 +138,14 @@ class SearchField extends Component {
     // for testing purposes. we've faced an issue
     // where the keyboard will be shown for a few
     // milliseconds and then it'll hide.
-    const bufferTimeout = 0;
+    const bufferTimeout = 100;
 
     if (!focused) {
       setTimeout(() => {
         TabBar.show();
       }, bufferTimeout);
     } else {
-      setTimeout(() => {
-        TabBar.hide();
-      }, bufferTimeout);
+      TabBar.hide();
     }
 
     clearTimeout(this.onBlurTimeout);

--- a/themes/theme-ios11/pages/Browse/components/SearchField/index.jsx
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/index.jsx
@@ -19,6 +19,7 @@ import { router } from '@virtuous/conductor';
 import SuggestionList from './components/SuggestionList';
 import connect from './connector';
 import styles from './style';
+import TabBar from '../../../../components/TabBar';
 
 const SUGGESTIONS_MIN = 1;
 
@@ -134,6 +135,21 @@ class SearchField extends Component {
    * @param {boolean} focused Whether the element currently became focused.
    */
   handleFocusChange = (focused) => {
+    // for testing purposes. we've faced an issue
+    // where the keyboard will be shown for a few
+    // milliseconds and then it'll hide.
+    const bufferTimeout = 0;
+
+    if (!focused) {
+      setTimeout(() => {
+        TabBar.show();
+      }, bufferTimeout);
+    } else {
+      setTimeout(() => {
+        TabBar.hide();
+      }, bufferTimeout);
+    }
+
     clearTimeout(this.onBlurTimeout);
     this.onBlurTimeout = !focused ?
       setTimeout(() => {

--- a/themes/theme-ios11/pages/Browse/components/SearchField/index.jsx
+++ b/themes/theme-ios11/pages/Browse/components/SearchField/index.jsx
@@ -127,7 +127,7 @@ class SearchField extends Component {
    * @param {boolean} focused Whether the element currently became focused.
    */
   handleFocusChange = (focused) => {
-    // for testing purposes. we've faced an issue
+    // we've faced an issue
     // where the keyboard will be shown for a few
     // milliseconds and then it'll hide.
     const bufferTimeout = 100;


### PR DESCRIPTION
# Description

fixes the issue with menu bar sticking to keyboard even when searching

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.
