### PR TITLE
Use NUM pad when switching quantity in cart

### DIFF
--- a/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/components/QuantityPicker/index.jsx
+++ b/themes/theme-ios11/pages/Cart/components/Item/components/Product/components/Layout/components/QuantityPicker/index.jsx
@@ -205,6 +205,7 @@ class QuantityPicker extends Component {
         <input
           ref={this.setRef}
           type="number"
+          pattern="[0-9]*"
           className={style}
           value={this.state.quantity}
           onChange={this.handleInputChange}


### PR DESCRIPTION
# Description
Use NUM pad when switching quantity in cart
additional pattern prop is required on iOS to bring up the numpad when changing the quantity 

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
