### PR TITLE
Add option to disable the favorite badge icon counter in TabBar

### DIFF
--- a/themes/theme-ios11/components/TabBar/components/FavoritesAction/components/FavoritesIconBadge/index.jsx
+++ b/themes/theme-ios11/components/TabBar/components/FavoritesAction/components/FavoritesIconBadge/index.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { withWidgetSettings } from '@shopgate/engage/core';
 import connect from './connector';
 import style from './style';
 
@@ -11,10 +12,16 @@ export class FavoritesIconBadge extends Component {
 
   static propTypes = {
     favoritesCount: PropTypes.number,
+    widgetSettings: PropTypes.shape({
+      showCounter: PropTypes.bool,
+    }),
   };
 
   static defaultProps = {
     favoritesCount: 0,
+    widgetSettings: {
+      showCounter: true,
+    },
   };
 
   /**
@@ -41,9 +48,15 @@ export class FavoritesIconBadge extends Component {
    * @returns {JSX}
    */
   render() {
+    const { showCounter } = this.props.widgetSettings;
     if (this.props.favoritesCount === 0) {
       return null;
     }
+
+    if (showCounter === false) {
+      return <div className={`${style} theme__tab-bar__favorites-icon-badge theme__badge`} />;
+    }
+
     const number = (this.props.favoritesCount > this.constructor.MAX_NUMBER) ?
       `${this.constructor.MAX_NUMBER}+`
       : this.props.favoritesCount;
@@ -53,4 +66,4 @@ export class FavoritesIconBadge extends Component {
   }
 }
 
-export default connect(FavoritesIconBadge);
+export default withWidgetSettings(connect(FavoritesIconBadge), '@shopgate/theme-ios11/components/TabBar/FavoritesIconBadge');

--- a/themes/theme-ios11/components/TabBar/components/FavoritesAction/components/FavoritesIconBadge/index.jsx
+++ b/themes/theme-ios11/components/TabBar/components/FavoritesAction/components/FavoritesIconBadge/index.jsx
@@ -53,15 +53,13 @@ export class FavoritesIconBadge extends Component {
       return null;
     }
 
-    if (showCounter === false) {
-      return <div className={`${style} theme__tab-bar__favorites-icon-badge theme__badge`} />;
-    }
-
     const number = (this.props.favoritesCount > this.constructor.MAX_NUMBER) ?
       `${this.constructor.MAX_NUMBER}+`
       : this.props.favoritesCount;
     return (
-      <div className={`${style} theme__tab-bar__favorites-icon-badge theme__badge`}>{number}</div>
+      <div className={`${style} theme__tab-bar__favorites-icon-badge theme__badge`}>
+        {showCounter !== false ? number : ''}
+      </div>
     );
   }
 }

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -287,6 +287,9 @@
               "style": {},
               "show": false
             }
+          },
+          "@shopgate/theme-ios11/components/TabBar/FavoritesIconBadge": {
+            "showCounter": true
           }
         },
         "styles": {},


### PR DESCRIPTION
# Description

Add the option to disable the favourite badge icon counter in TabBar

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.
