### PR TITLE
Fixed an issue at tracking event creation after successful scanner scan

### DIFF
--- a/libraries/commerce/scanner/index.js
+++ b/libraries/commerce/scanner/index.js
@@ -1,9 +1,13 @@
 // ACTION-CREATORS
 export { default as startScanner } from './action-creators/startScanner';
+export { default as successHandleScanner } from './action-creators/successHandleScanner';
+export { default as errorHandleScanner } from './action-creators/errorHandleScanner';
 
 // ACTIONS
 export { default as handleBarCode } from './actions/handleBarCode';
 export { default as handleQrCode } from './actions/handleQrCode';
+export { default as handleSearch } from './actions/handleSearch';
+export { default as handleNoResults } from './actions/handleNoResults';
 
 // CONSTANTS
 export * from './constants';

--- a/libraries/engage/scanner/index.js
+++ b/libraries/engage/scanner/index.js
@@ -1,11 +1,15 @@
 /** @module scanner */
 
 // ACTION-CREATORS
-export { default as startScanner } from '@shopgate/pwa-common-commerce/scanner//action-creators/startScanner';
+export { default as startScanner } from '@shopgate/pwa-common-commerce/scanner/action-creators/startScanner';
+export { default as successHandleScanner } from '@shopgate/pwa-common-commerce/scanner/action-creators/successHandleScanner';
+export { default as errorHandleScanner } from '@shopgate/pwa-common-commerce/scanner/action-creators/errorHandleScanner';
 
 // ACTIONS
 export { default as handleBarCode } from '@shopgate/pwa-common-commerce/scanner/actions/handleBarCode';
 export { default as handleQrCode } from '@shopgate/pwa-common-commerce/scanner/actions/handleQrCode';
+export { default as handleSearch } from '@shopgate/pwa-common-commerce/scanner/actions/handleSearch';
+export { default as handleNoResults } from '@shopgate/pwa-common-commerce/scanner/actions/handleNoResults';
 
 export { default as scanner } from '@shopgate/pwa-core/classes/Scanner';
 

--- a/libraries/tracking/helpers/index.js
+++ b/libraries/tracking/helpers/index.js
@@ -304,7 +304,7 @@ export const buildScannerUtmUrl = ({
     medium = 'qrcode_scanner';
     campaign = `${shopNumber}QRScan`;
 
-    const { type, data } = parse2dsQrCode(payload);
+    const { type, data } = parse2dsQrCode(payload) || {};
     if (type === QR_CODE_TYPE_SEARCH) {
       term = data.searchPhrase;
     }

--- a/libraries/tracking/helpers/index.js
+++ b/libraries/tracking/helpers/index.js
@@ -1,5 +1,6 @@
 import get from 'lodash/get';
 import find from 'lodash/find';
+import queryString from 'query-string';
 import { logger } from '@shopgate/pwa-core/helpers';
 import {
   QR_CODE_TYPE_HOMEPAGE,
@@ -310,6 +311,21 @@ export const buildScannerUtmUrl = ({
     }
   }
 
+  let parsedPayload;
+  let utmContent;
+
+  try {
+    parsedPayload = queryString.parseUrl(payload);
+  } catch (e) {
+    // noting to do here
+  }
+
+  if (parsedPayload && parsedPayload.query) {
+    if (parsedPayload.query.utm_content) {
+      utmContent = parsedPayload.query.utm_content;
+    }
+  }
+
   const { location } = scannerRoute;
 
   const newPath = new URL(location, 'http://scanner.com');
@@ -319,7 +335,7 @@ export const buildScannerUtmUrl = ({
     utm_medium: medium,
     utm_campaign: campaign,
     utm_term: term,
-    utm_content: referer,
+    utm_content: utmContent || referer,
   };
   /* eslint-enable camelcase */
 

--- a/libraries/tracking/helpers/index.spec.js
+++ b/libraries/tracking/helpers/index.spec.js
@@ -175,6 +175,17 @@ describe('Tracking helpers', () => {
         });
         expect(result).toEqual('/scanner?utm_source=shopgate&utm_medium=qrcode_scanner&utm_campaign=30177QRScan&utm_term=searchPhrase&utm_content=%2F');
       });
+
+      it('should handle custom urls with utm params', () => {
+        const result = buildScannerUtmUrl({
+          scannerRoute: { location: '/scanner' },
+          format: 'QR_CODE',
+          payload: 'http://custom.url/foo/bar?utm_content=some_content',
+          referer,
+        });
+
+        expect(result).toEqual('/scanner?utm_source=shopgate&utm_medium=qrcode_scanner&utm_campaign=30177QRScan&utm_content=some_content');
+      });
     });
 
     describe('custom Utms', () => {


### PR DESCRIPTION
# Description

This ticket fixes an issue that could occur when a custom handling for qr code scanning is implemented. When a scan was successful for a qr code payload that was no internal shopgate url, an js error was thrown.

Additionally it adds some additional actions to the @shopgate/engage/scanner library.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
