### PR TITLE
Add new surround portals in the quick links menu 

### DIFF
--- a/libraries/common/constants/Portals.js
+++ b/libraries/common/constants/Portals.js
@@ -13,6 +13,7 @@ const GLOBALS = 'globals';
 const ROUTES = 'routes';
 const FOOTER = 'footer';
 const CONTENT = 'content';
+const QUICK_LINKS = 'quick-links';
 const HOME = 'home';
 const LOGIN = 'login';
 const SCANNER = 'scanner';
@@ -72,6 +73,10 @@ export const NAV_MENU_CONTENT_AFTER = `${NAV_MENU}.${CONTENT}.${AFTER}`;
 export const NAV_MENU_HOME_BEFORE = `${NAV_MENU}.${HOME}.${BEFORE}`;
 export const NAV_MENU_HOME = `${NAV_MENU}.${HOME}`;
 export const NAV_MENU_HOME_AFTER = `${NAV_MENU}.${HOME}.${AFTER}`;
+
+export const NAV_MENU_QUICK_LINKS = `${NAV_MENU}.${QUICK_LINKS}`;
+export const NAV_MENU_QUICK_LINKS_BEFORE = `${NAV_MENU}.${QUICK_LINKS}.${BEFORE}`;
+export const NAV_MENU_QUICK_LINKS_AFTER = `${NAV_MENU}.${QUICK_LINKS}.${AFTER}`;
 
 export const NAV_MENU_SCANNER_BEFORE = `${NAV_MENU}.${SCANNER}.${BEFORE}`;
 export const NAV_MENU_SCANNER = `${NAV_MENU}.${SCANNER}`;

--- a/themes/theme-gmd/components/NavDrawer/components/QuickLinks/index.jsx
+++ b/themes/theme-gmd/components/NavDrawer/components/QuickLinks/index.jsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import camelCase from 'lodash/camelCase';
 import { themeConfig } from '@shopgate/engage';
-import { NavDrawer, DescriptionIcon, Icon } from '@shopgate/engage/components';
+import {
+  NavDrawer, DescriptionIcon, Icon, SurroundPortals,
+} from '@shopgate/engage/components';
+import {
+  NAV_MENU_QUICK_LINKS,
+} from '@shopgate/pwa-common/constants/Portals';
+import portalProps from '../../portalProps';
+
 import connect from './connector';
 
 const { icons } = themeConfig;
@@ -13,27 +20,30 @@ const { icons } = themeConfig;
  */
 const QuickLinks = ({ links, navigate }) => (
   (links && links.length > 0) && (
-    <NavDrawer.Section>
-      {links.map((link) => {
-        let icon = DescriptionIcon;
+    <SurroundPortals portalName={NAV_MENU_QUICK_LINKS} portalProps={portalProps}>
+      <NavDrawer.Section>
+        {links.map((link) => {
+          let icon = DescriptionIcon;
 
-        // Convert /page/some-link to pageSomeLink for custom icons
-        const path = camelCase(link.url);
-        if (icons[path]) {
-          icon = props => <Icon content={icons[path]} {...props} />;
-        }
+          // Convert /page/some-link to pageSomeLink for custom icons
+          const path = camelCase(link.url);
+          if (icons[path]) {
+            icon = props => <Icon content={icons[path]} {...props} />;
+          }
 
-        return (
-          <NavDrawer.Item
-            aria-hidden
-            key={link.url}
-            label={link.label}
-            onClick={() => navigate(link.url, link.label)}
-            icon={icon}
-          />
-        );
-      })}
-    </NavDrawer.Section>
+          return (
+            <NavDrawer.Item
+              aria-hidden
+              key={link.url}
+              label={link.label}
+              onClick={() => navigate(link.url, link.label)}
+              icon={icon}
+            />
+          );
+        })}
+      </NavDrawer.Section>
+    </SurroundPortals>
+
   )
 );
 

--- a/themes/theme-ios11/pages/More/components/Quicklinks/index.jsx
+++ b/themes/theme-ios11/pages/More/components/Quicklinks/index.jsx
@@ -1,5 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {
+  SurroundPortals,
+} from '@shopgate/engage/components';
+import {
+  NAV_MENU_QUICK_LINKS,
+} from '@shopgate/pwa-common/constants/Portals';
+import portalProps from '../../portalProps';
+
 import Section from '../Section';
 import connect from './connector';
 
@@ -15,11 +23,13 @@ function Quicklinks({ entries }) {
   }
 
   return (
-    <Section title="navigation.more_menu">
-      {entries.map(entry => (
-        <Section.Item href={entry.url} key={entry.url} label={entry.label} />
-      ))}
-    </Section>
+    <SurroundPortals portalName={NAV_MENU_QUICK_LINKS} portalProps={portalProps}>
+      <Section title="navigation.more_menu">
+        {entries.map(entry => (
+          <Section.Item href={entry.url} key={entry.url} label={entry.label} />
+        ))}
+      </Section>
+    </SurroundPortals>
   );
 }
 


### PR DESCRIPTION
# Description
Add new surround portals in the quick links menu 

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
