### PR TITLE
Fix FilterBar / ScrollHeader styling to work with persistent-search-bar

### DIFF
--- a/libraries/engage/components/ScrollHeader/index.jsx
+++ b/libraries/engage/components/ScrollHeader/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { viewScroll$ } from '@shopgate/pwa-common/streams/view';
-import { scrolledOut } from './style';
+import { scrolledIn, scrolledOut, transition } from './style';
 
 /**
  * Scroll Header component
@@ -34,11 +34,11 @@ function ScrollHeader({ children, hideOnScroll, scrollOffset }) {
     return undefined;
   });
 
-  const className = shouldHideHeader ? scrolledOut : '';
+  const className = shouldHideHeader ? scrolledOut : scrolledIn;
 
   return React.cloneElement(children, {
     ...children.props,
-    className: `${children.props.className.toString()} ${className}`,
+    className: `${children.props.className.toString()} ${className} ${transition}`,
   });
 }
 

--- a/libraries/engage/components/ScrollHeader/index.jsx
+++ b/libraries/engage/components/ScrollHeader/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { viewScroll$ } from '@shopgate/pwa-common/streams/view';
-import { scrolledIn, scrolledOut } from './style';
+import { scrolledOut } from './style';
 
 /**
  * Scroll Header component
@@ -34,7 +34,7 @@ function ScrollHeader({ children, hideOnScroll, scrollOffset }) {
     return undefined;
   });
 
-  const className = shouldHideHeader ? scrolledOut : scrolledIn;
+  const className = shouldHideHeader ? scrolledOut : '';
 
   return React.cloneElement(children, {
     ...children.props,

--- a/libraries/engage/components/ScrollHeader/style.js
+++ b/libraries/engage/components/ScrollHeader/style.js
@@ -11,6 +11,7 @@ const fadeIn = css.keyframes({
   '100%': { opacity: 1, top: 0 },
 });
 
+// todo: check if still in use
 export const scrolledIn = css({
   '&&': {
     animation: `${fadeIn} .2s`,

--- a/libraries/engage/components/ScrollHeader/style.js
+++ b/libraries/engage/components/ScrollHeader/style.js
@@ -1,27 +1,17 @@
 import { css } from 'glamor';
 
-const fadeOut = css.keyframes({
-  '0%': { opacity: 1 },
-  '99%': { opacity: 0.01, top: 0 },
-  '100%': { opacity: 0, top: '-20%' },
-});
-const fadeIn = css.keyframes({
-  '0%': { opacity: 0, top: '-20%' },
-  '1%': { opacity: 0.01, top: 0 },
-  '100%': { opacity: 1, top: 0 },
-});
-
-// todo: check if still in use
 export const scrolledIn = css({
   '&&': {
-    animation: `${fadeIn} .2s`,
-    animationFillMode: 'forwards',
+    transform: 'translateY(0%)',
   },
 }).toString();
 
 export const scrolledOut = css({
   '&&': {
-    animation: `${fadeOut} .2s`,
-    animationFillMode: 'forwards',
+    transform: 'translateY(-250%)',
   },
 }).toString();
+
+export const transition = css({
+  transition: 'transform 0.2s ease,transform 0.2s',
+});

--- a/themes/theme-gmd/components/FilterBar/index.jsx
+++ b/themes/theme-gmd/components/FilterBar/index.jsx
@@ -1,10 +1,11 @@
 import React, {
-  useState, useEffect, useMemo, memo,
+  useState, useEffect, useMemo, memo, useRef, useLayoutEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import { useWidgetSettings } from '@shopgate/engage/core';
 import { ScrollHeader } from '@shopgate/engage/components';
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
+import get from 'lodash/get';
 import Content from './components/Content';
 import styles from './style';
 
@@ -18,6 +19,16 @@ const { colors, variables: { scroll: { offset = 100 } = {} } } = themeConfig || 
 function FilterBar({ filters }) {
   const { hideOnScroll } = useWidgetSettings('@shopgate/engage/components/FilterBar');
   const [active, setActive] = useState(filters !== null && Object.keys(filters).length > 0);
+  const [offsetTop, setOffsetTop] = useState(0);
+
+  const containerRef = useRef();
+
+  useLayoutEffect(() => {
+    const currentOffset = get(containerRef, 'current.offsetTop');
+    if (offsetTop === 0 && offsetTop !== currentOffset) {
+      setOffsetTop(currentOffset);
+    }
+  });
 
   useEffect(() => {
     setActive(filters !== null && Object.keys(filters).length > 0);
@@ -28,9 +39,14 @@ function FilterBar({ filters }) {
     color: active ? colors.accentContrast : colors.dark,
   }), [active]);
 
+  const inlineStyle = {
+    ...style,
+    top: offsetTop || -2,
+  };
+
   return (
     <ScrollHeader hideOnScroll={hideOnScroll} scrollOffset={offset}>
-      <div className={`${styles} theme__filter-bar`} data-test-id="filterBar" style={style}>
+      <div className={`${styles} theme__filter-bar`} data-test-id="filterBar" style={inlineStyle} ref={containerRef}>
         <Content />
       </div>
     </ScrollHeader>

--- a/themes/theme-ios11/components/FilterBar/index.jsx
+++ b/themes/theme-ios11/components/FilterBar/index.jsx
@@ -1,6 +1,7 @@
 import React, {
-  useState, useEffect, useMemo, memo,
+  useState, useEffect, useMemo, memo, useRef, useLayoutEffect,
 } from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import { useWidgetSettings } from '@shopgate/engage/core';
 import { ScrollHeader } from '@shopgate/engage/components';
@@ -18,6 +19,14 @@ const { colors, variables: { scroll: { offset = 100 } = {} } } = themeConfig || 
 function FilterBar({ filters }) {
   const { hideOnScroll } = useWidgetSettings('@shopgate/engage/components/FilterBar');
   const [active, setActive] = useState(filters !== null && Object.keys(filters).length > 0);
+  const [offsetTop, setOffsetTop] = useState(0);
+
+  const containerRef = useRef();
+
+  useLayoutEffect(() => {
+    const currentOffset = get(containerRef, 'current.offsetTop');
+    setOffsetTop(currentOffset);
+  });
 
   useEffect(() => {
     setActive(filters !== null && Object.keys(filters).length > 0);
@@ -28,9 +37,14 @@ function FilterBar({ filters }) {
     color: active ? colors.accentContrast : colors.dark,
   }), [active]);
 
+  const inlineStyle = {
+    ...style,
+    top: offsetTop || -2,
+  };
+
   return (
     <ScrollHeader hideOnScroll={hideOnScroll} scrollOffset={offset}>
-      <div className={`${styles} theme__filter-bar`} data-test-id="filterBar" style={style}>
+      <div className={`${styles} theme__filter-bar`} data-test-id="filterBar" style={inlineStyle} ref={containerRef}>
         <Content />
       </div>
     </ScrollHeader>

--- a/themes/theme-ios11/components/FilterBar/index.jsx
+++ b/themes/theme-ios11/components/FilterBar/index.jsx
@@ -24,8 +24,8 @@ function FilterBar({ filters }) {
   const containerRef = useRef();
 
   useLayoutEffect(() => {
-    if (offsetTop === 0) {
-      const currentOffset = get(containerRef, 'current.offsetTop');
+    const currentOffset = get(containerRef, 'current.offsetTop');
+    if (offsetTop === 0 && offsetTop !== currentOffset) {
       setOffsetTop(currentOffset);
     }
   });

--- a/themes/theme-ios11/components/FilterBar/index.jsx
+++ b/themes/theme-ios11/components/FilterBar/index.jsx
@@ -24,8 +24,10 @@ function FilterBar({ filters }) {
   const containerRef = useRef();
 
   useLayoutEffect(() => {
-    const currentOffset = get(containerRef, 'current.offsetTop');
-    setOffsetTop(currentOffset);
+    if (offsetTop === 0) {
+      const currentOffset = get(containerRef, 'current.offsetTop');
+      setOffsetTop(currentOffset);
+    }
   });
 
   useEffect(() => {

--- a/themes/theme-ios11/components/FilterBar/style.js
+++ b/themes/theme-ios11/components/FilterBar/style.js
@@ -4,7 +4,8 @@ import { themeShadows } from '@shopgate/pwa-common/helpers/config';
 export default css({
   boxShadow: themeShadows.material,
   position: 'sticky',
-  top: '-2px', // behind header shadow
+  // todo: top has to be set dynamic depending on whether persistent-search-bar is installed or not
+  top: '56px', // top: '-2px', // behind header shadow
   left: 0,
   zIndex: 1,
 });

--- a/themes/theme-ios11/components/FilterBar/style.js
+++ b/themes/theme-ios11/components/FilterBar/style.js
@@ -4,8 +4,6 @@ import { themeShadows } from '@shopgate/pwa-common/helpers/config';
 export default css({
   boxShadow: themeShadows.material,
   position: 'sticky',
-  // todo: top has to be set dynamic depending on whether persistent-search-bar is installed or not
-  top: '56px', // top: '-2px', // behind header shadow
   left: 0,
   zIndex: 1,
 });


### PR DESCRIPTION
# Description

FilterBar scrolled behind persistent-search-bar (if extension attached) so far.
Fixed styling for FilterBar & ScrollHeader to consider availability of persistent-search-bar

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Look at a page with ProductGrid and check if FilterBar appears / hides as expected.
Test with persistent-search-bar extension attached & detached and check if both variants work well