### PR TITLE
Add portals to EffectivityDates (CURB)

### DIFF
--- a/libraries/commerce/product/constants/Portals.js
+++ b/libraries/commerce/product/constants/Portals.js
@@ -29,6 +29,7 @@ const PRICE = 'price';
 const PRICE_INFO = 'price-info';
 const MAP_PRICE = 'map-price';
 const ORDER_QUANTITY = 'order-quantity';
+const EFFECTIVITY_DATES = 'effectivity-dates';
 const UNIT_QUANTITY_PICKER = 'unit-quantity-picker';
 const TIERS = 'tiers';
 const ADD_TO_CART_BAR = 'add-to-cart-bar';
@@ -186,6 +187,7 @@ export const PRODUCT_MAP_PRICE_AFTER = `${PRODUCT}.${MAP_PRICE}.${AFTER}`;
 // ORDER QUANTITY HINT
 export const PRODUCT_ORDER_QUANTITY_BEFORE = `${PRODUCT}.${ORDER_QUANTITY}.${BEFORE}`;
 export const PRODUCT_ORDER_QUANTITY = `${PRODUCT}.${ORDER_QUANTITY}`;
+export const PRODUCT_EFFECTIVITY_DATES = `${PRODUCT}.${EFFECTIVITY_DATES}`;
 export const PRODUCT_ORDER_QUANTITY_AFTER = `${PRODUCT}.${ORDER_QUANTITY}.${AFTER}`;
 
 export const PRODUCT_UNIT_QUANTITY_PICKER = `${PRODUCT}.${UNIT_QUANTITY_PICKER}`;

--- a/libraries/engage/product/components/EffectivityDates/index.jsx
+++ b/libraries/engage/product/components/EffectivityDates/index.jsx
@@ -2,8 +2,13 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { css } from 'glamor';
-import { isBeta, useWidgetSettings, useWidgetStyles } from '@shopgate/engage/core';
-import { I18n, TimeBoundary } from '@shopgate/engage/components';
+import {
+  isBeta,
+  useWidgetSettings,
+  useWidgetStyles,
+} from '@shopgate/engage/core';
+import { I18n, TimeBoundary, SurroundPortals } from '@shopgate/engage/components';
+import { PRODUCT_EFFECTIVITY_DATES } from '@shopgate/pwa-common-commerce/product/constants/Portals';
 import { showExpiringLabel, showScheduledLabel } from './helpers';
 import { hint, notAvailable } from './style';
 import connect from './connector';
@@ -13,8 +18,8 @@ import connect from './connector';
  * @return {JSX}
  */
 const EffectivityDates = ({
-  dates, children, productNotAvailable,
-}) => {
+                            dates, children, productNotAvailable, productId,
+                          }) => {
   if (!isBeta() || !dates) {
     return children;
   }
@@ -29,35 +34,40 @@ const EffectivityDates = ({
   const hintClass = classNames(hint, hintAddClass);
 
   return (
-    <TimeBoundary start={startDate} end={endDate}>
-      {({ before, between, after }) => {
-        if (before) {
-          return showScheduledLabel(startDate, settings)
-            ? <I18n.Text string="product.available.at" params={{ startDate }} className={hintClass} />
-            : children;
-        }
+    <SurroundPortals
+      portalName={PRODUCT_EFFECTIVITY_DATES}
+      portalProps={{ dates, productNotAvailable, productId }}
+    >
+      <TimeBoundary start={startDate} end={endDate}>
+        {({ before, between, after }) => {
+          if (before) {
+            return showScheduledLabel(startDate, settings)
+              ? <I18n.Text string="product.available.at" params={{ startDate }} className={hintClass} />
+              : children;
+          }
 
-        if (between) {
-          return (
-            <Fragment>
-              {children}
-              {showExpiringLabel(endDate, settings) &&
-                <I18n.Text string="product.available.until" params={{ endDate }} className={hintClass} />
-              }
-            </Fragment>
-          );
-        }
+          if (between) {
+            return (
+              <Fragment>
+                {children}
+                {showExpiringLabel(endDate, settings) &&
+                  <I18n.Text string="product.available.until" params={{ endDate }} className={hintClass} />
+                }
+              </Fragment>
+            );
+          }
 
-        if (after) {
-          productNotAvailable();
+          if (after) {
+            productNotAvailable();
 
-          return showExpiringLabel(endDate, settings)
-            ? <I18n.Text string="product.available.not" className={notAvailable} />
-            : children;
-        }
-        return children;
-      }}
-    </TimeBoundary>
+            return showExpiringLabel(endDate, settings)
+              ? <I18n.Text string="product.available.not" className={hintClass} />
+              : children;
+          }
+          return children;
+        }}
+      </TimeBoundary>
+    </SurroundPortals>
   );
 };
 
@@ -68,6 +78,7 @@ EffectivityDates.propTypes = {
     startDate: PropTypes.string,
     endDate: PropTypes.string,
   }),
+  productId: PropTypes.string,
 };
 
 EffectivityDates.defaultProps = {


### PR DESCRIPTION
# Description

- surround EffectivityDates in Surround Portals
- update portal constants

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.
