### PR TITLE
Fixed a couple of small bugs related to push messages and tracking

### DIFF
--- a/libraries/commerce/category/actions/fetchCategoryOrRootCategories.js
+++ b/libraries/commerce/category/actions/fetchCategoryOrRootCategories.js
@@ -1,0 +1,22 @@
+import { mutable } from '@shopgate/pwa-common/helpers/redux';
+import fetchRootCategories from './fetchRootCategories';
+import fetchCategory from './fetchCategory';
+
+/**
+ * Retrieves a category from the server when a categoryId is given. Otherwise it will fetch the
+ * root categories.
+ * @param {string} categoryId The category ID.
+ * @return {Function} The dispatched action.
+ */
+function fetchCategoryOrRootCategories(categoryId) {
+  return (dispatch) => {
+    if (!categoryId) {
+      dispatch(fetchRootCategories());
+      return;
+    }
+
+    dispatch(fetchCategory(categoryId));
+  };
+}
+
+export default mutable(fetchCategoryOrRootCategories);

--- a/libraries/commerce/category/actions/getCategory.js
+++ b/libraries/commerce/category/actions/getCategory.js
@@ -1,18 +1,16 @@
-import fetchRootCategories from './fetchRootCategories';
-import fetchCategory from './fetchCategory';
+import { logDeprecationMessage } from '@shopgate/pwa-core/helpers';
+import fetchCategoryOrRootCategories from './fetchCategoryOrRootCategories';
 
 /**
- * Retrieves a category from the server.
+ * Deprecation fallback for the fetchCategoryOrRootCategories action
+ * @deprecated
  * @param {string} categoryId The category ID.
  * @return {Function} The dispatched action.
  */
-const getCategory = categoryId => (dispatch) => {
-  if (!categoryId) {
-    dispatch(fetchRootCategories());
-    return;
-  }
+const getCategory = (categoryId) => {
+  logDeprecationMessage('The fetch action getCategory will be removed in future versions due naming conflict with getCategory selector. Please use fetchCategoryOrRootCategories as a replacement');
 
-  dispatch(fetchCategory(categoryId));
+  return fetchCategoryOrRootCategories(categoryId);
 };
 
 export default getCategory;

--- a/libraries/commerce/category/index.js
+++ b/libraries/commerce/category/index.js
@@ -1,9 +1,9 @@
 // ACTIONS
 export { default as fetchCategory } from './actions/fetchCategory';
+export { default as fetchCategoryOrRootCategories } from './actions/fetchCategoryOrRootCategories';
 export { default as fetchCategoryChildren } from './actions/fetchCategoryChildren';
 export { default as fetchCategoryProducts } from './actions/fetchCategoryProducts';
 export { default as fetchRootCategories } from './actions/fetchRootCategories';
-export { default as getCategory } from './actions/getCategory';
 
 // CONSTANTS
 export * from './constants/index';

--- a/libraries/common/actions/app/handleLink.js
+++ b/libraries/common/actions/app/handleLink.js
@@ -40,6 +40,11 @@ export default function handleLink(payload, allowExternalLinks = false) {
     } else {
       // Remove the deeplink protocol from the link.
       pathname = link.replace(/^(.*:)(\/\/)?/, '/');
+
+      if (!pathname.startsWith('/')) {
+        // Take care that pathname starts with a slash. Otherwise routing can break
+        pathname = `/${pathname}`;
+      }
     }
 
     if (!pathname || pathname === INDEX_PATH || pathname.startsWith(INDEX_PATH_DEEPLINK)) {

--- a/libraries/common/actions/app/handleLink.spec.js
+++ b/libraries/common/actions/app/handleLink.spec.js
@@ -88,4 +88,22 @@ describe('handleLink()', () => {
       expect(historyPush).toHaveBeenCalledWith({ pathname: '/path/test' });
     });
   });
+
+  describe('handle relative links', () => {
+    it('should not modify valid links', () => {
+      const link = '/path/test';
+      handleLink({ link })(dispatch);
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(historyPush).toHaveBeenCalledTimes(1);
+      expect(historyPush).toHaveBeenCalledWith({ pathname: '/path/test' });
+    });
+
+    it('should add a leading slash when not included in link', () => {
+      const link = 'path/test';
+      handleLink({ link })(dispatch);
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(historyPush).toHaveBeenCalledTimes(1);
+      expect(historyPush).toHaveBeenCalledWith({ pathname: '/path/test' });
+    });
+  });
 });

--- a/libraries/engage/category/index.js
+++ b/libraries/engage/category/index.js
@@ -2,6 +2,7 @@
 
 // ACTIONS
 export { default as fetchCategory } from '@shopgate/pwa-common-commerce/category/actions/fetchCategory';
+export { default as fetchCategoryOrRootCategories } from '@shopgate/pwa-common-commerce/category/actions/fetchCategoryOrRootCategories';
 export { default as fetchCategoryChildren } from '@shopgate/pwa-common-commerce/category/actions/fetchCategoryChildren';
 export { default as fetchCategoryProducts } from '@shopgate/pwa-common-commerce/category/actions/fetchCategoryProducts';
 export { default as fetchRootCategories } from '@shopgate/pwa-common-commerce/category/actions/fetchRootCategories';

--- a/libraries/engage/category/index.js
+++ b/libraries/engage/category/index.js
@@ -6,7 +6,6 @@ export { default as fetchCategoryOrRootCategories } from '@shopgate/pwa-common-c
 export { default as fetchCategoryChildren } from '@shopgate/pwa-common-commerce/category/actions/fetchCategoryChildren';
 export { default as fetchCategoryProducts } from '@shopgate/pwa-common-commerce/category/actions/fetchCategoryProducts';
 export { default as fetchRootCategories } from '@shopgate/pwa-common-commerce/category/actions/fetchRootCategories';
-export { default as getCategory } from '@shopgate/pwa-common-commerce/category/actions/getCategory';
 
 // CONSTANTS
 export * from '@shopgate/pwa-common-commerce/category/constants/index';

--- a/libraries/tracking/streams/cart.js
+++ b/libraries/tracking/streams/cart.js
@@ -1,0 +1,54 @@
+import 'rxjs/add/operator/switchMap';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/defer';
+import { Observable } from 'rxjs/Observable';
+
+import {
+  productsAdded$ as originalProductsAdded$,
+} from '@shopgate/pwa-common-commerce/cart/streams';
+import { getProductById, fetchProductsById } from '@shopgate/pwa-common-commerce/product';
+
+/**
+ * Emits when a product was added to the cart and product data is available
+ */
+export const productsAdded$ = originalProductsAdded$
+  .switchMap((input) => {
+    const { getState, action, dispatch } = input;
+    const { products = [] } = action;
+
+    // Collect product ids from the add-to-cart action
+    const productIds = products.map(({ productId }) => productId).filter(Boolean);
+
+    // Check if we have product data for all productIds
+    const productDataAvailable = productIds
+      .every(productId => getProductById(getState(), { productId }));
+
+    if (productDataAvailable) {
+      // All product data for the tracking even is available - handover action data to subscribers
+      return Observable.of(input);
+    }
+
+    /**
+     * Incomplete product data can be caused by an add-to-cart push message. In that case the
+     * product was never fetched before due to visiting PDP. So we need to fetch missing product
+     * data first.
+     * Subscribers will receive the original action when product data comes available.
+     */
+    return Observable
+      .defer(async () => {
+        let result = { products: [] };
+
+        try {
+          result = await dispatch(fetchProductsById(productIds));
+        } catch (e) {
+        // nothing to do here - default result will be returned
+        }
+
+        return result;
+      })
+      .first()
+      // do not proceed when request didn't return any products (no suitable tracking data)
+      .filter(data => Array.isArray(data.products) && data.products.length > 0)
+      // handover original action to subscribers
+      .switchMap(() => Observable.of(input));
+  });

--- a/libraries/tracking/streams/cart.spec.js
+++ b/libraries/tracking/streams/cart.spec.js
@@ -1,0 +1,105 @@
+import { combineReducers } from 'redux';
+import { createMockStore } from '@shopgate/pwa-common/store';
+import product from '@shopgate/pwa-common-commerce/product/reducers';
+import addProductsToCart from '@shopgate/pwa-common-commerce/cart/action-creators/addProductsToCart';
+import {
+  getProductById,
+  fetchProductsById,
+} from '@shopgate/pwa-common-commerce/product';
+import { productsAdded$ } from './cart';
+
+jest.mock('@shopgate/pwa-common-commerce/product', () => ({
+  getProductById: jest.fn().mockReturnValue({ productData: { id: 'mock' } }),
+  fetchProductsById: jest.fn().mockReturnValue(() => Promise.resolve({
+    products: [
+      { id: 'SG' },
+      { id: 'ACME' },
+    ],
+  })),
+}));
+
+describe('Cart streams', () => {
+  let dispatch;
+
+  beforeEach(() => {
+    ({ dispatch } = createMockStore(combineReducers({ product })));
+  });
+
+  describe('productsAdded$', () => {
+    let productsAddedSubscriber;
+    let subscription;
+
+    let action;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      productsAddedSubscriber = jest.fn();
+      subscription = productsAdded$.subscribe(productsAddedSubscriber);
+
+      action = addProductsToCart([{
+        productId: 'SG',
+        quantity: 1,
+      }, {
+        productId: 'ACME',
+        quantity: 2,
+      }]);
+    });
+
+    afterEach(() => {
+      subscription.unsubscribe();
+    });
+
+    it('should directly emit when all product data is available in store', (done) => {
+      dispatch(action);
+
+      // ugly trick, but async screens are complicated to test
+      setTimeout(() => {
+        expect(productsAddedSubscriber).toHaveBeenCalledTimes(1);
+        expect(getProductById).toHaveBeenCalledTimes(2);
+        expect(fetchProductsById).not.toHaveBeenCalled();
+        done();
+      }, 0);
+    });
+
+    it('should emit after products where fetched when product data is not in store', (done) => {
+      // one product not available in store
+      getProductById.mockReturnValueOnce(null);
+
+      dispatch(action);
+
+      setTimeout(() => {
+        expect(productsAddedSubscriber).toHaveBeenCalledTimes(1);
+        // Array.every seems to stop the loop after first check failed - so only one call here
+        expect(getProductById).toHaveBeenCalledTimes(1);
+        expect(fetchProductsById).toHaveBeenCalledTimes(1);
+        done();
+      }, 0);
+    });
+
+    it('should not call the subscriber when request fails', (done) => {
+      getProductById.mockReturnValueOnce(null);
+      fetchProductsById.mockReturnValue(() => Promise.reject());
+
+      dispatch(action);
+
+      setTimeout(() => {
+        expect(productsAddedSubscriber).toHaveBeenCalledTimes(0);
+        done();
+      }, 0);
+    });
+
+    it('should not call the subscriber when request returns no products', (done) => {
+      getProductById.mockReturnValueOnce(null);
+      fetchProductsById.mockReturnValueOnce(() => Promise.resolve({ products: [] }));
+
+      dispatch(action);
+
+      setTimeout(() => {
+        expect(productsAddedSubscriber).toHaveBeenCalledTimes(0);
+        expect(getProductById).toHaveBeenCalledTimes(1);
+        expect(fetchProductsById).toHaveBeenCalledTimes(1);
+        done();
+      }, 0);
+    });
+  });
+});

--- a/libraries/tracking/subscriptions/cart.js
+++ b/libraries/tracking/subscriptions/cart.js
@@ -1,4 +1,4 @@
-import { productsAdded$ } from '@shopgate/pwa-common-commerce/cart/streams';
+import { productsAdded$ } from '../streams/cart';
 import { getAddToCartProducts } from '../selectors/cart';
 import getPage from '../selectors/page';
 import { track } from '../helpers/index';

--- a/themes/theme-gmd/widgets/CategoryList/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/widgets/CategoryList/__snapshots__/spec.jsx.snap
@@ -3,7 +3,6 @@
 exports[`<CategoryListWidget /> should not render the CategoryListWidget 1`] = `
 <CategoryListWidget
   fetchCategory={[Function]}
-  getCategory={[Function]}
   items={null}
   settings={
     Object {
@@ -18,7 +17,6 @@ exports[`<CategoryListWidget /> should not render the CategoryListWidget 1`] = `
 exports[`<CategoryListWidget /> should render the CategoryListWidget 1`] = `
 <CategoryListWidget
   fetchCategory={[Function]}
-  getCategory={[Function]}
   items={
     Array [
       Object {

--- a/themes/theme-gmd/widgets/CategoryList/connector.js
+++ b/themes/theme-gmd/widgets/CategoryList/connector.js
@@ -8,7 +8,7 @@ import { getCategoriesById } from '../selectors';
  * @return {Object} The extended component props.
  */
 const mapDispatchToProps = dispatch => ({
-  getCategory: categoryId => dispatch(fetchCategoryOrRootCategories(categoryId)),
+  fetchCategory: categoryId => dispatch(fetchCategoryOrRootCategories(categoryId)),
 });
 
 /**

--- a/themes/theme-gmd/widgets/CategoryList/connector.js
+++ b/themes/theme-gmd/widgets/CategoryList/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import getCategory from '@shopgate/pwa-common-commerce/category/actions/getCategory';
+import { fetchCategoryOrRootCategories } from '@shopgate/engage/category';
 import { getCategoriesById } from '../selectors';
 
 /**
@@ -8,9 +8,7 @@ import { getCategoriesById } from '../selectors';
  * @return {Object} The extended component props.
  */
 const mapDispatchToProps = dispatch => ({
-  getCategory(categoryId) {
-    dispatch(getCategory(categoryId));
-  },
+  getCategory: categoryId => dispatch(fetchCategoryOrRootCategories(categoryId)),
 });
 
 /**

--- a/themes/theme-gmd/widgets/CategoryList/index.jsx
+++ b/themes/theme-gmd/widgets/CategoryList/index.jsx
@@ -15,12 +15,12 @@ import styles from './style';
 class CategoryListWidget extends Component {
   static propTypes = {
     settings: PropTypes.shape().isRequired,
-    getCategory: PropTypes.func,
+    fetchCategory: PropTypes.func,
     items: PropTypes.arrayOf(PropTypes.shape()),
   };
 
   static defaultProps = {
-    getCategory: () => {},
+    fetchCategory: () => {},
     items: null,
   };
 
@@ -29,7 +29,7 @@ class CategoryListWidget extends Component {
    */
   componentDidMount() {
     if (!this.props.items) {
-      this.props.getCategory(this.props.settings.categoryNumber);
+      this.props.fetchCategory(this.props.settings.categoryNumber);
     }
   }
 

--- a/themes/theme-gmd/widgets/NestedCategoryFilter/components/Picker/connector.js
+++ b/themes/theme-gmd/widgets/NestedCategoryFilter/components/Picker/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import fetchCategory from '@shopgate/pwa-common-commerce/category/actions/getCategory';
+import { fetchCategoryOrRootCategories } from '@shopgate/engage/category';
 import { getCategoriesById } from '../../../selectors';
 
 /**
@@ -18,7 +18,7 @@ const mapStateToProps = (state, { categoryId }) => ({
  * @return {Object} The extended component props.
  */
 const mapDispatchToProps = dispatch => ({
-  fetchCategory: id => dispatch(fetchCategory(id)),
+  fetchCategory: id => dispatch(fetchCategoryOrRootCategories(id)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/themes/theme-gmd/widgets/NestedCategoryFilter/components/Picker/index.spec.jsx
+++ b/themes/theme-gmd/widgets/NestedCategoryFilter/components/Picker/index.spec.jsx
@@ -5,7 +5,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { ThemeContext } from '@shopgate/pwa-common/context';
 import mockRenderOptions from '@shopgate/pwa-common/helpers/mocks/mockRenderOptions';
-import getCategory from '@shopgate/pwa-common-commerce/category/actions/getCategory';
+import { fetchCategoryOrRootCategories } from '@shopgate/engage/category';
 import themeApi from '../../../../themeApi';
 import { mockedState, categoriesById, emptyRootCategories } from '../../mockData';
 import Picker from './index';
@@ -13,8 +13,12 @@ import styles from './style';
 
 jest.unmock('@shopgate/pwa-common/context');
 jest.unmock('@shopgate/pwa-ui-shared');
+
 jest.mock('@shopgate/engage/components');
-jest.mock('@shopgate/pwa-common-commerce/category/actions/getCategory', () => jest.fn(() => () => { }));
+
+jest.mock('@shopgate/engage/category', () => ({
+  fetchCategoryOrRootCategories: jest.fn(() => () => { }),
+}));
 
 /**
  * Renders the component.
@@ -54,9 +58,8 @@ describe('<NestedCategoryFilterPicker />', () => {
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(`div.${label}`).text()).toEqual(props.label);
     expect(wrapper.find(`div.${selection}`).text()).toEqual('common.please_choose');
-
     expect(wrapper.find('Drawer').first().prop('isOpen')).toBe(false);
-    expect(getCategory).not.toHaveBeenCalled();
+    expect(fetchCategoryOrRootCategories).not.toHaveBeenCalled();
   });
 
   it('should render the picker without a label', () => {
@@ -90,7 +93,7 @@ describe('<NestedCategoryFilterPicker />', () => {
     expect(wrapper.find('Drawer').first().prop('isOpen')).toBe(false);
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith(props.categoryId, categoriesById['1-2']);
-    expect(getCategory).not.toHaveBeenCalled();
+    expect(fetchCategoryOrRootCategories).not.toHaveBeenCalled();
   });
 
   it('should not accept user interaction when no categoryId was passed', () => {
@@ -104,7 +107,7 @@ describe('<NestedCategoryFilterPicker />', () => {
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(`div.${label}`).parent().hasClass(buttonDisabled)).toBe(true);
     expect(wrapper.find('Drawer').first().prop('isOpen')).toBe(false);
-    expect(getCategory).not.toHaveBeenCalled();
+    expect(fetchCategoryOrRootCategories).not.toHaveBeenCalled();
   });
 
   it('should accept user interaction when the categoryId is an empty string', () => {
@@ -116,7 +119,7 @@ describe('<NestedCategoryFilterPicker />', () => {
     wrapper.find(Picker).simulate('click');
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('Drawer').first().prop('isOpen')).toBe(true);
-    expect(getCategory).not.toHaveBeenCalled();
+    expect(fetchCategoryOrRootCategories).not.toHaveBeenCalled();
   });
 
   it('should highlight the preselected subcategory within the sheet ', () => {
@@ -128,7 +131,7 @@ describe('<NestedCategoryFilterPicker />', () => {
     wrapper.find(Picker).simulate('click');
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('Drawer SheetItem').first().prop('selected')).toBe(true);
-    expect(getCategory).not.toHaveBeenCalled();
+    expect(fetchCategoryOrRootCategories).not.toHaveBeenCalled();
   });
 
   it('should request category data when it is not available yet', () => {
@@ -138,8 +141,8 @@ describe('<NestedCategoryFilterPicker />', () => {
       categoryId,
     });
 
-    expect(getCategory).toHaveBeenCalledTimes(1);
-    expect(getCategory).toHaveBeenCalledWith(categoryId);
+    expect(fetchCategoryOrRootCategories).toHaveBeenCalledTimes(1);
+    expect(fetchCategoryOrRootCategories).toHaveBeenCalledWith(categoryId);
   });
 
   it('should request root category data when it is not available yet', () => {
@@ -154,7 +157,7 @@ describe('<NestedCategoryFilterPicker />', () => {
       },
     });
 
-    expect(getCategory).toHaveBeenCalledTimes(1);
-    expect(getCategory).toHaveBeenCalledWith(categoryId);
+    expect(fetchCategoryOrRootCategories).toHaveBeenCalledTimes(1);
+    expect(fetchCategoryOrRootCategories).toHaveBeenCalledWith(categoryId);
   });
 });

--- a/themes/theme-ios11/widgets/CategoryList/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/widgets/CategoryList/__snapshots__/spec.jsx.snap
@@ -3,7 +3,6 @@
 exports[`<CategoryListWidget /> should not render the CategoryListWidget 1`] = `
 <CategoryListWidget
   fetchCategory={[Function]}
-  getCategory={[Function]}
   items={null}
   settings={
     Object {
@@ -18,7 +17,6 @@ exports[`<CategoryListWidget /> should not render the CategoryListWidget 1`] = `
 exports[`<CategoryListWidget /> should render the CategoryListWidget 1`] = `
 <CategoryListWidget
   fetchCategory={[Function]}
-  getCategory={[Function]}
   items={
     Array [
       Object {

--- a/themes/theme-ios11/widgets/CategoryList/connector.js
+++ b/themes/theme-ios11/widgets/CategoryList/connector.js
@@ -8,7 +8,7 @@ import { getCategoriesById } from '../selectors';
  * @return {Object} The extended component props.
  */
 const mapDispatchToProps = dispatch => ({
-  getCategory: categoryId => dispatch(fetchCategoryOrRootCategories(categoryId)),
+  fetchCategory: categoryId => dispatch(fetchCategoryOrRootCategories(categoryId)),
 });
 
 /**

--- a/themes/theme-ios11/widgets/CategoryList/connector.js
+++ b/themes/theme-ios11/widgets/CategoryList/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import getCategory from '@shopgate/pwa-common-commerce/category/actions/getCategory';
+import { fetchCategoryOrRootCategories } from '@shopgate/engage/category';
 import { getCategoriesById } from '../selectors';
 
 /**
@@ -8,9 +8,7 @@ import { getCategoriesById } from '../selectors';
  * @return {Object} The extended component props.
  */
 const mapDispatchToProps = dispatch => ({
-  getCategory(categoryId) {
-    dispatch(getCategory(categoryId));
-  },
+  getCategory: categoryId => dispatch(fetchCategoryOrRootCategories(categoryId)),
 });
 
 /**

--- a/themes/theme-ios11/widgets/CategoryList/index.jsx
+++ b/themes/theme-ios11/widgets/CategoryList/index.jsx
@@ -15,12 +15,12 @@ import connect from './connector';
 class CategoryListWidget extends Component {
   static propTypes = {
     settings: PropTypes.shape().isRequired,
-    getCategory: PropTypes.func,
+    fetchCategory: PropTypes.func,
     items: PropTypes.arrayOf(PropTypes.shape()),
   };
 
   static defaultProps = {
-    getCategory: () => {},
+    fetchCategory: () => {},
     items: null,
   };
 
@@ -29,7 +29,7 @@ class CategoryListWidget extends Component {
    */
   componentDidMount() {
     if (!this.props.items) {
-      this.props.getCategory(this.props.settings.categoryNumber);
+      this.props.fetchCategory(this.props.settings.categoryNumber);
     }
   }
 

--- a/themes/theme-ios11/widgets/NestedCategoryFilter/components/Picker/connector.js
+++ b/themes/theme-ios11/widgets/NestedCategoryFilter/components/Picker/connector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import fetchCategory from '@shopgate/pwa-common-commerce/category/actions/getCategory';
+import { fetchCategoryOrRootCategories } from '@shopgate/engage/category';
 import { getCategoriesById } from '../../../selectors';
 
 /**
@@ -18,7 +18,7 @@ const mapStateToProps = (state, { categoryId }) => ({
  * @return {Object} The extended component props.
  */
 const mapDispatchToProps = dispatch => ({
-  fetchCategory: id => dispatch(fetchCategory(id)),
+  fetchCategory: id => dispatch(fetchCategoryOrRootCategories(id)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/themes/theme-ios11/widgets/NestedCategoryFilter/components/Picker/index.spec.jsx
+++ b/themes/theme-ios11/widgets/NestedCategoryFilter/components/Picker/index.spec.jsx
@@ -5,7 +5,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { ThemeContext } from '@shopgate/pwa-common/context';
 import mockRenderOptions from '@shopgate/pwa-common/helpers/mocks/mockRenderOptions';
-import getCategory from '@shopgate/pwa-common-commerce/category/actions/getCategory';
+import { fetchCategoryOrRootCategories } from '@shopgate/engage/category';
 import themeApi from '../../../../themeApi';
 import { mockedState, categoriesById, emptyRootCategories } from '../../mockData';
 import Picker from './index';
@@ -16,7 +16,9 @@ jest.unmock('@shopgate/pwa-ui-shared');
 
 jest.mock('@shopgate/engage/components');
 
-jest.mock('@shopgate/pwa-common-commerce/category/actions/getCategory', () => jest.fn(() => () => { }));
+jest.mock('@shopgate/engage/category', () => ({
+  fetchCategoryOrRootCategories: jest.fn(() => () => { }),
+}));
 
 /**
  * Renders the component.
@@ -57,7 +59,7 @@ describe('<NestedCategoryFilterPicker />', () => {
     expect(wrapper.find(`div.${label}`).text()).toEqual(props.label);
     expect(wrapper.find(`div.${selection}`).text()).toEqual('common.please_choose');
     expect(wrapper.find('Drawer').first().prop('isOpen')).toBe(false);
-    expect(getCategory).not.toHaveBeenCalled();
+    expect(fetchCategoryOrRootCategories).not.toHaveBeenCalled();
   });
 
   it('should render the picker without a label', () => {
@@ -91,7 +93,7 @@ describe('<NestedCategoryFilterPicker />', () => {
     expect(wrapper.find('Drawer').first().prop('isOpen')).toBe(false);
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith(props.categoryId, categoriesById['1-2']);
-    expect(getCategory).not.toHaveBeenCalled();
+    expect(fetchCategoryOrRootCategories).not.toHaveBeenCalled();
   });
 
   it('should not accept user interaction when no categoryId was passed', () => {
@@ -105,7 +107,7 @@ describe('<NestedCategoryFilterPicker />', () => {
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find(`div.${label}`).parent().hasClass(buttonDisabled)).toBe(true);
     expect(wrapper.find('Drawer').first().prop('isOpen')).toBe(false);
-    expect(getCategory).not.toHaveBeenCalled();
+    expect(fetchCategoryOrRootCategories).not.toHaveBeenCalled();
   });
 
   it('should accept user interaction when the categoryId is an empty string', () => {
@@ -117,7 +119,7 @@ describe('<NestedCategoryFilterPicker />', () => {
     wrapper.find(Picker).simulate('click');
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('Drawer').first().prop('isOpen')).toBe(true);
-    expect(getCategory).not.toHaveBeenCalled();
+    expect(fetchCategoryOrRootCategories).not.toHaveBeenCalled();
   });
 
   it('should highlight the preselected subcategory within the sheet ', () => {
@@ -129,7 +131,7 @@ describe('<NestedCategoryFilterPicker />', () => {
     wrapper.find(Picker).simulate('click');
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('Drawer SheetItem').first().prop('selected')).toBe(true);
-    expect(getCategory).not.toHaveBeenCalled();
+    expect(fetchCategoryOrRootCategories).not.toHaveBeenCalled();
   });
 
   it('should request category data when it is not available yet', () => {
@@ -139,8 +141,8 @@ describe('<NestedCategoryFilterPicker />', () => {
       categoryId,
     });
 
-    expect(getCategory).toHaveBeenCalledTimes(1);
-    expect(getCategory).toHaveBeenCalledWith(categoryId);
+    expect(fetchCategoryOrRootCategories).toHaveBeenCalledTimes(1);
+    expect(fetchCategoryOrRootCategories).toHaveBeenCalledWith(categoryId);
   });
 
   it('should request root category data when it is not available yet', () => {
@@ -155,7 +157,7 @@ describe('<NestedCategoryFilterPicker />', () => {
       },
     });
 
-    expect(getCategory).toHaveBeenCalledTimes(1);
-    expect(getCategory).toHaveBeenCalledWith(categoryId);
+    expect(fetchCategoryOrRootCategories).toHaveBeenCalledTimes(1);
+    expect(fetchCategoryOrRootCategories).toHaveBeenCalledWith(categoryId);
   });
 });


### PR DESCRIPTION
# Description
- page tracking events don't contain category names when navigation to category
- push message links without a leading slash cause white pages
- adding a product to cart via push causes error due to missing currency in tracking data
- opening the app via push with coupon doesn't redeem the coupon

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Push messages can be simulated by calling the following function in the console
```js
window.SGEvent.__call('openPushNotification', [{link: '/index?coupon=test'}])
```
