### PR TITLE
Add functionality to style widgets via theme config without page context

### DIFF
--- a/libraries/engage/core/config/__tests__/getThemeStyles.spec.js
+++ b/libraries/engage/core/config/__tests__/getThemeStyles.spec.js
@@ -1,0 +1,56 @@
+import { getThemeStyles } from '../getThemeStyles';
+import { getThemeConfig } from '../getThemeConfig';
+
+jest.mock('../getThemeConfig', () => ({
+  getThemeConfig: jest.fn(),
+}));
+
+describe('engage > core > config', () => {
+  describe('getThemeStyles()', () => {
+    it('should return an empty object if no styles property exists', () => {
+      getThemeConfig.mockReturnValueOnce({});
+      const styles = getThemeStyles();
+      expect(styles).toEqual({});
+    });
+
+    it('should return all styles if no key is given', () => {
+      const mockStyles = {
+        '@shopgate/engage/product/ProductGrid': {
+          color: 'red',
+        },
+        '@shopgate/engage/product/ProductSlider': {
+          color: 'blue',
+        },
+      };
+      getThemeConfig.mockReturnValueOnce({
+        styles: mockStyles,
+      });
+      const styles = getThemeStyles();
+      expect(styles).toEqual(mockStyles);
+    });
+
+    it('should return specific styles if key is given', () => {
+      const mockStyles = {
+        '@shopgate/engage/product/ProductGrid': {
+          color: 'red',
+        },
+        '@shopgate/engage/product/ProductSlider': {
+          color: 'blue',
+        },
+      };
+      getThemeConfig.mockReturnValueOnce({
+        styles: mockStyles,
+      });
+      const styles = getThemeStyles('@shopgate/engage/product/ProductSlider');
+      expect(styles).toEqual({
+        color: 'blue',
+      });
+    });
+
+    it('should return undefined if key is no available', () => {
+      getThemeConfig.mockReturnValueOnce({});
+      const styles = getThemeStyles('keyNotAvailable');
+      expect(styles).toBeUndefined();
+    });
+  });
+});

--- a/libraries/engage/core/config/getThemeStyles.js
+++ b/libraries/engage/core/config/getThemeStyles.js
@@ -1,0 +1,12 @@
+import { getThemeConfig } from './getThemeConfig';
+
+/**
+ * Retrieves the global theme styles. Returns undefined when the given key doesn't exist there.
+ *
+ * @param {string|null} [key=null] settings key
+ * @returns {Object|undefined|*}
+ */
+export function getThemeStyles(key = null) {
+  const { styles = {} } = getThemeConfig();
+  return key ? styles[key] : styles;
+}

--- a/libraries/engage/core/config/index.js
+++ b/libraries/engage/core/config/index.js
@@ -35,5 +35,6 @@ export { getThemeAssets } from './getThemeAssets';
 export { getThemeColors } from './getThemeColors';
 export { getThemeConfig } from './getThemeConfig';
 export { getThemeSettings } from './getThemeSettings';
+export { getThemeStyles } from './getThemeStyles';
 export { getWidgetConfig } from './getWidgetConfig';
 export { getWidgetSettings } from './getWidgetSettings';

--- a/libraries/engage/core/hooks/__tests__/useWidgetStyles.spec.js
+++ b/libraries/engage/core/hooks/__tests__/useWidgetStyles.spec.js
@@ -1,8 +1,13 @@
 import { useWidgetStyles } from '../useWidgetStyles';
 import { useWidgetConfig } from '../useWidgetConfig';
+import { getThemeStyles } from '../../config';
 
 jest.mock('../useWidgetConfig', () => ({
   useWidgetConfig: jest.fn(),
+}));
+
+jest.mock('../../config/getThemeStyles', () => ({
+  getThemeStyles: jest.fn(),
 }));
 
 describe('engage > core > hooks', () => {
@@ -13,12 +18,14 @@ describe('engage > core > hooks', () => {
 
     it('should return an empty object if no styles property exists', () => {
       useWidgetConfig.mockReturnValueOnce({});
+      getThemeStyles.mockReturnValueOnce({});
       const styles = useWidgetStyles();
       expect(styles).toEqual({});
     });
 
     it('should return an empty object if no styles exist', () => {
       useWidgetConfig.mockReturnValueOnce({ style: {} });
+      getThemeStyles.mockReturnValueOnce({});
       const styles = useWidgetStyles();
       expect(styles).toEqual({});
     });
@@ -30,6 +37,8 @@ describe('engage > core > hooks', () => {
           width: '100%',
         },
       });
+      getThemeStyles.mockReturnValueOnce({});
+
       const styles = useWidgetStyles();
       expect(styles).toEqual({
         color: '#ff0000',
@@ -37,11 +46,52 @@ describe('engage > core > hooks', () => {
       });
     });
 
+    it('should return all theme styles.', () => {
+      useWidgetConfig.mockReturnValueOnce({
+        styles: {},
+      });
+      getThemeStyles.mockReturnValueOnce({
+        color: '#ff0000',
+        width: '100%',
+      });
+
+      const styles = useWidgetStyles();
+      expect(styles).toEqual({
+        color: '#ff0000',
+        width: '100%',
+      });
+    });
+
+    it('should return merged  widget/theme styles.', () => {
+      useWidgetConfig.mockReturnValueOnce({
+        styles: {
+          color: '#666666',
+          height: '100%',
+        },
+      });
+      getThemeStyles.mockReturnValueOnce({
+        color: '#ff0000',
+        width: '100%',
+      });
+
+      const styles = useWidgetStyles();
+      expect(styles).toEqual({
+        color: '#666666',
+        width: '100%',
+        height: '100%',
+      });
+    });
+
     it('should pass down its given params to the lower level helper function.', () => {
       useWidgetConfig.mockReturnValueOnce({});
+      getThemeStyles.mockReturnValueOnce({});
+
       useWidgetStyles('widgetId', 3);
+
       expect(useWidgetConfig).toBeCalledWith('widgetId', 3);
       expect(useWidgetConfig).toBeCalledTimes(1);
+      expect(getThemeStyles).toBeCalledWith('widgetId');
+      expect(getThemeStyles).toBeCalledTimes(1);
     });
   });
 });

--- a/libraries/engage/core/hooks/useWidgetStyles.js
+++ b/libraries/engage/core/hooks/useWidgetStyles.js
@@ -1,6 +1,6 @@
 import defaultsDeep from 'lodash/defaultsDeep';
 import { useWidgetConfig } from './useWidgetConfig';
-import { getThemeStyles } from '../config/getThemeStyles';
+import { getThemeStyles } from '../config';
 
 /**
  * Retrieves the styles for a specific widget by its id. Returns an empty object when no styles
@@ -14,5 +14,5 @@ export function useWidgetStyles(widgetId, index = 0) {
   const { styles = {} } = useWidgetConfig(widgetId, index);
 
   const globalStyles = getThemeStyles(widgetId);
-  return defaultsDeep(globalStyles, styles);
+  return defaultsDeep(styles, globalStyles);
 }

--- a/libraries/engage/core/hooks/useWidgetStyles.js
+++ b/libraries/engage/core/hooks/useWidgetStyles.js
@@ -1,4 +1,6 @@
+import defaultsDeep from 'lodash/defaultsDeep';
 import { useWidgetConfig } from './useWidgetConfig';
+import { getThemeStyles } from '../config/getThemeStyles';
 
 /**
  * Retrieves the styles for a specific widget by its id. Returns an empty object when no styles
@@ -10,5 +12,7 @@ import { useWidgetConfig } from './useWidgetConfig';
  */
 export function useWidgetStyles(widgetId, index = 0) {
   const { styles = {} } = useWidgetConfig(widgetId, index);
-  return styles;
+
+  const globalStyles = getThemeStyles(widgetId);
+  return defaultsDeep(globalStyles, styles);
 }

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -275,6 +275,7 @@
             "slidesPerView": 2.3
           }
         },
+        "styles": {},
         "typography": {
           "family": "Roboto, Arial, sans-serif",
           "rootSize": 16,

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -266,6 +266,7 @@
             "slidesPerView": 2.3
           }
         },
+        "styles": {},
         "typography": {
           "family": "system, -apple-system, \"SF Pro Display\", \"Helvetica Neue\", \"Lucida Grande\"",
           "rootSize": 17,


### PR DESCRIPTION
# Description

To style a widget via the theme there was only the option to do this via a page config.

Now widgets can be styled globally via the theme.
An already existing page styling remains available and overwrites the theme styling if necessary.

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Try to create page specific styles and theme styles for a selected widget and check if page styling overwrites theme styling.
