### PR TITLE
Improved InfiniteContainer when response contains less products than requested (PWA7)

### DIFF
--- a/libraries/commerce/category/actions/fetchCategoryProducts.js
+++ b/libraries/commerce/category/actions/fetchCategoryProducts.js
@@ -28,7 +28,7 @@ const fetchCategoryProducts = ({
   (dispatch, getState) => {
     const sortOrder = sort || getSortOrder(getState(), { categoryId });
 
-    dispatch(fetchProducts({
+    return dispatch(fetchProducts({
       cached,
       cachedTime,
       params: {

--- a/libraries/commerce/search/actions/fetchSearchResults.js
+++ b/libraries/commerce/search/actions/fetchSearchResults.js
@@ -62,6 +62,9 @@ const fetchSearchResults = params => (dispatch, getState) => {
       }
     });
   }
+
+  // eslint-disable-next-line consistent-return
+  return promise;
 };
 
 /** @mixes {MutableFunction} */

--- a/libraries/common/providers/loading/index.spec.jsx
+++ b/libraries/common/providers/loading/index.spec.jsx
@@ -55,7 +55,7 @@ describe('LoadingProvider', () => {
     expect(wrapper.find('MockComponent > div').exists()).toBe(false);
   });
 
-  it('should render the child component when the current path is loading', () => {
+  it('should render the child component when the current path is loading', async () => {
     const wrapper = createWrapper(MOCKED_PATH);
     expect(wrapper).toMatchSnapshot();
     wrapper.instance().setLoading(MOCKED_PATH);

--- a/themes/theme-gmd/components/ProductGrid/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/components/ProductGrid/__snapshots__/spec.jsx.snap
@@ -47,6 +47,7 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
           className={null}
         />
       }
+      promiseBased={true}
       requestHash={null}
       totalItems={null}
       wrapper={[Function]}

--- a/themes/theme-gmd/components/ProductGrid/index.jsx
+++ b/themes/theme-gmd/components/ProductGrid/index.jsx
@@ -56,6 +56,7 @@ const ProductGrid = ({
           initialLimit={ITEMS_PER_LOAD}
           limit={ITEMS_PER_LOAD}
           requestHash={requestHash}
+          promiseBased
         />
       )}
     </ViewContext.Consumer>

--- a/themes/theme-gmd/pages/Category/components/Products/actions/getProducts.js
+++ b/themes/theme-gmd/pages/Category/components/Products/actions/getProducts.js
@@ -11,7 +11,7 @@ import fetchCategoryProducts from '@shopgate/pwa-common-commerce/category/action
 const getProducts = (categoryId, sort, offset) => (dispatch, getState) => {
   const filters = getActiveFilters(getState());
 
-  dispatch(fetchCategoryProducts({
+  return dispatch(fetchCategoryProducts({
     categoryId,
     sort,
     offset,

--- a/themes/theme-gmd/pages/Category/components/Products/index.jsx
+++ b/themes/theme-gmd/pages/Category/components/Products/index.jsx
@@ -31,11 +31,12 @@ class CategoryProducts extends PureComponent {
 
   /**
    * @param {number} offset The offset for the fetching.
+   * @returns {Promise}
    */
   fetchProducts = (offset) => {
     const includeCharacteristics = isBeta();
 
-    this.props.getProducts(
+    return this.props.getProducts(
       this.props.categoryId,
       this.props.sort,
       offset || this.props.products.length,

--- a/themes/theme-gmd/pages/Search/components/Products/actions/getProducts.js
+++ b/themes/theme-gmd/pages/Search/components/Products/actions/getProducts.js
@@ -11,7 +11,7 @@ import fetchSearchResults from '@shopgate/pwa-common-commerce/search/actions/fet
 const getProducts = (searchPhrase, sort, offset) => (dispatch, getState) => {
   const filters = getActiveFilters(getState());
 
-  dispatch(fetchSearchResults({
+  return dispatch(fetchSearchResults({
     searchPhrase,
     offset,
     filters,

--- a/themes/theme-gmd/pages/Search/components/Products/index.jsx
+++ b/themes/theme-gmd/pages/Search/components/Products/index.jsx
@@ -5,6 +5,7 @@ import connect from './connector';
 
 /**
  * The SearchProducts component.
+ * @returns {JSX}
  */
 class SearchProducts extends PureComponent {
   static propTypes = {
@@ -21,13 +22,15 @@ class SearchProducts extends PureComponent {
     totalProductCount: null,
   };
 
-  fetchProducts = () => {
-    this.props.getProducts(
-      this.props.searchPhrase,
-      this.props.sort,
-      this.props.products.length
-    );
-  }
+  /**
+   * @param {number} offset The offset for the fetching.
+   * @returns {Promise}
+   */
+  fetchProducts = offset => this.props.getProducts(
+    this.props.searchPhrase,
+    this.props.sort,
+    offset || this.props.products.length
+  )
 
   /**
    * @returns {JSX}

--- a/themes/theme-ios11/components/ProductGrid/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/components/ProductGrid/__snapshots__/spec.jsx.snap
@@ -47,6 +47,7 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
           className={null}
         />
       }
+      promiseBased={true}
       requestHash={null}
       totalItems={null}
       wrapper={[Function]}

--- a/themes/theme-ios11/components/ProductGrid/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/index.jsx
@@ -56,6 +56,7 @@ const ProductGrid = ({
           initialLimit={ITEMS_PER_LOAD}
           limit={ITEMS_PER_LOAD}
           requestHash={requestHash}
+          promiseBased
         />
       )}
     </ViewContext.Consumer>

--- a/themes/theme-ios11/components/ProductList/index.jsx
+++ b/themes/theme-ios11/components/ProductList/index.jsx
@@ -48,6 +48,7 @@ const ProductList = ({
           initialLimit={10}
           limit={ITEMS_PER_LOAD}
           requestHash={requestHash}
+          promiseBased
         />
       )}
     </ViewContext.Consumer>

--- a/themes/theme-ios11/pages/Category/components/Products/actions/getProducts.js
+++ b/themes/theme-ios11/pages/Category/components/Products/actions/getProducts.js
@@ -11,7 +11,7 @@ import fetchCategoryProducts from '@shopgate/pwa-common-commerce/category/action
 const getProducts = (categoryId, sort, offset) => (dispatch, getState) => {
   const filters = getActiveFilters(getState());
 
-  dispatch(fetchCategoryProducts({
+  return dispatch(fetchCategoryProducts({
     categoryId,
     sort,
     offset,

--- a/themes/theme-ios11/pages/Category/components/Products/index.jsx
+++ b/themes/theme-ios11/pages/Category/components/Products/index.jsx
@@ -27,11 +27,12 @@ class CategoryProducts extends PureComponent {
 
   /**
    * @param {number} offset The offset for the fetching.
+   * @returns {Promise}
    */
   fetchProducts = (offset) => {
     const includeCharacteristics = isBeta();
 
-    this.props.getProducts(
+    return this.props.getProducts(
       this.props.categoryId,
       this.props.sort,
       offset || this.props.products.length,

--- a/themes/theme-ios11/pages/Search/components/Products/actions/getProducts.js
+++ b/themes/theme-ios11/pages/Search/components/Products/actions/getProducts.js
@@ -11,7 +11,7 @@ import fetchSearchResults from '@shopgate/pwa-common-commerce/search/actions/fet
 const getProducts = (searchPhrase, sort, offset) => (dispatch, getState) => {
   const filters = getActiveFilters(getState());
 
-  dispatch(fetchSearchResults({
+  return dispatch(fetchSearchResults({
     searchPhrase,
     offset,
     filters,

--- a/themes/theme-ios11/pages/Search/components/Products/index.jsx
+++ b/themes/theme-ios11/pages/Search/components/Products/index.jsx
@@ -21,31 +21,33 @@ class SearchProducts extends PureComponent {
     totalProductCount: null,
   };
 
-  fetchProducts = () => {
-    this.props.getProducts(
-      this.props.searchPhrase,
-      this.props.sort,
-      this.props.products.length
-    );
-  }
-
   /**
+   * @param {number} offset The offset for the fetching.
+   * @returns {Promise}
+   */
+   fetchProducts = offset => this.props.getProducts(
+     this.props.searchPhrase,
+     this.props.sort,
+     offset || this.props.products.length
+   )
+
+   /**
    * @returns {JSX}
    */
-  render() {
-    if (!this.props.products) {
-      return null;
-    }
+   render() {
+     if (!this.props.products) {
+       return null;
+     }
 
-    return (
-      <ProductGrid
-        handleGetProducts={this.fetchProducts}
-        products={this.props.products}
-        totalProductCount={this.props.totalProductCount}
-        requestHash={this.props.hash}
-      />
-    );
-  }
+     return (
+       <ProductGrid
+         handleGetProducts={this.fetchProducts}
+         products={this.props.products}
+         totalProductCount={this.props.totalProductCount}
+         requestHash={this.props.hash}
+       />
+     );
+   }
 }
 
 export default connect(SearchProducts);


### PR DESCRIPTION
# Description
The `InfiniteContainer` component which is used to display product lists in categories or search contains a bug that can potentially break the lazy loading process for products.

Right now parts of the process expect that a products request always returns all products within the requested "page". When one or more products are missing, this can cause that the page is stuck in loading state.
Additionally this issue can occur when different "pages" within e.g. a category contain the same product. In that case our product reducer logic filters out duplicates. This can also cause that less products are shown as expected by the limit / offset logic.

This PR fixed the issue by adding an additional mode to the InfiniteContainer that is based on request promises. It doesn't rely on counting products, but is based on request responses and updates internal offset state whenever a response came in.

The new mode is activated by adding the "promiseBased" prop the the container. Prop value is `false` by default to avoid issues in extensions that use the component, since request actions need to be dispatched in a special way. Core pages use the new logic by default.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Goto a category with a lot of products and check if requests are dispatched as expected and UI updates as expected.
