### PR TITLE
CCP-2553 Fixed horizontal scrolling bug on pdp when discount badge was visible

### DIFF
--- a/libraries/engage/product/components/ProductBadges/index.jsx
+++ b/libraries/engage/product/components/ProductBadges/index.jsx
@@ -9,7 +9,7 @@ import { PORTAL_PRODUCT_BADGES } from '../../../components/constants';
 const styles = {
   root: css({
     position: 'absolute',
-    left: 10,
+    paddingLeft: 10,
     top: 10,
     zIndex: 5,
     transform: 'translate3d(0, 0, 0)',

--- a/libraries/engage/product/components/ProductDiscountBadge/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/product/components/ProductDiscountBadge/__snapshots__/spec.jsx.snap
@@ -33,7 +33,7 @@ exports[`<ProductDiscountBadge /> should not render with discount if widgetSetti
         productId="1234"
       >
         <div
-          className="css-1ut1k4d css-1bfvyxg product_badges product_badges__product-discount-badge"
+          className="css-6hbts6 css-1bfvyxg product_badges product_badges__product-discount-badge"
         >
           <SurroundPortals
             portalName="component.product-badges"
@@ -122,7 +122,7 @@ exports[`<ProductDiscountBadge /> should render with discount 1`] = `
         productId="1234"
       >
         <div
-          className="css-1ut1k4d css-1bfvyxg product_badges product_badges__product-discount-badge"
+          className="css-6hbts6 css-1bfvyxg product_badges product_badges__product-discount-badge"
         >
           <SurroundPortals
             portalName="component.product-badges"
@@ -292,7 +292,7 @@ exports[`<ProductDiscountBadge /> should render without discount 1`] = `
         productId="1234"
       >
         <div
-          className="css-1ut1k4d css-1bfvyxg product_badges product_badges__product-discount-badge"
+          className="css-6hbts6 css-1bfvyxg product_badges product_badges__product-discount-badge"
         >
           <SurroundPortals
             portalName="component.product-badges"

--- a/themes/theme-gmd/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-gmd/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
@@ -236,7 +236,7 @@ exports[`<ProductCard /> should render as expected 1`] = `
                   productId="PR0DUCTID"
                 >
                   <div
-                    className="css-1ut1k4d product_badges product_badges__product-card"
+                    className="css-6hbts6 product_badges product_badges__product-card"
                   >
                     <SurroundPortals
                       portalName="component.product-badges"

--- a/themes/theme-ios11/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/themeApi/ProductCard/__snapshots__/index.spec.jsx.snap
@@ -236,7 +236,7 @@ exports[`<ProductCard /> should render as expected 1`] = `
                   productId="PR0DUCTID"
                 >
                   <div
-                    className="css-1ut1k4d product_badges product_badges__product-card"
+                    className="css-6hbts6 product_badges product_badges__product-card"
                   >
                     <SurroundPortals
                       portalName="component.product-badges"


### PR DESCRIPTION
# Description

The ProductBadges component has a width of 100%. Since it was shifted by 10px to right it increased the width of PDP what caused that scrolling came possible in horizontal direction.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
