### PR TITLE
Fixed broken checkout success page when product options have an unexpected format

### DIFF
--- a/libraries/engage/checkout/helpers/index.js
+++ b/libraries/engage/checkout/helpers/index.js
@@ -50,7 +50,7 @@ export const convertLineItemsToCartItems = (lineItems = []) => lineItems.map((li
   if (Array.isArray(options)) {
     properties = options.map(option => ({
       label: option.name,
-      value: option.values[0].name,
+      value: option?.value?.name || option?.values?.[0]?.name,
     }));
   }
 


### PR DESCRIPTION
# Description

Due to a recent change within the order service, order line item options have an unexpected shape now. This causes a JS error that results into a white page on checkout success.

This change was done a resolve some inconsistencies with the API documentation.

Instead of a "values" property with an array value, an options entry now has "value" property with an object value.

This pull request fixes the issue with the new shape of the response value.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Create a cart that contains a product with options and proceed to checkout success page. No whitepage should occur.
