### PR TITLE
Added configurable info text block to reviews list

### DIFF
--- a/libraries/engage/reviews/components/Reviews/components/ReviewsInfoText/index.jsx
+++ b/libraries/engage/reviews/components/Reviews/components/ReviewsInfoText/index.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from 'glamor';
+import classNames from 'classnames';
+import appConfig from '@shopgate/pwa-common/helpers/config';
+import { Link } from '@shopgate/engage/components';
+
+const styles = {
+  root: css({
+    textAlign: 'center',
+    marginBottom: '2rem',
+    marginTop: 16,
+    fontSize: '.875rem',
+    fontWeight: 300,
+    lineHeight: 1.5,
+    marginLeft: 16,
+    marginRight: 16,
+  }),
+  link: css({
+    textAlign: 'center',
+    fontWeight: 600,
+    marginTop: 8,
+  }).toString(),
+};
+
+const {
+  reviewsInfoText: {
+    text,
+    linkText,
+    linkUrl,
+  } = {},
+} = appConfig;
+
+/**
+ * The ReviewsInfoText component
+ * @param {Object} props The component props
+ * @param {Array} [props.reviews] The reviews shown inside the Reviews component
+ * @returns {JSX}
+ */
+const ReviewsInfoText = ({
+  reviews,
+}) => {
+  if (!reviews || reviews.length === 0 || !text) {
+    return null;
+  }
+
+  return (
+    <div className={classNames(styles.root, 'engage__reviews__review_info_text')}>
+      <div>
+        {text}
+        { linkText && linkUrl && (
+          <Link href={linkUrl} className={styles.link}>
+            {linkText}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ReviewsInfoText.propTypes = {
+  reviews: PropTypes.arrayOf(PropTypes.shape()),
+};
+
+ReviewsInfoText.defaultProps = {
+  reviews: [],
+};
+
+export default ReviewsInfoText;

--- a/libraries/engage/reviews/components/Reviews/index.jsx
+++ b/libraries/engage/reviews/components/Reviews/index.jsx
@@ -6,6 +6,7 @@ import { PRODUCT_REVIEWS } from '@shopgate/engage/product';
 import List from './components/List';
 import Header from './components/Header';
 import AllReviewsLink from './components/AllReviewsLink';
+import ReviewsInfoText from './components/ReviewsInfoText';
 import styles from './style';
 import connect from './connector';
 
@@ -26,6 +27,7 @@ function Reviews({ productId, reviews }) {
           <Header productId={productId} />
           <List productId={productId} reviews={reviews} />
           <AllReviewsLink productId={productId} />
+          <ReviewsInfoText reviews={reviews} />
         </div>
       )}
     </SurroundPortals>

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -575,6 +575,19 @@
         "type": "json",
         "label": "App rating settings"
       }
+    },
+    "reviewsInfoText": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": {
+        "text": null,
+        "linkText": null,
+        "linkUrl": null
+      },
+      "params": {
+        "type": "json",
+        "label": "An info text shown after the reviews on PDP"
+      }
     }
   }
 }

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -585,6 +585,19 @@
         "type": "json",
         "label": "App rating settings"
       }
+    },
+    "reviewsInfoText": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": {
+        "text": null,
+        "linkText": null,
+        "linkUrl": null
+      },
+      "params": {
+        "type": "json",
+        "label": "An info text shown after the reviews on PDP"
+      }
     }
   }
 }


### PR DESCRIPTION
# Description

This ticket is about to add an optional text block below the review list on PDP. The block can be configured via the theme config.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

