### PR TITLE
Improve configurability of phone inputs in form builder forms

### DIFF
--- a/libraries/engage/account/components/Profile/Profile.config.js
+++ b/libraries/engage/account/components/Profile/Profile.config.js
@@ -6,6 +6,7 @@ import { generateCustomerAttributesFields } from '@shopgate/engage/account/helpe
  * @param {Object} additionalOptions Options for the customer attributes creation helper
  * @param {Array} additionalOptions.customerAttributes Customer attributes.
  * @param {Array} additionalOptions.supportedCountries A list of supported countries.
+ * @param {Array} additionalOptions.countrySortOrder Sort order for supported countries.
  * @param {Object} additionalOptions.userLocation User location for better phone picker defaults.
  * @param {boolean} [additionalOptions.allowPleaseChoose] Allows please choose option for required
  * attributes.

--- a/libraries/engage/account/components/Profile/Profile.provider.jsx
+++ b/libraries/engage/account/components/Profile/Profile.provider.jsx
@@ -233,6 +233,7 @@ const ProfileProvider = ({
     customer: defaultState,
     isCheckout,
     supportedCountries: shopSettings.supportedCountries,
+    countrySortOrder: shopSettings.countrySortOrder,
     userLocation,
     formState,
     saveForm: formState.handleSubmit,
@@ -242,6 +243,7 @@ const ProfileProvider = ({
   }), [
     userLocation,
     shopSettings.supportedCountries,
+    shopSettings.countrySortOrder,
     contacts,
     merchantCustomerAttributes,
     isCheckout,

--- a/libraries/engage/account/components/Profile/ProfileForm.jsx
+++ b/libraries/engage/account/components/Profile/ProfileForm.jsx
@@ -78,6 +78,7 @@ const ProfileForm = forwardRef((_, ref) => {
     validationErrors,
     merchantCustomerAttributes,
     supportedCountries,
+    countrySortOrder,
     userLocation,
   } = useProfileContext();
 
@@ -85,9 +86,10 @@ const ProfileForm = forwardRef((_, ref) => {
     () => generateFormConfig({
       customerAttributes: merchantCustomerAttributes,
       supportedCountries,
+      countrySortOrder,
       userLocation,
     }),
-    [merchantCustomerAttributes, supportedCountries, userLocation]
+    [countrySortOrder, merchantCustomerAttributes, supportedCountries, userLocation]
   );
 
   /* eslint-disable react-hooks/exhaustive-deps */

--- a/libraries/engage/account/components/ProfileContact/ProfileContact.config.js
+++ b/libraries/engage/account/components/ProfileContact/ProfileContact.config.js
@@ -3,20 +3,23 @@ import { ADDRESS_TYPE_SHIPPING, ADDRESS_TYPE_BILLING } from '@shopgate/engage/ch
 
 /**
  * Generates form configuration.
- * @param {Array} supportedCountries A list of supported countries.
- * @param {Object} userLocation User location for better phone picker defaults.
- * @param {boolean} isCheckout Whether the form is shown within the checkout process
- * @param {string} type An address type
- * @param {number} numberOfAddressLines The number of address lines
+ * @param {Object} options Options for the helper
+ * @param {Array} options.supportedCountries A list of supported countries.
+ * @param {Array} options.countrySortOrder Sort order for supported countries.
+ * @param {Object} options.userLocation User location for better phone picker defaults.
+ * @param {boolean} options.isCheckout Whether the form is shown within the checkout process
+ * @param {string} options.type An address type
+ * @param {number} options.numberOfAddressLines The number of address lines
  * @returns {Object}
  */
-export const generateFormConfig = (
+export const generateFormConfig = ({
   supportedCountries,
+  countrySortOrder,
   userLocation,
   isCheckout,
   type,
-  numberOfAddressLines
-) => ({
+  numberOfAddressLines,
+}) => ({
   fields: {
     firstName: {
       type: 'text',
@@ -42,6 +45,7 @@ export const generateFormConfig = (
         label: `${i18n.text('checkout.pickup_contact.form.mobile')} *`,
         config: {
           supportedCountries,
+          countrySortOrder,
           userLocation,
         },
       },

--- a/libraries/engage/account/components/ProfileContact/ProfileContact.jsx
+++ b/libraries/engage/account/components/ProfileContact/ProfileContact.jsx
@@ -112,13 +112,14 @@ const ProfileContact = ({
     return Math.max(numberOfAddressLines, addressLinesInContact);
   }, [contact, numberOfAddressLines]);
 
-  const formConfig = useMemo(() => generateFormConfig(
-    shopSettings?.supportedCountries,
+  const formConfig = useMemo(() => generateFormConfig({
+    supportedCountries: shopSettings?.supportedCountries,
+    countrySortOrder: shopSettings?.countrySortOrder,
     userLocation,
     isCheckout,
     type,
-    addressLines
-  ), [addressLines, isCheckout, shopSettings, type, userLocation]);
+    numberOfAddressLines: addressLines,
+  }), [addressLines, isCheckout, shopSettings, type, userLocation]);
 
   const constraints = useMemo(() => generateConstraints(isCheckout), [isCheckout]);
 

--- a/libraries/engage/account/helper/form.js
+++ b/libraries/engage/account/helper/form.js
@@ -33,6 +33,7 @@ const mapCustomerAttributeType = (attribute) => {
  * @param {Object} options Options for the helper
  * @param {Array} options.customerAttributes Customer attributes.
  * @param {Array} options.supportedCountries A list of supported countries.
+ * @param {Array} options.countrySortOrder Sort order for supported countries.
  * @param {Object} options.userLocation User location for better phone picker defaults.
  * @param {boolean} options.allowPleaseChoose Allows please choose option for required attributes.
  * @returns {Object}
@@ -40,6 +41,7 @@ const mapCustomerAttributeType = (attribute) => {
 export const generateCustomerAttributesFields = ({
   customerAttributes,
   supportedCountries,
+  countrySortOrder,
   userLocation,
   allowPleaseChoose = true,
 }) => ({
@@ -62,6 +64,7 @@ export const generateCustomerAttributesFields = ({
       ...(attribute.type === 'callingNumber' ? {
         config: {
           supportedCountries,
+          countrySortOrder,
           userLocation,
         },
       } : null),

--- a/libraries/engage/checkout/components/Checkout/CheckoutPickupContactForm.config.js
+++ b/libraries/engage/checkout/components/Checkout/CheckoutPickupContactForm.config.js
@@ -11,11 +11,17 @@ const pickupFieldActions = [{
 
 /**
  * Generates form configuration.
- * @param {Array} supportedCountries A list of supported countries.
- * @param {Object} userLocation User location for better phone picker defaults.
+ * @param {Object} options Options for the helper
+ * @param {Array} options.supportedCountries A list of supported countries.
+ * @param {Array} options.countrySortOrder Sort order for supported countries.
+ * @param {Object} options.userLocation User location for better phone picker defaults.
  * @returns {Object}
  */
-const generateFormConfig = (supportedCountries, userLocation) => ({
+const generateFormConfig = ({
+  supportedCountries,
+  countrySortOrder,
+  userLocation,
+}) => ({
   fields: {
     instructions: {
       type: 'text',
@@ -51,6 +57,7 @@ const generateFormConfig = (supportedCountries, userLocation) => ({
       actions: pickupFieldActions,
       config: {
         supportedCountries,
+        countrySortOrder,
         userLocation,
       },
     },

--- a/libraries/engage/checkout/components/Checkout/CheckoutPickupContactForm.jsx
+++ b/libraries/engage/checkout/components/Checkout/CheckoutPickupContactForm.jsx
@@ -56,6 +56,7 @@ const styles = {
 const PickupContactForm = () => {
   const {
     supportedCountries,
+    countrySortOrder,
     userLocation,
     defaultPickupPersonState,
     formValidationErrors,
@@ -64,8 +65,12 @@ const PickupContactForm = () => {
   } = useCheckoutContext();
 
   const formConfig = React.useMemo(
-    () => generateFormConfig(supportedCountries, userLocation),
-    [supportedCountries, userLocation]
+    () => generateFormConfig({
+      supportedCountries,
+      countrySortOrder,
+      userLocation,
+    }),
+    [countrySortOrder, supportedCountries, userLocation]
   );
 
   const handleUpdate = React.useCallback((values) => {

--- a/libraries/engage/checkout/providers/CheckoutProvider.jsx
+++ b/libraries/engage/checkout/providers/CheckoutProvider.jsx
@@ -410,6 +410,7 @@ const CheckoutProvider = ({
     isButtonLocked: ((isLocked || isButtonLocked) && needsPayment) || !isOrderable,
     isLoading,
     supportedCountries: shopSettings.supportedCountries,
+    countrySortOrder: shopSettings.countrySortOrder,
     formValidationErrors: convertValidationErrors(formState.validationErrors || {}),
     formSetValues: formState.setValues,
     handleSubmitOrder: (...params) => {
@@ -454,6 +455,7 @@ const CheckoutProvider = ({
     isOrderable,
     isLoading,
     shopSettings.supportedCountries,
+    shopSettings.countrySortOrder,
     formState,
     handleUpdateShippingMethod,
     userLocation,

--- a/libraries/engage/components/Form/Builder/ElementPhoneNumber.jsx
+++ b/libraries/engage/components/Form/Builder/ElementPhoneNumber.jsx
@@ -157,7 +157,7 @@ const UnwrappedElementPhoneNumber = React.memo<Props>((props: Props) => {
     let country;
 
     if (value) {
-      // Try to parse the value the determine a country
+      // Try to parse the value to determine a country
       const phoneNumber = parsePhoneNumber(value || '');
 
       if (phoneNumber && phoneNumber.country) {

--- a/libraries/engage/components/Form/Builder/ElementPhoneNumber.jsx
+++ b/libraries/engage/components/Form/Builder/ElementPhoneNumber.jsx
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import classnames from 'classnames';
-import { camelCase, upperCase } from 'lodash';
+import { camelCase, upperCase, isEqual } from 'lodash';
 import { i18n } from '@shopgate/engage/core';
 import { parsePhoneNumber } from 'react-phone-number-input';
 import PhoneInputCountrySelect from 'react-phone-number-input/mobile';
@@ -189,6 +189,18 @@ const UnwrappedElementPhoneNumber = React.memo<Props>((props: Props) => {
     return country;
   }, [countries, countrySortOrder, userLocation, value]);
 
+  const countryOptionsOrder = React.useMemo(() => {
+    const countryListsEqual = isEqual([...countries].sort(), [...countrySortOrder].sort());
+    /**
+     * When list with supported countries has the same entries as the country sort order, we don't
+     * need to add a separator to the countryOptionsOrder array since the country picker lists
+     * will not show a section with unordered countries.
+     */
+    return countrySortOrder.length
+      ? [...countrySortOrder, ...(countryListsEqual ? [] : ['|'])]
+      : [];
+  }, [countries, countrySortOrder]);
+
   const hasCountrySelect = React.useMemo(() => countries.length > 1, [countries.length]);
 
   const handleChangeWrapped = React.useCallback((phoneValue) => {
@@ -229,7 +241,7 @@ const UnwrappedElementPhoneNumber = React.memo<Props>((props: Props) => {
           onBlur={() => setIsFocused(false)}
           disabled={disabled}
           {...hasCountrySelect ? {
-            countryOptionsOrder: countrySortOrder.length ? [...countrySortOrder, '|'] : [],
+            countryOptionsOrder,
             addInternationalOption: false,
             flags,
             countries,

--- a/libraries/engage/components/Form/Builder/ElementPhoneNumber.jsx
+++ b/libraries/engage/components/Form/Builder/ElementPhoneNumber.jsx
@@ -1,10 +1,11 @@
 // @flow
 import * as React from 'react';
 import classnames from 'classnames';
-import { camelCase } from 'lodash';
+import { camelCase, upperCase } from 'lodash';
 import { i18n } from '@shopgate/engage/core';
 import { parsePhoneNumber } from 'react-phone-number-input';
-import PhoneInput from 'react-phone-number-input/mobile';
+import PhoneInputCountrySelect from 'react-phone-number-input/mobile';
+import PhoneInput from 'react-phone-number-input/input-mobile';
 import { getCountries } from 'react-phone-number-input/input';
 import en from 'react-phone-number-input/locale/en';
 import de from 'react-phone-number-input/locale/de';
@@ -12,10 +13,10 @@ import es from 'react-phone-number-input/locale/es';
 import fr from 'react-phone-number-input/locale/fr';
 import pt from 'react-phone-number-input/locale/pt';
 import flags from 'react-phone-number-input/flags';
-import TextField from '@shopgate/pwa-ui-shared/TextField';
 import { useCountriesNames } from '@shopgate/engage/i18n';
 import { css } from 'glamor';
 import { themeConfig } from '@shopgate/engage';
+import Label from '@shopgate/pwa-ui-shared/TextField/components/Label';
 import FormHelper from './FormHelper';
 
 const { variables, colors } = themeConfig;
@@ -80,6 +81,7 @@ type Props = {
     handleChange: (string, any) => void,
     config?: {
       supportedCountries?: string[],
+      countrySortOrder?: string[],
       userLocation?: any,
     }
   },
@@ -111,10 +113,10 @@ const UnwrappedElementPhoneNumber = React.memo<Props>((props: Props) => {
   const {
     label,
     handleChange,
-    default: defaultValue = '',
     disabled = false,
     config: {
       supportedCountries = [],
+      countrySortOrder = [],
       userLocation = {},
     } = {},
   } = element;
@@ -123,30 +125,17 @@ const UnwrappedElementPhoneNumber = React.memo<Props>((props: Props) => {
 
   // Maps available countries to correct format.
   const countries = React.useMemo(() => {
-    if (!supportedCountries) {
+    if (supportedCountries.length === 0) {
       return builtInCountries;
     }
 
-    const sortedCountries = [
-      ...builtInCountries,
-    ];
-
-    const sanitizedSupportedCountries = supportedCountries.map((country) => {
+    return supportedCountries.map((country) => {
       const pieces = country.split('_');
-      return pieces[0];
+      return upperCase(pieces[0]);
     });
-
-    sanitizedSupportedCountries.forEach((country) => {
-      sortedCountries.splice(sortedCountries.indexOf(country), 1);
-    });
-
-    return [
-      ...sanitizedSupportedCountries,
-      ...sortedCountries,
-    ];
   }, [supportedCountries]);
 
-  const countriesNames = useCountriesNames(supportedCountries, locales);
+  const countriesNames = useCountriesNames(countries, locales);
 
   // Get labels for supported countries.
   const labels = React.useMemo(() => {
@@ -164,30 +153,50 @@ const UnwrappedElementPhoneNumber = React.memo<Props>((props: Props) => {
     return output;
   }, [countries, countriesNames]);
 
-  // Sets the default country based on the users location.
   const defaultCountry = React.useMemo(() => {
-    if (!defaultValue && !value && userLocation) {
-      return userLocation.country;
+    let country;
+
+    if (value) {
+      // Try to parse the value the determine a country
+      const phoneNumber = parsePhoneNumber(value || '');
+
+      if (phoneNumber && phoneNumber.country) {
+        ({ country } = phoneNumber);
+      }
     }
 
-    const phoneNumber = parsePhoneNumber(value || '');
-
-    if (phoneNumber && phoneNumber.country) {
-      return phoneNumber.country;
+    if (!country && userLocation) {
+      // Take the country from the user location if present
+      ({ country } = userLocation);
     }
 
-    if (userLocation) {
-      return userLocation.country;
+    if (!country) {
+      // If no country could be determined yet, take the country from the language
+      ([, country] = i18n.getLang().split('-'));
     }
 
-    return i18n.getLang().split('-')[1];
-  }, [defaultValue, userLocation, value]);
+    // Check if the determined country is included inside the available countries
+    if (!countries.includes(country)) {
+      if (countrySortOrder?.length && countries.includes(countrySortOrder[0])) {
+        // Take first country if the sort order list if present
+        ([country] = countrySortOrder);
+      } else {
+        // Take first country from the list
+        ([country] = countries);
+      }
+    }
+
+    return country;
+  }, [countries, countrySortOrder, userLocation, value]);
+
+  const hasCountrySelect = React.useMemo(() => countries.length > 1, [countries.length]);
 
   const handleChangeWrapped = React.useCallback((phoneValue) => {
     handleChange(phoneValue, { target: { name } });
   }, [handleChange, name]);
 
-  const phoneClasses = classnames({
+  const phoneClasses = classnames('textField', {
+    simpleInput: !hasCountrySelect,
     [camelCase(name)]: true,
     phonePicker: true,
     phonePickerError: !!errorText,
@@ -201,45 +210,33 @@ const UnwrappedElementPhoneNumber = React.memo<Props>((props: Props) => {
     return null;
   }
 
-  if (!countries || countries.length === 0) {
-    return (
-      <>
-        <TextField
-          name={name}
-          value={value}
-          onChange={handleChange}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          label={label}
-          className={classnames(styles.formField, { validationError: !!errorText })}
-          disabled={disabled}
-        />
-        <FormHelper
-          errorText={errorText}
-          element={element}
-          formName={formName}
-        />
-      </>
-    );
-  }
+  const Component = hasCountrySelect ? PhoneInputCountrySelect : PhoneInput;
 
   return (
     <div className="formBuilderField">
       <div className={phoneClasses}>
-        <PhoneInput
+        <Label
+          label={label}
+          isFocused={isFocused}
+          isFloating={isFocused || !!value}
+        />
+        <Component
           defaultCountry={defaultCountry}
-          addInternationalOption={false}
-          flags={flags}
           name={name}
           value={value || ''}
           onChange={handleChangeWrapped}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
-          placeholder={label}
-          countries={countries}
-          labels={labels}
           disabled={disabled}
-          countryOptionsOrder={supportedCountries.length ? [...supportedCountries, '|'] : []}
+          {...hasCountrySelect ? {
+            countryOptionsOrder: countrySortOrder.length ? [...countrySortOrder, '|'] : [],
+            addInternationalOption: false,
+            flags,
+            countries,
+            labels,
+          } : {
+            className: 'PhoneInputInput',
+          }}
         />
       </div>
       <FormHelper

--- a/libraries/engage/components/Form/Builder/ElementPhoneNumber.jsx
+++ b/libraries/engage/components/Form/Builder/ElementPhoneNumber.jsx
@@ -190,14 +190,21 @@ const UnwrappedElementPhoneNumber = React.memo<Props>((props: Props) => {
   }, [countries, countrySortOrder, userLocation, value]);
 
   const countryOptionsOrder = React.useMemo(() => {
-    const countryListsEqual = isEqual([...countries].sort(), [...countrySortOrder].sort());
+    /**
+     * To avoid component errors remove countries from the sort order array that are not part
+     * of the counties array.
+     */
+    const sanitizedCountrySortOrder = countrySortOrder.filter(
+      countryCode => countries.includes(countryCode)
+    );
+    const countryListsEqual = isEqual([...countries].sort(), [...sanitizedCountrySortOrder].sort());
     /**
      * When list with supported countries has the same entries as the country sort order, we don't
      * need to add a separator to the countryOptionsOrder array since the country picker lists
      * will not show a section with unordered countries.
      */
-    return countrySortOrder.length
-      ? [...countrySortOrder, ...(countryListsEqual ? [] : ['|'])]
+    return sanitizedCountrySortOrder.length
+      ? [...sanitizedCountrySortOrder, ...(countryListsEqual ? [] : ['|'])]
       : [];
   }, [countries, countrySortOrder]);
 

--- a/libraries/engage/components/Form/Builder/stylePresets.js
+++ b/libraries/engage/components/Form/Builder/stylePresets.js
@@ -111,6 +111,19 @@ export const OUTLINED_FORM_FIELDS = {
     paddingTop: 24,
     paddingBottom: 2,
   },
+  ' .textField.phonePicker:not(.simpleInput) .label': {
+    left: 48,
+    '&.floating': {
+      left: 0,
+    },
+  },
+  ' .textField.phonePicker:not(.simpleInput) input': {
+    paddingLeft: 0,
+  },
+  ' .phonePicker > .PhoneInputInput': {
+    paddingLeft: 16,
+    width: '100%',
+  },
   ' .phonePicker .PhoneInputInput': {
     borderBottom: 'none',
     color: 'var(--color-text-high-emphasis)',

--- a/libraries/engage/core/config/config.types.js
+++ b/libraries/engage/core/config/config.types.js
@@ -6,6 +6,7 @@ export type MerchantSettings = {
 
 export type ShopSettings = {
   supportedCountries?: string[];
+  countrySortOrder?: string[];
 }
 
 export type ConfigState = {

--- a/libraries/engage/orders/components/OrderDetails/OrderDetailsAuthenticate.jsx
+++ b/libraries/engage/orders/components/OrderDetails/OrderDetailsAuthenticate.jsx
@@ -16,6 +16,7 @@ const OrderDetailsAuthenticate = () => {
   const { pathname } = useRoute();
   const {
     supportedCountries,
+    countrySortOrder,
     userLocation,
     validationErrors,
     updateForm,
@@ -28,8 +29,12 @@ const OrderDetailsAuthenticate = () => {
   } = useOrderDetails();
 
   const formConfig = useMemo(
-    () => generateFormConfig(supportedCountries, userLocation),
-    [supportedCountries, userLocation]
+    () => generateFormConfig({
+      supportedCountries,
+      countrySortOrder,
+      userLocation,
+    }),
+    [countrySortOrder, supportedCountries, userLocation]
   );
 
   const handleUpdate = useCallback((values) => {

--- a/libraries/engage/orders/components/OrderDetails/OrderDetailsAuthenticateForm.config.js
+++ b/libraries/engage/orders/components/OrderDetails/OrderDetailsAuthenticateForm.config.js
@@ -2,11 +2,17 @@ import { i18n } from '@shopgate/engage/core';
 
 /**
  * Generates form configuration.
- * @param {Array} supportedCountries A list of supported countries.
- * @param {Object} userLocation User location for better phone picker defaults.
+ * @param {Object} options Options for the helper
+ * @param {Array} options.supportedCountries A list of supported countries.
+ * @param {Array} options.countrySortOrder Sort order for supported countries.
+ * @param {Object} options.userLocation User location for better phone picker defaults.
  * @returns {Object}
  */
-const generateFormConfig = (supportedCountries, userLocation) => ({
+const generateFormConfig = ({
+  supportedCountries,
+  countrySortOrder,
+  userLocation,
+}) => ({
   fields: {
     email: {
       type: 'email',
@@ -17,6 +23,7 @@ const generateFormConfig = (supportedCountries, userLocation) => ({
       label: `${i18n.text('checkout.pickup_contact.form.mobile')} *`,
       config: {
         supportedCountries,
+        countrySortOrder,
         userLocation,
       },
     },

--- a/libraries/engage/orders/providers/OrderDetailsPrivateProvider.jsx
+++ b/libraries/engage/orders/providers/OrderDetailsPrivateProvider.jsx
@@ -55,12 +55,20 @@ const OrderDetailsProvider = ({
       order,
       isLoading,
       supportedCountries: shopSettings.supportedCountries,
+      countrySortOrder: shopSettings.countrySortOrder,
       userLocation,
       fetchOrderDetails,
       cancelOrder: handleCancel,
     }),
-    [order, isLoading, shopSettings.supportedCountries,
-      userLocation, fetchOrderDetails, handleCancel]
+    [
+      order,
+      isLoading,
+      shopSettings.supportedCountries,
+      shopSettings.countrySortOrder,
+      userLocation,
+      fetchOrderDetails,
+      handleCancel,
+    ]
   );
 
   return (

--- a/libraries/engage/orders/providers/OrderDetailsProvider.jsx
+++ b/libraries/engage/orders/providers/OrderDetailsProvider.jsx
@@ -171,6 +171,7 @@ const OrderDetailsProvider = ({
       isLoading,
       showForm,
       supportedCountries: shopSettings.supportedCountries,
+      countrySortOrder: shopSettings.countrySortOrder,
       validationErrors: convertValidationErrors(
         authenticateFormState.validationErrors || {}
       ),
@@ -192,6 +193,7 @@ const OrderDetailsProvider = ({
       isLoading,
       order,
       shopSettings.supportedCountries,
+      shopSettings.countrySortOrder,
       userLocation,
       errorMessage,
     ]

--- a/libraries/engage/package.json
+++ b/libraries/engage/package.json
@@ -36,7 +36,7 @@
     "moment": "^2.27.0",
     "react-helmet": "^5.1.3",
     "react-leaflet": "^2.7.0",
-    "react-phone-number-input": "^3.0.22",
+    "react-phone-number-input": "^3.2.16",
     "react-player": "1.11.0",
     "react-portal": "^3.1.0",
     "react-swipeable": "^4.0.1",

--- a/libraries/engage/registration/components/GuestRegistration/GuestRegistrationFormPickup.config.js
+++ b/libraries/engage/registration/components/GuestRegistration/GuestRegistrationFormPickup.config.js
@@ -11,10 +11,17 @@ const pickupFieldActions = [{
 
 /**
  * Generates form configuration.
- * @param {Object} params Additional parameters
+ * @param {Object} options Options for the helper
+ * @param {Array} options.supportedCountries A list of supported countries.
+ * @param {Array} options.countrySortOrder Sort order for supported countries.
+ * @param {Object} options.userLocation User location for better phone picker defaults.
  * @returns {Object}
  */
-const generateFormConfig = ({ supportedCountries, userLocation }) => ({
+const generateFormConfig = ({
+  supportedCountries,
+  countrySortOrder,
+  userLocation,
+}) => ({
   fields: {
     pickupPerson: {
       type: 'radio',
@@ -45,6 +52,7 @@ const generateFormConfig = ({ supportedCountries, userLocation }) => ({
       actions: pickupFieldActions,
       config: {
         supportedCountries,
+        countrySortOrder,
         userLocation,
       },
     },

--- a/libraries/engage/registration/components/GuestRegistration/GuestRegistrationFormPickup.jsx
+++ b/libraries/engage/registration/components/GuestRegistration/GuestRegistrationFormPickup.jsx
@@ -45,6 +45,7 @@ const styles = {
 const GuestRegistrationFormPickup = () => {
   const {
     supportedCountries,
+    countrySortOrder,
     userLocation,
     defaultPickupFormState,
     pickupFormValidationErrors,
@@ -56,9 +57,10 @@ const GuestRegistrationFormPickup = () => {
   const formConfig = React.useMemo(
     () => generateFormConfig({
       supportedCountries,
+      countrySortOrder,
       userLocation,
     }),
-    [supportedCountries, userLocation]
+    [countrySortOrder, supportedCountries, userLocation]
   );
 
   const handleUpdate = useCallback((values) => {

--- a/libraries/engage/registration/components/Registration/RegistrationFormBilling.config.js
+++ b/libraries/engage/registration/components/Registration/RegistrationFormBilling.config.js
@@ -7,6 +7,7 @@ import { i18n } from '@shopgate/engage/core';
  */
 const generateFormConfig = ({
   supportedCountries,
+  countrySortOrder,
   userLocation,
   numberOfAddressLines,
   isGuest,
@@ -32,6 +33,7 @@ const generateFormConfig = ({
       label: `${i18n.text('checkout.pickup_contact.form.mobile')} *`,
       config: {
         supportedCountries,
+        countrySortOrder,
         userLocation,
       },
     },

--- a/libraries/engage/registration/components/Registration/RegistrationFormBilling.jsx
+++ b/libraries/engage/registration/components/Registration/RegistrationFormBilling.jsx
@@ -15,6 +15,7 @@ import { form, section } from './RegistrationContent.style';
 const RegistrationFormBilling = ({ isGuest }) => {
   const {
     supportedCountries,
+    countrySortOrder,
     userLocation,
     defaultBillingFormState,
     billingFormValidationErrors,
@@ -27,12 +28,14 @@ const RegistrationFormBilling = ({ isGuest }) => {
   const formConfig = useMemo(
     () => generateFormConfig({
       supportedCountries,
+      countrySortOrder,
       userLocation,
       numberOfAddressLines,
       isGuest,
       isReserveOnly: orderReserveOnly,
     }),
     [
+      countrySortOrder,
       isGuest,
       numberOfAddressLines,
       orderReserveOnly,

--- a/libraries/engage/registration/components/Registration/RegistrationFormExtra.config.js
+++ b/libraries/engage/registration/components/Registration/RegistrationFormExtra.config.js
@@ -10,10 +10,11 @@ const generateFormConfig = ({
   customerAttributes,
   isGuest,
   supportedCountries,
+  countrySortOrder,
   userLocation,
 }) => ({
   fields: {
-    ...(!isGuest && {
+    ...(!isGuest ? {
       marketingOptIn: {
         type: 'checkbox',
         label: i18n.text('registration.marketing_opt_in_label'),
@@ -22,6 +23,7 @@ const generateFormConfig = ({
     ...generateCustomerAttributesFields({
       customerAttributes,
       supportedCountries,
+      countrySortOrder,
       userLocation,
     }),
   },

--- a/libraries/engage/registration/components/Registration/RegistrationFormExtra.jsx
+++ b/libraries/engage/registration/components/Registration/RegistrationFormExtra.jsx
@@ -19,6 +19,7 @@ const RegistrationFormExtra = ({ isGuest }) => {
     customerAttributes,
     extraFormValidationErrors,
     supportedCountries,
+    countrySortOrder,
     userLocation,
   } = useRegistration(isGuest);
 
@@ -27,9 +28,10 @@ const RegistrationFormExtra = ({ isGuest }) => {
       customerAttributes,
       isGuest,
       supportedCountries,
+      countrySortOrder,
       userLocation,
     }),
-    [customerAttributes, isGuest, supportedCountries, userLocation]
+    [countrySortOrder, customerAttributes, isGuest, supportedCountries, userLocation]
   );
 
   const handleUpdate = useCallback((values) => {

--- a/libraries/engage/registration/components/Registration/RegistrationFormShipping.config.js
+++ b/libraries/engage/registration/components/Registration/RegistrationFormShipping.config.js
@@ -7,6 +7,7 @@ import { i18n } from '@shopgate/engage/core';
  */
 const generateFormConfig = ({
   supportedCountries,
+  countrySortOrder,
   userLocation,
   numberOfAddressLines,
 }) => ({
@@ -24,6 +25,7 @@ const generateFormConfig = ({
       label: `${i18n.text('checkout.pickup_contact.form.mobile')} *`,
       config: {
         supportedCountries,
+        countrySortOrder,
         userLocation,
       },
     },

--- a/libraries/engage/registration/components/Registration/RegistrationFormShipping.jsx
+++ b/libraries/engage/registration/components/Registration/RegistrationFormShipping.jsx
@@ -18,6 +18,7 @@ import {
 const RegistrationFormShipping = ({ isGuest }) => {
   const {
     supportedCountries,
+    countrySortOrder,
     userLocation,
     defaultShippingFormState,
     shippingFormValidationErrors,
@@ -30,10 +31,11 @@ const RegistrationFormShipping = ({ isGuest }) => {
   const formConfig = useMemo(
     () => generateFormConfig({
       supportedCountries,
+      countrySortOrder,
       userLocation,
       numberOfAddressLines,
     }),
-    [numberOfAddressLines, supportedCountries, userLocation]
+    [countrySortOrder, numberOfAddressLines, supportedCountries, userLocation]
   );
 
   const handleUpdate = useCallback((values) => {

--- a/libraries/engage/registration/providers/GuestRegistrationProvider.jsx
+++ b/libraries/engage/registration/providers/GuestRegistrationProvider.jsx
@@ -429,6 +429,7 @@ const GuestRegistrationProvider = ({
       numberOfAddressLines,
       userLocation,
       supportedCountries: shopSettings.supportedCountries,
+      countrySortOrder: shopSettings.countrySortOrder,
       isLocked,
       handleSubmit,
       /**
@@ -468,6 +469,7 @@ const GuestRegistrationProvider = ({
       numberOfAddressLines,
       userLocation,
       shopSettings.supportedCountries,
+      shopSettings.countrySortOrder,
       isLocked,
       handleSubmit,
     ]

--- a/libraries/engage/registration/providers/RegistrationProvider.jsx
+++ b/libraries/engage/registration/providers/RegistrationProvider.jsx
@@ -318,6 +318,7 @@ const RegistrationProvider = ({
   const value = useMemo(
     () => ({
       supportedCountries: shopSettings.supportedCountries || [],
+      countrySortOrder: shopSettings.countrySortOrder || [],
       customerAttributes,
       userLocation,
       defaultBaseFormState,
@@ -350,6 +351,7 @@ const RegistrationProvider = ({
     }),
     [
       shopSettings.supportedCountries,
+      shopSettings.countrySortOrder,
       customerAttributes,
       userLocation,
       defaultBaseFormState,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,6 +2817,11 @@ classnames@^2.2.5, classnames@^2.2.6:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
+classnames@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 clean-css@4.2.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"
@@ -3412,10 +3417,10 @@ cosmiconfig@^5.0.2, cosmiconfig@^5.0.7:
     lodash.get "^4.4.2"
     parse-json "^4.0.0"
 
-country-flag-icons@^1.0.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/country-flag-icons/-/country-flag-icons-1.2.0.tgz#c5c62ac37f73891aa11b85f6401ef4c67a7edeb2"
-  integrity sha512-0pKnYXoxXpkAabooiT5pfFfBFOk+V5nToDk+a0McHP6oOiIgD+cQmADVjcGrmvqm+cdNIiHQ94eKQ4vsWqwN0A==
+country-flag-icons@^1.5.4:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/country-flag-icons/-/country-flag-icons-1.5.5.tgz#04a41c83e2ea38ea28054d4e3eff9d1ce16aec1c"
+  integrity sha512-k4WXZ/WvWOSiYXRG1n8EYHNr1m/IX0GffKqAidaet5DrJsDOmJ8Q/8JvvONhZNnKYg24s4lvsm+9og1HcuIU/g==
 
 coveralls@^3.0.0, coveralls@^3.0.1:
   version "3.0.2"
@@ -6107,12 +6112,12 @@ inline-style-prefixer@^4.0.0:
     bowser "^1.7.3"
     css-in-js-utils "^2.0.0"
 
-input-format@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/input-format/-/input-format-0.3.0.tgz#f662b1667b6d067769f44c717bcfcc92554bee75"
-  integrity sha512-7ipaXJ5Hnd2o62IxLRTCMcl7AOPzxU2PTfDunPDIaaAjq+Q8DcjI4/nmPo3fXJUvdTCX97BlW8d+7ArUhVTxAA==
+input-format@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/input-format/-/input-format-0.3.8.tgz#9445b0cab2f0457fbe36d77d607e942fd37345c5"
+  integrity sha512-tLR0XRig1xIcG1PtIpMd/uoltvkAI62CN9OIbtj4/tEJAkqTCQLNHUZ9N4M46w0dopny7Rlt/lRH5Xzp7e6F+g==
   dependencies:
-    prop-types "^15.7.2"
+    prop-types "^15.8.1"
 
 inquirer@^3.2.2:
   version "3.3.0"
@@ -7502,13 +7507,10 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-libphonenumber-js@^1.7.45:
-  version "1.7.48"
-  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.7.48.tgz#15b7258b642d0ef5faced14401528639be9a8eaa"
-  integrity sha512-qiHOxCBQ8cNqSkpUcAFn0vwk8eZs6Bq6ttQTiiAICEfUZp3uQ/RuOnPqYMw5qciHCrCNjLN3qp3ih1u0+NuzVA==
-  dependencies:
-    minimist "^1.2.5"
-    xml2js "^0.4.17"
+libphonenumber-js@^1.10.17:
+  version "1.10.17"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.10.17.tgz#7efcfa3068fc076bc59a43a08a723ccd95308474"
+  integrity sha512-UQrNzsusSn5qaojdpWqporWRdpx6AGeb+egj64NrpYuyKHvnSH9jMp/1Dy3b/WnMyJA5zgV1yw//jC6J0dCXkw==
 
 lint-staged@^7.2.2:
   version "7.3.0"
@@ -8267,11 +8269,6 @@ minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minimist@~0.0.1:
   version "0.0.10"
@@ -9598,6 +9595,15 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8,
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 proxy-addr@~2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"
@@ -9875,6 +9881,11 @@ react-inline-transition-group@^2.2.1:
     prop-types "^15.5.8"
     react-transition-hooks "^1.2.0"
 
+react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.2, react-is@^16.8.4, react-is@^16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
@@ -9895,16 +9906,16 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-phone-number-input@^3.0.22:
-  version "3.0.22"
-  resolved "https://registry.yarnpkg.com/react-phone-number-input/-/react-phone-number-input-3.0.22.tgz#4e694492388dc7350e687e2c7900a7c843f7d06d"
-  integrity sha512-LLQENqN3Pz4I/L/A5a4jrLezfIM++J/YLmejCqgs3K1aO0BKoTJIHlhRms1D0tApZUdXB8nDTQNLO5VGZcVDww==
+react-phone-number-input@^3.2.16:
+  version "3.2.16"
+  resolved "https://registry.yarnpkg.com/react-phone-number-input/-/react-phone-number-input-3.2.16.tgz#41d581d0b8f61bc34b2e446ed26535c2efaf64c4"
+  integrity sha512-xNmY6chXarq6BT+1MiB7owzrvitC7BbXUR8RCMJ0g4afeACr9T3KwkDpVDII+DTmPRjSqs7fV7ZI1H2qjDGHcQ==
   dependencies:
-    classnames "^2.2.5"
-    country-flag-icons "^1.0.2"
-    input-format "^0.3.0"
-    libphonenumber-js "^1.7.45"
-    prop-types "^15.7.2"
+    classnames "^2.3.1"
+    country-flag-icons "^1.5.4"
+    input-format "^0.3.8"
+    libphonenumber-js "^1.10.17"
+    prop-types "^15.8.1"
 
 react-player@1.11.0:
   version "1.11.0"
@@ -10641,7 +10652,7 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@>=0.6.0, sax@^1.2.1, sax@^1.2.4:
+sax@^1.2.1, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -12704,19 +12715,6 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
-
-xml2js@^0.4.17:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
-  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
-
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
-  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
# Description
This ticket is about to improve configurability of phone number inputs within forms like registration. Right now those fields render a country picker in any case - even if the shop only supports a single country.

To archive this goal, the logic how the country list is determined will is changed. Like at other components the "supportedCountries" shop config is now used to create the county list. Before it was used to show selected countries at the top of the country list. 
When the list is empty, the country selector contains all countries that the react-phone-number-input supports. "supportedCountries" only contains a single entry, the country select will be hidden.

To avoid loosing functionality with the prioritized countries, the ticket introduces a new shop config called "countrySortOrder" that can be used to put some selected countries with a predefined sort order at the top of the country list.

Besides that the ticked adds support for floating labels to the phone number inputs.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [x] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Configure "supportedCountries" and "countrySortOrder" in your storefront extension settings to test how the phone number input behaves.
