### PR TITLE
Improve image refresh cycle in ProductImageSlider

### DIFF
--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -48,6 +48,9 @@ class ProductImageSlider extends Component {
   constructor(props, context) {
     super(props, context);
     this.mediaRef = React.createRef(null);
+    this.state = {
+      depImage: null,
+    };
   }
 
   /**
@@ -80,10 +83,16 @@ class ProductImageSlider extends Component {
     }
 
     if (depImage) {
+      // if depImage has not changed since last time
+      if (this.state.depImage === depImage) {
+        if (this.mediaRef.current) this.mediaRef.current.style.filter = 'none';
+        return true;
+      }
       // Blur for image load
       if (this.mediaRef.current) {
         this.mediaRef.current.style.filter = 'blur(3px)';
       }
+      this.setState({ depImage });
       loadProductImage(depImage)
         .then(() => {
           if (this.mounted) {
@@ -159,16 +168,19 @@ class ProductImageSlider extends Component {
     let onClick = this.handleOpenGallery;
 
     if (!content) {
+      let src = null;
+      if (product && product.featuredImageBaseUrl) src = product.featuredImageBaseUrl;
+      else if (images && images.length) [src] = images;
       content = (
         <ProductImage
-          src={product ? product.featuredImageBaseUrl : null}
+          src={src}
           className={className}
-          forcePlaceholder={!product}
+          forcePlaceholder={!src}
           resolutions={pdpResolutions}
           noBackground
         />
       );
-      if (!product || !product.featuredImageBaseUrl) {
+      if (!src) {
         onClick = noop;
       }
     }

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -85,7 +85,9 @@ class ProductImageSlider extends Component {
     if (depImage) {
       // if depImage has not changed since last time
       if (this.state.depImage === depImage) {
-        if (this.mediaRef.current) this.mediaRef.current.style.filter = 'none';
+        if (this.mediaRef.current) {
+          this.mediaRef.current.style.filter = 'none';
+        }
         return true;
       }
       // Blur for image load
@@ -169,8 +171,11 @@ class ProductImageSlider extends Component {
 
     if (!content) {
       let src = null;
-      if (product && product.featuredImageBaseUrl) src = product.featuredImageBaseUrl;
-      else if (images && images.length) [src] = images;
+      if (product && product.featuredImageBaseUrl) {
+        src = product.featuredImageBaseUrl;
+      } else if (images && images.length) {
+        [src] = images;
+      }
       content = (
         <ProductImage
           src={src}

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -48,6 +48,9 @@ class ProductImageSlider extends Component {
   constructor(props, context) {
     super(props, context);
     this.mediaRef = React.createRef(null);
+    this.state = {
+      depImage: null,
+    };
   }
 
   /**
@@ -78,10 +81,16 @@ class ProductImageSlider extends Component {
       }
     }
     if (depImage) {
+      // if depImage has not changed since last time
+      if (this.state.depImage === depImage) {
+        if (this.mediaRef.current) this.mediaRef.current.style.filter = 'none';
+        return true;
+      }
       // Blur for image load
       if (this.mediaRef.current) {
         this.mediaRef.current.style.filter = 'blur(3px)';
       }
+      this.setState({ depImage });
       loadProductImage(depImage)
         .then(() => {
           if (this.mounted) {
@@ -155,16 +164,20 @@ class ProductImageSlider extends Component {
 
     let onClick = this.handleOpenGallery;
     if (!content) {
+      let src = null;
+      if (product && product.featuredImageBaseUrl) src = product.featuredImageBaseUrl;
+      else if (images && images.length) [src] = images;
+
       content = (
         <ProductImage
-          src={product ? product.featuredImageBaseUrl : null}
+          src={src}
           className={className}
-          forcePlaceholder={!product}
+          forcePlaceholder={!src}
           resolutions={pdpResolutions}
           noBackground
         />
       );
-      if (!product || !product.featuredImageBaseUrl) {
+      if (!src) {
         onClick = noop;
       }
     }

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -83,7 +83,9 @@ class ProductImageSlider extends Component {
     if (depImage) {
       // if depImage has not changed since last time
       if (this.state.depImage === depImage) {
-        if (this.mediaRef.current) this.mediaRef.current.style.filter = 'none';
+        if (this.mediaRef.current) {
+          this.mediaRef.current.style.filter = 'none';
+        }
         return true;
       }
       // Blur for image load
@@ -165,8 +167,11 @@ class ProductImageSlider extends Component {
     let onClick = this.handleOpenGallery;
     if (!content) {
       let src = null;
-      if (product && product.featuredImageBaseUrl) src = product.featuredImageBaseUrl;
-      else if (images && images.length) [src] = images;
+      if (product && product.featuredImageBaseUrl) {
+        src = product.featuredImageBaseUrl;
+      } else if (images && images.length) {
+        [src] = images;
+      }
 
       content = (
         <ProductImage


### PR DESCRIPTION
# Description

Improve image refresh cycle in ProductImageSlider

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Open a specific ProductDetail page (few times in a row) and check product image.
In a specific scenario where variant had no images and parent had only one image the product image was not displayed correctly.