### PR TITLE
Fix wrong FilterBar positioning if you navigate back from e.g. product detail

### DIFF
--- a/themes/theme-gmd/components/FilterBar/index.jsx
+++ b/themes/theme-gmd/components/FilterBar/index.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useState, useEffect, useMemo, memo, useRef, useLayoutEffect,
+  useState, useEffect, useMemo, memo, useRef,
 } from 'react';
 import PropTypes from 'prop-types';
 import { useWidgetSettings } from '@shopgate/engage/core';
@@ -23,12 +23,12 @@ function FilterBar({ filters }) {
 
   const containerRef = useRef();
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const currentOffset = get(containerRef, 'current.offsetTop');
     if (offsetTop === 0 && offsetTop !== currentOffset) {
       setOffsetTop(currentOffset);
     }
-  });
+  }, [offsetTop]);
 
   useEffect(() => {
     setActive(filters !== null && Object.keys(filters).length > 0);

--- a/themes/theme-ios11/components/FilterBar/index.jsx
+++ b/themes/theme-ios11/components/FilterBar/index.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useState, useEffect, useMemo, memo, useRef, useLayoutEffect,
+  useState, useEffect, useMemo, memo, useRef,
 } from 'react';
 import get from 'lodash/get';
 import PropTypes from 'prop-types';
@@ -23,12 +23,12 @@ function FilterBar({ filters }) {
 
   const containerRef = useRef();
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const currentOffset = get(containerRef, 'current.offsetTop');
     if (offsetTop === 0 && offsetTop !== currentOffset) {
       setOffsetTop(currentOffset);
     }
-  });
+  }, [offsetTop]);
 
   useEffect(() => {
     setActive(filters !== null && Object.keys(filters).length > 0);


### PR DESCRIPTION
# Description

Fix wrong FilterBar positioning if you navigate back from e.g. product detail.
This is an addition of the original FilterBar fix

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Browse and search for a product. Select an item from the list and go back to search list.
Check if the FilterBar is still displayed correctly.