### PR TITLE
Prevent product detail reloads, validate quantity

### DIFF
--- a/libraries/engage/product/components/UnitQuantityPicker/ProductUnitQuantityPicker.jsx
+++ b/libraries/engage/product/components/UnitQuantityPicker/ProductUnitQuantityPicker.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import classNames from 'classnames';
@@ -62,6 +62,24 @@ const ProductUnitQuantityPicker = ({
     };
   }, [stockInfo]);
 
+  /**
+   * Validates an value based on minValue & maxValue and corrects it if necessary
+   * @param {number} val The value to be tested / adjusted
+   * @returns {number}
+   */
+  const validateQuantity = (val) => {
+    if (minValue && val < minValue) return minValue;
+    if (maxValue && val > maxValue) return maxValue;
+    return val;
+  };
+
+  useEffect(() => {
+    const validatedQuantity = validateQuantity(quantity);
+    if (validatedQuantity !== quantity) {
+      setQuantity(validatedQuantity);
+    }
+  }, [quantity, minValue, maxValue, validateQuantity, setQuantity]);
+
   if (!product) {
     return null;
   }
@@ -79,7 +97,7 @@ const ProductUnitQuantityPicker = ({
             maxDecimals={hasUnitWithDecimals ? 2 : 0}
             incrementStep={hasUnitWithDecimals ? 0.25 : 1}
             decrementStep={hasUnitWithDecimals ? 0.25 : 1}
-            onChange={setQuantity}
+            onChange={value => setQuantity(value)}
             value={quantity}
             disabled={disabled}
             minValue={minValue}

--- a/libraries/engage/product/components/UnitQuantityPicker/ProductUnitQuantityPicker.jsx
+++ b/libraries/engage/product/components/UnitQuantityPicker/ProductUnitQuantityPicker.jsx
@@ -97,7 +97,7 @@ const ProductUnitQuantityPicker = ({
             maxDecimals={hasUnitWithDecimals ? 2 : 0}
             incrementStep={hasUnitWithDecimals ? 0.25 : 1}
             decrementStep={hasUnitWithDecimals ? 0.25 : 1}
-            onChange={value => setQuantity(value)}
+            onChange={setQuantity}
             value={quantity}
             disabled={disabled}
             minValue={minValue}

--- a/themes/theme-gmd/pages/Product/components/Content/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Content/index.jsx
@@ -85,7 +85,6 @@ class ProductContent extends PureComponent {
       productId,
       variantId,
       currency: nextProps.currency,
-      quantity: 1,
       ...(productIdChanged && {
         options: {},
         optionsPrices: {},

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -85,7 +85,9 @@ class ProductImageSlider extends Component {
     if (depImage) {
       // if depImage has not changed since last time
       if (this.state.depImage === depImage) {
-        if (this.mediaRef.current) this.mediaRef.current.style.filter = 'none';
+        if (this.mediaRef.current) {
+          this.mediaRef.current.style.filter = 'none';
+        }
         return true;
       }
       // Blur for image load
@@ -169,8 +171,11 @@ class ProductImageSlider extends Component {
 
     if (!content) {
       let src = null;
-      if (product && product.featuredImageBaseUrl) src = product.featuredImageBaseUrl;
-      else if (images && images.length) [src] = images;
+      if (product && product.featuredImageBaseUrl) {
+        src = product.featuredImageBaseUrl;
+      } else if (images && images.length) {
+        [src] = images;
+      }
 
       content = (
         <ProductImage

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -48,6 +48,9 @@ class ProductImageSlider extends Component {
   constructor(props, context) {
     super(props, context);
     this.mediaRef = React.createRef(null);
+    this.state = {
+      depImage: null,
+    };
   }
 
   /**
@@ -80,10 +83,16 @@ class ProductImageSlider extends Component {
     }
 
     if (depImage) {
+      // if depImage has not changed since last time
+      if (this.state.depImage === depImage) {
+        if (this.mediaRef.current) this.mediaRef.current.style.filter = 'none';
+        return true;
+      }
       // Blur for image load
       if (this.mediaRef.current) {
         this.mediaRef.current.style.filter = 'blur(3px)';
       }
+      this.setState({ depImage });
       loadProductImage(depImage)
         .then(() => {
           if (this.mounted) {
@@ -159,16 +168,20 @@ class ProductImageSlider extends Component {
     let onClick = this.handleOpenGallery;
 
     if (!content) {
+      let src = null;
+      if (product && product.featuredImageBaseUrl) src = product.featuredImageBaseUrl;
+      else if (images && images.length) [src] = images;
+
       content = (
         <ProductImage
-          src={product ? product.featuredImageBaseUrl : null}
+          src={src}
           className={className}
-          forcePlaceholder={!product}
+          forcePlaceholder={!src}
           resolutions={pdpResolutions}
           noBackground
         />
       );
-      if (!product || !product.featuredImageBaseUrl) {
+      if (!src) {
         onClick = noop;
       }
     }

--- a/themes/theme-ios11/pages/Product/components/Content/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Content/index.jsx
@@ -86,7 +86,6 @@ class ProductContent extends PureComponent {
       productId,
       variantId,
       currency: nextProps.currency,
-      quantity: 1,
       ...(productIdChanged && {
         options: {},
         optionsPrices: {},

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -48,6 +48,9 @@ class ProductImageSlider extends Component {
   constructor(props, context) {
     super(props, context);
     this.mediaRef = React.createRef(null);
+    this.state = {
+      depImage: null,
+    };
   }
 
   /**
@@ -78,10 +81,16 @@ class ProductImageSlider extends Component {
       }
     }
     if (depImage) {
+      // if depImage has not changed since last time
+      if (this.state.depImage === depImage) {
+        if (this.mediaRef.current) this.mediaRef.current.style.filter = 'none';
+        return true;
+      }
       // Blur for image load
       if (this.mediaRef.current) {
         this.mediaRef.current.style.filter = 'blur(3px)';
       }
+      this.setState({ depImage });
       loadProductImage(depImage)
         .then(() => {
           if (this.mounted) {
@@ -155,16 +164,20 @@ class ProductImageSlider extends Component {
 
     let onClick = this.handleOpenGallery;
     if (!content) {
+      let src = null;
+      if (product && product.featuredImageBaseUrl) src = product.featuredImageBaseUrl;
+      else if (images && images.length) [src] = images;
+
       content = (
         <ProductImage
-          src={product ? product.featuredImageBaseUrl : null}
+          src={src}
           className={className}
-          forcePlaceholder={!product}
+          forcePlaceholder={!src}
           resolutions={pdpResolutions}
           noBackground
         />
       );
-      if (!product || !product.featuredImageBaseUrl) {
+      if (!src) {
         onClick = noop;
       }
     }

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -83,7 +83,9 @@ class ProductImageSlider extends Component {
     if (depImage) {
       // if depImage has not changed since last time
       if (this.state.depImage === depImage) {
-        if (this.mediaRef.current) this.mediaRef.current.style.filter = 'none';
+        if (this.mediaRef.current) {
+          this.mediaRef.current.style.filter = 'none';
+        }
         return true;
       }
       // Blur for image load
@@ -165,8 +167,11 @@ class ProductImageSlider extends Component {
     let onClick = this.handleOpenGallery;
     if (!content) {
       let src = null;
-      if (product && product.featuredImageBaseUrl) src = product.featuredImageBaseUrl;
-      else if (images && images.length) [src] = images;
+      if (product && product.featuredImageBaseUrl) {
+        src = product.featuredImageBaseUrl;
+      } else if (images && images.length) {
+        [src] = images;
+      }
 
       content = (
         <ProductImage


### PR DESCRIPTION
# Description

Prevent multiple Image reloads on ProductDetail.
Validate quantity (min/max) within ProductUnitQuantityPicker

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Open a specific ProductDetail page (few times in a row) and check if product image and quantity are persistent.
