### PR TITLE
Reset default <button> color introduced with iOS15

### DIFF
--- a/libraries/common/styles/reset/form.js
+++ b/libraries/common/styles/reset/form.js
@@ -11,6 +11,11 @@ css.global('button, html [type="button"], [type="reset"], [type="submit"]', {
   WebkitAppearance: 'button',
 });
 
+// since iOS 15 button has a default color of blue rgb(0, 122, 255);
+css.global('button', {
+  color: 'inherit',
+});
+
 /**
  * 1. Change font properties to `inherit` in Safari.
  * 2. Correct the inability to style clickable types in iOS and Safari.


### PR DESCRIPTION
# Description

Reset default `<button>` color introduced with iOS15

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.
