### PR TITLE
CURB-2220 Workaround to handle redux devtools issues without web bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ To set up a new core extension you need to perform the following steps:
 * Open the monorepo's `lerna.json` file and add your extension as an additional entry in `packages`
 * Add the same entry additionally into `workspaces` in the `package.json` file
 
+## PWA 7 specialities
+The GMD theme of PWA 7 supports a special mode to display responsive content for desktop browsers. To enable PWA in desktop browsers, pipeline requests (that are an app concept originally) are transformed to AJAX requests which are send to a special proxy which is called "web bridge".
+
+To enable the bridge, frontend needs to be started with a special environment parameter.
+
+```shell
+WEB_BRIDGE=1 sgconnect frontend start
+```
+or
+```shell
+WEB_BRIDGE=1 sgconnect frontend start -t theme-gmd
+```
+
 ## About Shopgate
 
 Shopgate is the leading mobile commerce platform.

--- a/libraries/engage/components/ResponsiveContainer/breakpoints.js
+++ b/libraries/engage/components/ResponsiveContainer/breakpoints.js
@@ -1,4 +1,6 @@
-import { hasWebBridge } from '@shopgate/engage/core';
+import { hasWebBridge, isIOSTheme } from '@shopgate/engage/core';
+
+const iosThemeActive = isIOSTheme();
 
 /* eslint-disable extra-rules/no-single-line-objects */
 const breakpoints = [
@@ -33,7 +35,8 @@ export const parser = (comparators, breakpoint, {
   const config = breakpoints.find(b => b.name === breakpointString);
 
   // Web / App config.
-  const isWeb = hasWebBridge();
+  // Handle iOS theme as app for now so that media queries in shared components only work for app
+  const isWeb = hasWebBridge() && !iosThemeActive;
 
   // Always mode.
   if ((webAlways && isWeb) || (appAlways && !isWeb)) {

--- a/libraries/engage/components/View/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/libraries/engage/components/View/__tests__/__snapshots__/index.spec.jsx.snap
@@ -10,7 +10,7 @@ exports[`engage > components > view > index should have structured content 1`] =
   }
   style={
     Object {
-      "display": "block",
+      "display": "flex",
     }
   }
 >

--- a/libraries/engage/components/View/components/Content/style.js
+++ b/libraries/engage/components/View/components/Content/style.js
@@ -13,6 +13,7 @@ export default css({
     position: 'absolute',
     WebkitOverflowScrolling: 'touch',
   } : {
+    height: '100%',
     backgroundColor: 'var(--page-background-color)',
   }),
   [responsiveMediaQuery('>xs', { webOnly: true })]: {

--- a/libraries/engage/components/View/index.jsx
+++ b/libraries/engage/components/View/index.jsx
@@ -31,7 +31,7 @@ function ViewContainer({
   }
 
   const style = {
-    display: visible ? 'block' : 'none',
+    display: visible ? 'flex' : 'none',
   };
 
   return (

--- a/libraries/engage/product/components/ProductProperties/__tests__/ProductProperties.spec.jsx
+++ b/libraries/engage/product/components/ProductProperties/__tests__/ProductProperties.spec.jsx
@@ -16,6 +16,7 @@ jest.mock('../../../../core', () => ({
   isBeta: () => false,
   hasWebBridge: () => false,
   withForwardedRef: jest.fn(),
+  isIOSTheme: jest.fn(() => false),
 }));
 
 const properties = [

--- a/libraries/engage/styles/reset/root.js
+++ b/libraries/engage/styles/reset/root.js
@@ -1,8 +1,10 @@
 import { css } from 'glamor';
-import { useScrollContainer, hasWebBridge } from '@shopgate/engage/core';
+import { useScrollContainer, hasWebBridge, isIOSTheme } from '@shopgate/engage/core';
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 
 const { typography } = themeConfig;
+
+const iosThemeActive = isIOSTheme();
 
 css.global('*, *:before, *:after', {
   boxSizing: 'border-box',
@@ -49,7 +51,7 @@ css.global('html, body', {
   backgroundColor: 'var(--page-background-color)',
 });
 
-if (hasWebBridge()) {
+if (hasWebBridge() && !iosThemeActive) {
   css.insert(`@media(min-width: 600px) {
     html, body {
       background-color: var(--color-background-gutter-body, var(--page-background-color))

--- a/themes/theme-gmd/components/ProductGrid/components/Item/style.js
+++ b/themes/theme-gmd/components/ProductGrid/components/Item/style.js
@@ -22,6 +22,7 @@ export const badgesPortal = css({
   [responsiveMediaQuery('>xs', { webOnly: true })]: {
     left: 'initial',
     right: 5,
+    width: 'inherit',
   },
 }).toString();
 

--- a/themes/theme-gmd/widgets/ProductSlider/spec.jsx
+++ b/themes/theme-gmd/widgets/ProductSlider/spec.jsx
@@ -7,6 +7,7 @@ import {
 
 jest.mock('@shopgate/engage/core', () => ({
   hasWebBridge: jest.fn(() => false),
+  isIOSTheme: jest.fn(() => false),
   withWidgetSettings: component => component,
 }));
 

--- a/themes/theme-ios11/components/ProductFilters/style.js
+++ b/themes/theme-ios11/components/ProductFilters/style.js
@@ -1,13 +1,14 @@
 import { css } from 'glamor';
 import { responsiveMediaQuery } from '@shopgate/engage/styles';
+import { useScrollContainer } from '@shopgate/engage/core';
 
 export const filters = css({
-  top: 0,
+  ...(useScrollContainer() ? { top: 0 } : { top: 44 }),
   [responsiveMediaQuery('>xs', { webOnly: true })]: {
     top: 64,
   },
   [responsiveMediaQuery('<=xs', { webOnly: true })]: {
-    top: 56,
+    top: 44,
   },
   display: 'block',
   zIndex: 1000,

--- a/themes/theme-ios11/components/Viewport/style.js
+++ b/themes/theme-ios11/components/Viewport/style.js
@@ -1,4 +1,5 @@
 import { css } from 'glamor';
+import { useScrollContainer, hasWebBridge } from '@shopgate/engage/core';
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 
 const { colors } = themeConfig;
@@ -17,7 +18,7 @@ const viewport = css({
     '100vh',
     //    'var(--vh-100, 100vh)',
   ],
-  overflow: 'hidden',
+  overflow: useScrollContainer() ? 'hidden' : 'inherit',
   position: 'relative',
   width: '100vw',
 });
@@ -26,12 +27,16 @@ const content = css({
   flexGrow: 1,
   position: 'relative',
   zIndex: 0,
+  ...(hasWebBridge() ? {
+    display: 'flex',
+    justifyContent: 'center',
+  } : {}),
 });
 
 const header = css({
   top: 0,
   flexShrink: 1,
-  position: 'relative',
+  position: hasWebBridge() ? 'sticky' : 'relative',
   zIndex: 1,
 });
 


### PR DESCRIPTION
# Description
This ticket is about to provide a workaround to handle issues with the Redux dev tools when developing against the iOS theme. As a quick solution it adds compatibility to the web bridge mode that was just implemented for gmd till now.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

