### PR TITLE
ScrollHeader adapted so that it also works multiple times on the page

### DIFF
--- a/libraries/engage/components/ScrollHeader/index.jsx
+++ b/libraries/engage/components/ScrollHeader/index.jsx
@@ -4,7 +4,7 @@ import React, {
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import get from 'lodash/get';
-import { useScroll } from '@shopgate/engage/core';
+import { useScroll, hasWebBridge } from '@shopgate/engage/core';
 import { header, hidden } from './style';
 import { ViewContext } from '../View';
 
@@ -36,8 +36,10 @@ function ScrollHeader({ className, children }) {
   useScroll(onScroll, contentRef?.current);
 
   useEffect(() => {
-    const currentOffset = get(ref, 'current.offsetTop');
-    setOffsetTop(currentOffset);
+    if (!hasWebBridge()) {
+      const currentOffset = get(ref, 'current.offsetTop');
+      setOffsetTop(currentOffset);
+    }
   }, []);
 
   return (
@@ -48,7 +50,7 @@ function ScrollHeader({ className, children }) {
         shouldHideHeader && hidden,
         className
       )}
-      style={{ top: offsetTop }}
+      style={offsetTop ? { top: offsetTop } : {}}
     >
       {children}
     </div>

--- a/libraries/engage/components/ScrollHeader/index.jsx
+++ b/libraries/engage/components/ScrollHeader/index.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useState, useContext, useRef, useCallback, useLayoutEffect,
+  useState, useContext, useRef, useCallback, useEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -33,15 +33,13 @@ function ScrollHeader({ className, children }) {
     }
   }, [offset]);
 
-  useLayoutEffect(() => {
-    const currentOffset = get(ref, 'current.offsetTop');
-    // todo currentOffset > 10 !!! not good
-    if (offsetTop === 0 && offset === 0 && offsetTop !== currentOffset && currentOffset > 10) {
-      setOffsetTop(currentOffset);
-    }
-  });
-
   useScroll(onScroll, contentRef?.current);
+
+  useEffect(() => {
+    const currentOffset = get(ref, 'current.offsetTop');
+    setOffsetTop(currentOffset);
+  }, []);
+
   return (
     <div
       ref={ref}

--- a/libraries/engage/components/ScrollHeader/index.jsx
+++ b/libraries/engage/components/ScrollHeader/index.jsx
@@ -1,8 +1,9 @@
 import React, {
-  useState, useContext, useRef, useCallback,
+  useState, useContext, useRef, useCallback, useLayoutEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import get from 'lodash/get';
 import { useScroll } from '@shopgate/engage/core';
 import { header, hidden } from './style';
 import { ViewContext } from '../View';
@@ -17,6 +18,7 @@ function ScrollHeader({ className, children }) {
   const [shouldHideHeader, setShouldHideHeader] = useState(false);
   const { contentRef } = useContext(ViewContext);
   const [offset, setOffset] = useState(0);
+  const [offsetTop, setOffsetTop] = useState(0);
 
   const onScroll = useCallback((callbackData) => {
     const { previousScrollTop, currentScrollTop } = callbackData;
@@ -31,6 +33,14 @@ function ScrollHeader({ className, children }) {
     }
   }, [offset]);
 
+  useLayoutEffect(() => {
+    const currentOffset = get(ref, 'current.offsetTop');
+    // todo currentOffset > 10 !!! not good
+    if (offsetTop === 0 && offset === 0 && offsetTop !== currentOffset && currentOffset > 10) {
+      setOffsetTop(currentOffset);
+    }
+  });
+
   useScroll(onScroll, contentRef?.current);
   return (
     <div
@@ -40,6 +50,7 @@ function ScrollHeader({ className, children }) {
         shouldHideHeader && hidden,
         className
       )}
+      style={{ top: offsetTop }}
     >
       {children}
     </div>

--- a/libraries/engage/components/ScrollHeader/style.js
+++ b/libraries/engage/components/ScrollHeader/style.js
@@ -3,7 +3,6 @@ import { responsiveMediaQuery } from '@shopgate/engage/styles';
 
 export const header = css({
   position: 'sticky',
-  top: 0,
   left: 0,
   backgroundColor: '#fff',
   transform: 'translateY(0)',

--- a/libraries/engage/components/ScrollHeader/style.js
+++ b/libraries/engage/components/ScrollHeader/style.js
@@ -14,6 +14,6 @@ export const header = css({
 }).toString();
 
 export const hidden = css({
-  transform: 'translateY(-110%)',
+  transform: 'translateY(-250%)',
 }).toString();
 

--- a/themes/theme-gmd/pages/Category/components/Content/index.jsx
+++ b/themes/theme-gmd/pages/Category/components/Content/index.jsx
@@ -14,9 +14,9 @@ import AppBar from '../AppBar';
 const CategoryContent = ({ categoryId, hasChildren, hasProducts }) => (
   <Fragment>
     <AppBar hasProducts={hasProducts} hasChildren={hasChildren} categoryId={categoryId} />
+    <ProductFilters categoryId={categoryId} showFilters={hasProducts} />
     <CategoryListContent categoryId={categoryId} />
 
-    <ProductFilters categoryId={categoryId} showFilters={hasProducts} />
     <ProductsContent categoryId={categoryId} hasProducts={hasProducts} />
     <Empty
       categoryId={categoryId}

--- a/themes/theme-ios11/pages/Category/components/Content/index.jsx
+++ b/themes/theme-ios11/pages/Category/components/Content/index.jsx
@@ -14,9 +14,9 @@ import AppBar from '../AppBar';
 const CategoryContent = ({ categoryId, hasChildren, hasProducts }) => (
   <Fragment>
     <AppBar hasProducts={hasProducts} hasChildren={hasChildren} categoryId={categoryId} />
+    <ProductFilters categoryId={categoryId} showFilters={hasProducts} />
     <CategoryListContent categoryId={categoryId} />
 
-    <ProductFilters categoryId={categoryId} showFilters={hasProducts} />
     <ProductsContent categoryId={categoryId} hasProducts={hasProducts} />
     <Empty
       categoryId={categoryId}


### PR DESCRIPTION
# Description

Adapt ScrollHeader styling.
Now works if multiple ScrollHeaders are on the same page ( e.g. FilterBar & persistent-search-bar)


## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Look at a page with ProductGrid and check if FilterBar appears / hides as expected.
Test with persistent-search-bar extension attached & detached and check if both variants work well
