### PR TITLE
Improved InfiniteContainer when response contains less products than requested

### DIFF
--- a/libraries/commerce/category/actions/fetchCategoryProducts.js
+++ b/libraries/commerce/category/actions/fetchCategoryProducts.js
@@ -28,7 +28,7 @@ const fetchCategoryProducts = ({
   (dispatch, getState) => {
     const sortOrder = sort || getSortOrder(getState());
 
-    dispatch(fetchProducts({
+    return dispatch(fetchProducts({
       cached,
       cachedTime,
       params: {

--- a/libraries/commerce/search/actions/fetchSearchResults.js
+++ b/libraries/commerce/search/actions/fetchSearchResults.js
@@ -58,6 +58,9 @@ const fetchSearchResults = params => (dispatch) => {
       }
     });
   }
+
+  // eslint-disable-next-line consistent-return
+  return promise;
 };
 
 /** @mixes {MutableFunction} */

--- a/libraries/common/components/InfiniteContainer/index.jsx
+++ b/libraries/common/components/InfiniteContainer/index.jsx
@@ -58,10 +58,10 @@ class InfiniteContainer extends Component {
      * 10ms was chosen because, on the one hand, it prevents the scroll event from flooding but,
      * on the other hand, it does not hinder users that scroll quickly from reloading next chunk.
      */
-    this.handleLoadingProxy = throttle((force, nextProps) =>
+    this.handleLoadingProxy = throttle(() =>
       (props.promiseBased
-        ? this.handleLoadingPromise(force, nextProps)
-        : this.handleLoading(force, nextProps)), 10);
+        ? this.handleLoadingPromise()
+        : this.handleLoading()), 10);
 
     this.handleLoadingProxy.bind(this);
 
@@ -120,7 +120,9 @@ class InfiniteContainer extends Component {
 
       if (this.receivedTotalItems(nextProps)) {
         // Trigger loading if totalItems are available
-        this.handleLoadingProxy(true, nextProps);
+        (nextProps.promiseBased
+          ? this.handleLoadingPromise
+          : this.handleLoading)(true, nextProps);
       }
 
       this.verifyAllDone(nextProps);
@@ -376,7 +378,7 @@ class InfiniteContainer extends Component {
       return;
     }
 
-    if (force || this.validateScrollPosition()) {
+    if (force === true || this.validateScrollPosition()) {
       // Add isLoading state to prevent requests while the current one is running
       this.isLoading = true;
 

--- a/libraries/common/components/InfiniteContainer/index.jsx
+++ b/libraries/common/components/InfiniteContainer/index.jsx
@@ -19,11 +19,11 @@ class InfiniteContainer extends Component {
     iterator: PropTypes.func.isRequired,
     loader: PropTypes.func.isRequired,
     containerRef: PropTypes.shape(),
+    enablePromiseBasedLoading: PropTypes.bool,
     initialLimit: PropTypes.number,
     limit: PropTypes.number,
     loadingIndicator: PropTypes.node,
     preloadMultiplier: PropTypes.number,
-    promiseBased: PropTypes.bool,
     requestHash: PropTypes.string,
     totalItems: PropTypes.number,
     wrapper: PropTypes.oneOfType([
@@ -41,7 +41,7 @@ class InfiniteContainer extends Component {
     requestHash: null,
     totalItems: null,
     wrapper: 'div',
-    promiseBased: false,
+    enablePromiseBasedLoading: false,
   };
 
   /**
@@ -58,12 +58,13 @@ class InfiniteContainer extends Component {
      * 10ms was chosen because, on the one hand, it prevents the scroll event from flooding but,
      * on the other hand, it does not hinder users that scroll quickly from reloading next chunk.
      */
-    this.handleLoadingProxy = throttle(() =>
-      (props.promiseBased
-        ? this.handleLoadingPromise()
-        : this.handleLoading()), 10);
-
-    this.handleLoadingProxy.bind(this);
+    this.handleLoadingProxy = throttle(() => {
+      if (props.enablePromiseBasedLoading) {
+        this.handleLoadingPromise();
+      } else {
+        this.handleLoading();
+      }
+    }, 10);
 
     // A flag to prevent concurrent loading requests.
     this.isLoading = false;
@@ -120,9 +121,11 @@ class InfiniteContainer extends Component {
 
       if (this.receivedTotalItems(nextProps)) {
         // Trigger loading if totalItems are available
-        (nextProps.promiseBased
-          ? this.handleLoadingPromise
-          : this.handleLoading)(true, nextProps);
+        if (nextProps.enablePromiseBasedLoading) {
+          this.handleLoadingPromise(true, nextProps);
+        } else {
+          this.handleLoading(true, nextProps);
+        }
       }
 
       this.verifyAllDone(nextProps);
@@ -157,8 +160,10 @@ class InfiniteContainer extends Component {
    * Reset the loading flag.
    */
   componentDidUpdate() {
-    if (!this.props.promiseBased) {
-      // When promise based implementation is active, `isLoading` is reset when response comes in d
+    // When promise based implementation is active, `isLoading` is reset when response comes in.
+    // In the legacy implementation this happens after the fetched items reached the component and
+    // is not necessary here anymore.
+    if (!this.props.enablePromiseBasedLoading) {
       this.isLoading = false;
     }
   }
@@ -224,16 +229,19 @@ class InfiniteContainer extends Component {
    * @returns {boolean}
    */
   allItemsAreRendered(props = this.props) {
-    const [start, length] = this.state.offset;
+    const [offset, limit] = this.state.offset;
 
-    if (props.promiseBased) {
+    if (props.enablePromiseBasedLoading) {
       const { totalItems } = props;
-      return totalItems !== null && (start + length >= totalItems);
+      // At promise based loading the offset is increased after the response came in.
+      // This method is invoked to evaluate if a new request needs to be dispatched, so we check
+      // against the current offset state.
+      return totalItems !== null && (offset >= totalItems);
     }
 
     return (
       !this.needsToReceiveItems(props) &&
-      start + length >= props.totalItems
+      offset + limit >= props.totalItems
     );
   }
 
@@ -385,10 +393,11 @@ class InfiniteContainer extends Component {
       const { loader } = props;
 
       try {
-        // Increase the offset for the upcoming request
-        const { offset } = this.increaseOffset();
+        const [offset] = this.state.offset;
         // Dispatch the request
         await loader(offset);
+        // Increase the offset for the next request
+        this.increaseOffset();
       } catch (e) {
         // Stop lazy loading processes on request error
         this.stopLazyLoading();

--- a/libraries/common/components/InfiniteContainer/index.jsx
+++ b/libraries/common/components/InfiniteContainer/index.jsx
@@ -23,6 +23,7 @@ class InfiniteContainer extends Component {
     limit: PropTypes.number,
     loadingIndicator: PropTypes.node,
     preloadMultiplier: PropTypes.number,
+    promiseBased: PropTypes.bool,
     requestHash: PropTypes.string,
     totalItems: PropTypes.number,
     wrapper: PropTypes.oneOfType([
@@ -40,6 +41,7 @@ class InfiniteContainer extends Component {
     requestHash: null,
     totalItems: null,
     wrapper: 'div',
+    promiseBased: false,
   };
 
   /**
@@ -56,7 +58,13 @@ class InfiniteContainer extends Component {
      * 10ms was chosen because, on the one hand, it prevents the scroll event from flooding but,
      * on the other hand, it does not hinder users that scroll quickly from reloading next chunk.
      */
-    this.handleLoadingProxy = throttle(() => this.handleLoading(), 10);
+    this.handleLoadingProxy = throttle((force, nextProps) =>
+      (props.promiseBased
+        ? this.handleLoadingPromise(force, nextProps)
+        : this.handleLoading(force, nextProps)), 10);
+
+    this.handleLoadingProxy.bind(this);
+
     // A flag to prevent concurrent loading requests.
     this.isLoading = false;
 
@@ -101,7 +109,7 @@ class InfiniteContainer extends Component {
   UNSAFE_componentWillReceiveProps(nextProps) {
     /**
      * Downstream logic to process the props. It's wrapped into a separate function, since it might
-     * beed to be executed after the state was updated to avoid race conditions.
+     * be executed after the state was updated to avoid race conditions.
      */
     const finalize = () => {
       const { current } = nextProps.containerRef;
@@ -112,7 +120,7 @@ class InfiniteContainer extends Component {
 
       if (this.receivedTotalItems(nextProps)) {
         // Trigger loading if totalItems are available
-        this.handleLoading(true, nextProps);
+        this.handleLoadingProxy(true, nextProps);
       }
 
       this.verifyAllDone(nextProps);
@@ -147,7 +155,10 @@ class InfiniteContainer extends Component {
    * Reset the loading flag.
    */
   componentDidUpdate() {
-    this.isLoading = false;
+    if (!this.props.promiseBased) {
+      // When promise based implementation is active, `isLoading` is reset when response comes in d
+      this.isLoading = false;
+    }
   }
 
   /**
@@ -213,6 +224,11 @@ class InfiniteContainer extends Component {
   allItemsAreRendered(props = this.props) {
     const [start, length] = this.state.offset;
 
+    if (props.promiseBased) {
+      const { totalItems } = props;
+      return totalItems !== null && (start + length >= totalItems);
+    }
+
     return (
       !this.needsToReceiveItems(props) &&
       start + length >= props.totalItems
@@ -221,6 +237,7 @@ class InfiniteContainer extends Component {
 
   /**
    * Increases the current offset by limit (from props).
+   * @returns {Object}
    */
   increaseOffset() {
     const [start, length] = this.state.offset;
@@ -239,6 +256,11 @@ class InfiniteContainer extends Component {
     this.setState({
       offset: [newOffset, this.props.limit],
     });
+
+    return {
+      offset: newOffset,
+      limit: this.props.limit,
+    };
   }
 
   /**
@@ -258,14 +280,21 @@ class InfiniteContainer extends Component {
   }
 
   /**
+   * Stops the lazy loading processes
+   */
+  stopLazyLoading() {
+    this.setState({ awaitingItems: false });
+    this.unbindEvents();
+  }
+
+  /**
    * Verifies if all items are loaded and shown, then set final state and unbind events.
    * @param {Object} [props] The current or next component props.
    * @returns {boolean} Returns true if the component has reached the final state.
    */
   verifyAllDone(props = this.props) {
     if (this.allItemsAreRendered(props)) {
-      this.setState({ awaitingItems: false });
-      this.unbindEvents();
+      this.stopLazyLoading();
 
       return true;
     }
@@ -326,6 +355,45 @@ class InfiniteContainer extends Component {
           this.increaseOffset();
         }
       }
+    }
+  }
+
+  /**
+   * Handles incrementing of render offset and the request of new items if necessary.
+   *
+   * Other than the regular handleLoading method this one requires that the loader returns a promise
+   * that can be used to check if we received a response for a request. That check is needed
+   * for offset handling.
+   * @param {boolean} [force] If set to true, proceed independently of scroll validation.
+   * @param {Object} [props] The current or next component props.
+   */
+  async handleLoadingPromise(force = false, props = this.props) {
+    if (this.isLoading) {
+      return;
+    }
+
+    if (this.verifyAllDone()) {
+      return;
+    }
+
+    if (force || this.validateScrollPosition()) {
+      // Add isLoading state to prevent requests while the current one is running
+      this.isLoading = true;
+
+      const { loader } = props;
+
+      try {
+        // Increase the offset for the upcoming request
+        const { offset } = this.increaseOffset();
+        // Dispatch the request
+        await loader(offset);
+      } catch (e) {
+        // Stop lazy loading processes on request error
+        this.stopLazyLoading();
+      }
+
+      // Remove the loading state to enable next request
+      this.isLoading = false;
     }
   }
 

--- a/libraries/common/providers/loading/index.spec.jsx
+++ b/libraries/common/providers/loading/index.spec.jsx
@@ -56,7 +56,7 @@ describe('LoadingProvider', () => {
     expect(wrapper.find('MockComponent > div').exists()).toBe(false);
   });
 
-  it('should render the child component when the current path is loading', () => {
+  it('should render the child component when the current path is loading', async () => {
     const wrapper = createWrapper(MOCKED_PATH);
     expect(wrapper).toMatchSnapshot();
     wrapper.instance().setLoading(MOCKED_PATH);

--- a/libraries/engage/product/components/ProductList/index.jsx
+++ b/libraries/engage/product/components/ProductList/index.jsx
@@ -48,7 +48,7 @@ const ProductList = ({
           initialLimit={10}
           limit={ITEMS_PER_LOAD}
           requestHash={requestHash}
-          promiseBased
+          enablePromiseBasedLoading
         />
       )}
     </ViewContext.Consumer>

--- a/libraries/engage/product/components/ProductList/index.jsx
+++ b/libraries/engage/product/components/ProductList/index.jsx
@@ -48,6 +48,7 @@ const ProductList = ({
           initialLimit={10}
           limit={ITEMS_PER_LOAD}
           requestHash={requestHash}
+          promiseBased
         />
       )}
     </ViewContext.Consumer>

--- a/themes/theme-gmd/components/ProductGrid/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/components/ProductGrid/__snapshots__/spec.jsx.snap
@@ -50,6 +50,7 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
       loader={[Function]}
       loadingIndicator={<LoadingIndicator />}
       preloadMultiplier={2}
+      promiseBased={true}
       requestHash={null}
       totalItems={null}
       wrapper={[Function]}

--- a/themes/theme-gmd/components/ProductGrid/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/components/ProductGrid/__snapshots__/spec.jsx.snap
@@ -43,6 +43,7 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
           "current": null,
         }
       }
+      enablePromiseBasedLoading={true}
       initialLimit={32}
       items={Array []}
       iterator={[Function]}
@@ -50,7 +51,6 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
       loader={[Function]}
       loadingIndicator={<LoadingIndicator />}
       preloadMultiplier={2}
-      promiseBased={true}
       requestHash={null}
       totalItems={null}
       wrapper={[Function]}

--- a/themes/theme-gmd/components/ProductGrid/index.jsx
+++ b/themes/theme-gmd/components/ProductGrid/index.jsx
@@ -59,7 +59,7 @@ const ProductGrid = ({
           initialLimit={ITEMS_PER_LOAD}
           limit={ITEMS_PER_LOAD}
           requestHash={requestHash}
-          promiseBased
+          enablePromiseBasedLoading
         />
       )}
     </ViewContext.Consumer>

--- a/themes/theme-gmd/components/ProductGrid/index.jsx
+++ b/themes/theme-gmd/components/ProductGrid/index.jsx
@@ -59,6 +59,7 @@ const ProductGrid = ({
           initialLimit={ITEMS_PER_LOAD}
           limit={ITEMS_PER_LOAD}
           requestHash={requestHash}
+          promiseBased
         />
       )}
     </ViewContext.Consumer>

--- a/themes/theme-gmd/pages/Category/components/Products/actions/getProducts.js
+++ b/themes/theme-gmd/pages/Category/components/Products/actions/getProducts.js
@@ -11,7 +11,7 @@ import fetchCategoryProducts from '@shopgate/pwa-common-commerce/category/action
 const getProducts = (categoryId, sort, offset) => (dispatch, getState) => {
   const filters = getActiveFilters(getState());
 
-  dispatch(fetchCategoryProducts({
+  return dispatch(fetchCategoryProducts({
     categoryId,
     sort,
     offset,

--- a/themes/theme-gmd/pages/Category/components/Products/index.jsx
+++ b/themes/theme-gmd/pages/Category/components/Products/index.jsx
@@ -27,11 +27,12 @@ class CategoryProducts extends PureComponent {
 
   /**
    * @param {number} offset The offset for the fetching.
+   * @returns {Promise}
    */
   fetchProducts = (offset) => {
     const includeCharacteristics = isBeta();
 
-    this.props.getProducts(
+    return this.props.getProducts(
       this.props.categoryId,
       this.props.sort,
       offset || this.props.products.length,

--- a/themes/theme-gmd/pages/Search/components/Products/actions/getProducts.js
+++ b/themes/theme-gmd/pages/Search/components/Products/actions/getProducts.js
@@ -11,7 +11,7 @@ import fetchSearchResults from '@shopgate/pwa-common-commerce/search/actions/fet
 const getProducts = (searchPhrase, sort, offset) => (dispatch, getState) => {
   const filters = getActiveFilters(getState());
 
-  dispatch(fetchSearchResults({
+  return dispatch(fetchSearchResults({
     searchPhrase,
     offset,
     filters,

--- a/themes/theme-gmd/pages/Search/components/Products/index.jsx
+++ b/themes/theme-gmd/pages/Search/components/Products/index.jsx
@@ -5,6 +5,7 @@ import connect from './connector';
 
 /**
  * The SearchProducts component.
+ * @returns {JSX}
  */
 class SearchProducts extends PureComponent {
   static propTypes = {
@@ -21,13 +22,15 @@ class SearchProducts extends PureComponent {
     totalProductCount: null,
   };
 
-  fetchProducts = () => {
-    this.props.getProducts(
-      this.props.searchPhrase,
-      this.props.sort,
-      this.props.products.length
-    );
-  }
+  /**
+   * @param {number} offset The offset for the fetching.
+   * @returns {Promise}
+   */
+  fetchProducts = offset => this.props.getProducts(
+    this.props.searchPhrase,
+    this.props.sort,
+    offset || this.props.products.length
+  )
 
   /**
    * @returns {JSX}

--- a/themes/theme-ios11/components/ProductGrid/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/components/ProductGrid/__snapshots__/spec.jsx.snap
@@ -50,6 +50,7 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
       loader={[Function]}
       loadingIndicator={<LoadingIndicator />}
       preloadMultiplier={2}
+      promiseBased={true}
       requestHash={null}
       totalItems={null}
       wrapper={[Function]}

--- a/themes/theme-ios11/components/ProductGrid/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/components/ProductGrid/__snapshots__/spec.jsx.snap
@@ -43,6 +43,7 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
           "current": null,
         }
       }
+      enablePromiseBasedLoading={true}
       initialLimit={32}
       items={Array []}
       iterator={[Function]}
@@ -50,7 +51,6 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
       loader={[Function]}
       loadingIndicator={<LoadingIndicator />}
       preloadMultiplier={2}
-      promiseBased={true}
       requestHash={null}
       totalItems={null}
       wrapper={[Function]}

--- a/themes/theme-ios11/components/ProductGrid/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/index.jsx
@@ -59,7 +59,7 @@ const ProductGrid = ({
           initialLimit={ITEMS_PER_LOAD}
           limit={ITEMS_PER_LOAD}
           requestHash={requestHash}
-          promiseBased
+          enablePromiseBasedLoading
         />
       )}
     </ViewContext.Consumer>

--- a/themes/theme-ios11/components/ProductGrid/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/index.jsx
@@ -59,6 +59,7 @@ const ProductGrid = ({
           initialLimit={ITEMS_PER_LOAD}
           limit={ITEMS_PER_LOAD}
           requestHash={requestHash}
+          promiseBased
         />
       )}
     </ViewContext.Consumer>

--- a/themes/theme-ios11/pages/Category/components/Products/actions/getProducts.js
+++ b/themes/theme-ios11/pages/Category/components/Products/actions/getProducts.js
@@ -11,7 +11,7 @@ import fetchCategoryProducts from '@shopgate/pwa-common-commerce/category/action
 const getProducts = (categoryId, sort, offset) => (dispatch, getState) => {
   const filters = getActiveFilters(getState());
 
-  dispatch(fetchCategoryProducts({
+  return dispatch(fetchCategoryProducts({
     categoryId,
     sort,
     offset,

--- a/themes/theme-ios11/pages/Category/components/Products/index.jsx
+++ b/themes/theme-ios11/pages/Category/components/Products/index.jsx
@@ -27,11 +27,12 @@ class CategoryProducts extends PureComponent {
 
   /**
    * @param {number} offset The offset for the fetching.
+   * @returns {Promise}
    */
   fetchProducts = (offset) => {
     const includeCharacteristics = isBeta();
 
-    this.props.getProducts(
+    return this.props.getProducts(
       this.props.categoryId,
       this.props.sort,
       offset || this.props.products.length,

--- a/themes/theme-ios11/pages/Search/components/Products/actions/getProducts.js
+++ b/themes/theme-ios11/pages/Search/components/Products/actions/getProducts.js
@@ -11,7 +11,7 @@ import fetchSearchResults from '@shopgate/pwa-common-commerce/search/actions/fet
 const getProducts = (searchPhrase, sort, offset) => (dispatch, getState) => {
   const filters = getActiveFilters(getState());
 
-  dispatch(fetchSearchResults({
+  return dispatch(fetchSearchResults({
     searchPhrase,
     offset,
     filters,

--- a/themes/theme-ios11/pages/Search/components/Products/index.jsx
+++ b/themes/theme-ios11/pages/Search/components/Products/index.jsx
@@ -21,31 +21,33 @@ class SearchProducts extends PureComponent {
     totalProductCount: null,
   };
 
-  fetchProducts = () => {
-    this.props.getProducts(
-      this.props.searchPhrase,
-      this.props.sort,
-      this.props.products.length
-    );
-  }
-
   /**
+   * @param {number} offset The offset for the fetching.
+   * @returns {Promise}
+   */
+   fetchProducts = offset => this.props.getProducts(
+     this.props.searchPhrase,
+     this.props.sort,
+     offset || this.props.products.length
+   )
+
+   /**
    * @returns {JSX}
    */
-  render() {
-    if (!this.props.products) {
-      return null;
-    }
+   render() {
+     if (!this.props.products) {
+       return null;
+     }
 
-    return (
-      <ProductGrid
-        handleGetProducts={this.fetchProducts}
-        products={this.props.products}
-        totalProductCount={this.props.totalProductCount}
-        requestHash={this.props.hash}
-      />
-    );
-  }
+     return (
+       <ProductGrid
+         handleGetProducts={this.fetchProducts}
+         products={this.props.products}
+         totalProductCount={this.props.totalProductCount}
+         requestHash={this.props.hash}
+       />
+     );
+   }
 }
 
 export default connect(SearchProducts);


### PR DESCRIPTION
# Description
The `InfiniteContainer` component which is used to display product lists in categories or search contains a bug that can potentially break the lazy loading process for products.

Right now parts of the process expect that a products request always returns all products within the requested "page". When one or more products are missing, this can cause that the page is stuck in loading state.
Additionally this issue can occur when different "pages" within e.g. a category contain the same product. In that case our product reducer logic filters out duplicates. This can also cause that less products are shown as expected by the limit / offset logic.

This PR fixed the issue by adding an additional mode to the InfiniteContainer that is based on request promises. It doesn't rely on counting products, but is based on request responses and updates internal offset state whenever a response came in.

The new mode is activated by adding the "promiseBased" prop the the container. Prop value is `false` by default to avoid issues in extensions that use the component, since request actions need to be dispatched in a special way. Core pages use the new logic by default.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Goto a category with a lot of products and check if requests are dispatched as expected and UI updates as expected.
