### PR TITLE
Added configurable info text block to reviews list

### DIFF
--- a/libraries/engage/reviews/components/Reviews/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/reviews/components/Reviews/__snapshots__/spec.jsx.snap
@@ -2375,6 +2375,44 @@ exports[`<Reviews /> should render reviews, header and all reviews link 1`] = `
                 </div>
               </AllReviewsLink>
             </Connect(AllReviewsLink)>
+            <ReviewsInfo
+              reviews={
+                Array [
+                  Object {
+                    "author": "",
+                    "date": "2017-09-06T12:38:51.000Z",
+                    "id": 1,
+                    "rate": 100,
+                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                    "title": "",
+                  },
+                  Object {
+                    "author": "",
+                    "date": "2017-09-06T12:38:51.000Z",
+                    "id": 2,
+                    "rate": 100,
+                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                    "title": "",
+                  },
+                  Object {
+                    "author": "",
+                    "date": "2017-09-06T12:38:51.000Z",
+                    "id": 3,
+                    "rate": 100,
+                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                    "title": "",
+                  },
+                  Object {
+                    "author": "",
+                    "date": "2017-09-06T12:38:51.000Z",
+                    "id": 4,
+                    "rate": 100,
+                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                    "title": "",
+                  },
+                ]
+              }
+            />
           </div>
         </Portal>
         <Portal
@@ -3515,6 +3553,28 @@ exports[`<Reviews /> should render reviews, header, but no all reviews link 1`] 
                 productId="foo"
               />
             </Connect(AllReviewsLink)>
+            <ReviewsInfo
+              reviews={
+                Array [
+                  Object {
+                    "author": "",
+                    "date": "2017-09-06T12:38:51.000Z",
+                    "id": 1,
+                    "rate": 100,
+                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                    "title": "",
+                  },
+                  Object {
+                    "author": "",
+                    "date": "2017-09-06T12:38:51.000Z",
+                    "id": 2,
+                    "rate": 100,
+                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                    "title": "",
+                  },
+                ]
+              }
+            />
           </div>
         </Portal>
         <Portal
@@ -3598,6 +3658,9 @@ exports[`<Reviews /> should render when no reviews and rating given 1`] = `
                 productId="foo"
               />
             </Connect(AllReviewsLink)>
+            <ReviewsInfo
+              reviews={null}
+            />
           </div>
         </Portal>
         <Portal

--- a/libraries/engage/reviews/components/Reviews/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/reviews/components/Reviews/__snapshots__/spec.jsx.snap
@@ -2375,44 +2375,7 @@ exports[`<Reviews /> should render reviews, header and all reviews link 1`] = `
                 </div>
               </AllReviewsLink>
             </Connect(AllReviewsLink)>
-            <ReviewsInfo
-              reviews={
-                Array [
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 1,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 2,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 3,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 4,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                ]
-              }
-            />
+            <ReviewsInfo />
           </div>
         </Portal>
         <Portal
@@ -3553,28 +3516,7 @@ exports[`<Reviews /> should render reviews, header, but no all reviews link 1`] 
                 productId="foo"
               />
             </Connect(AllReviewsLink)>
-            <ReviewsInfo
-              reviews={
-                Array [
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 1,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 2,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                ]
-              }
-            />
+            <ReviewsInfo />
           </div>
         </Portal>
         <Portal
@@ -3658,9 +3600,7 @@ exports[`<Reviews /> should render when no reviews and rating given 1`] = `
                 productId="foo"
               />
             </Connect(AllReviewsLink)>
-            <ReviewsInfo
-              reviews={null}
-            />
+            <ReviewsInfo />
           </div>
         </Portal>
         <Portal

--- a/libraries/engage/reviews/components/Reviews/components/ReviewsInfo/index.jsx
+++ b/libraries/engage/reviews/components/Reviews/components/ReviewsInfo/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import classNames from 'classnames';
 import appConfig from '@shopgate/pwa-common/helpers/config';
@@ -32,13 +31,10 @@ const {
 /**
  * The ReviewsInfo component
  * @param {Object} props The component props
- * @param {Array} [props.reviews] The reviews shown inside the Reviews component
  * @returns {JSX}
  */
-const ReviewsInfo = ({
-  reviews,
-}) => {
-  if (!Array.isArray(reviews) || reviews.length === 0 || !text) {
+const ReviewsInfo = () => {
+  if (!text) {
     return null;
   }
 
@@ -54,14 +50,6 @@ const ReviewsInfo = ({
       </div>
     </div>
   );
-};
-
-ReviewsInfo.propTypes = {
-  reviews: PropTypes.arrayOf(PropTypes.shape()),
-};
-
-ReviewsInfo.defaultProps = {
-  reviews: [],
 };
 
 export default ReviewsInfo;

--- a/libraries/engage/reviews/components/Reviews/components/ReviewsInfo/index.jsx
+++ b/libraries/engage/reviews/components/Reviews/components/ReviewsInfo/index.jsx
@@ -22,7 +22,7 @@ const styles = {
 };
 
 const {
-  reviewsInfoText: {
+  reviewsInfo: {
     text,
     linkText,
     linkUrl,
@@ -30,12 +30,12 @@ const {
 } = appConfig;
 
 /**
- * The ReviewsInfoText component
+ * The ReviewsInfo component
  * @param {Object} props The component props
  * @param {Array} [props.reviews] The reviews shown inside the Reviews component
  * @returns {JSX}
  */
-const ReviewsInfoText = ({
+const ReviewsInfo = ({
   reviews,
 }) => {
   if (!Array.isArray(reviews) || reviews.length === 0 || !text) {
@@ -56,12 +56,12 @@ const ReviewsInfoText = ({
   );
 };
 
-ReviewsInfoText.propTypes = {
+ReviewsInfo.propTypes = {
   reviews: PropTypes.arrayOf(PropTypes.shape()),
 };
 
-ReviewsInfoText.defaultProps = {
+ReviewsInfo.defaultProps = {
   reviews: [],
 };
 
-export default ReviewsInfoText;
+export default ReviewsInfo;

--- a/libraries/engage/reviews/components/Reviews/components/ReviewsInfoText/index.jsx
+++ b/libraries/engage/reviews/components/Reviews/components/ReviewsInfoText/index.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from 'glamor';
+import classNames from 'classnames';
+import appConfig from '@shopgate/pwa-common/helpers/config';
+import { Link } from '@shopgate/engage/components';
+
+const styles = {
+  root: css({
+    textAlign: 'center',
+    marginBottom: '2rem',
+    marginTop: 16,
+    fontSize: '.875rem',
+    fontWeight: 300,
+    lineHeight: 1.5,
+    marginLeft: 16,
+    marginRight: 16,
+  }),
+  link: css({
+    textAlign: 'center',
+    fontWeight: 600,
+    marginTop: 8,
+  }).toString(),
+};
+
+const {
+  reviewsInfoText: {
+    text,
+    linkText,
+    linkUrl,
+  } = {},
+} = appConfig;
+
+/**
+ * The ReviewsInfoText component
+ * @param {Object} props The component props
+ * @param {Array} [props.reviews] The reviews shown inside the Reviews component
+ * @returns {JSX}
+ */
+const ReviewsInfoText = ({
+  reviews,
+}) => {
+  if (!reviews || reviews.length === 0 || !text) {
+    return null;
+  }
+
+  return (
+    <div className={classNames(styles.root, 'engage__reviews__review_info_text')}>
+      <div>
+        {text}
+        { linkText && linkUrl && (
+          <Link href={linkUrl} className={styles.link}>
+            {linkText}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ReviewsInfoText.propTypes = {
+  reviews: PropTypes.arrayOf(PropTypes.shape()),
+};
+
+ReviewsInfoText.defaultProps = {
+  reviews: [],
+};
+
+export default ReviewsInfoText;

--- a/libraries/engage/reviews/components/Reviews/components/ReviewsInfoText/index.jsx
+++ b/libraries/engage/reviews/components/Reviews/components/ReviewsInfoText/index.jsx
@@ -8,14 +8,12 @@ import { Link } from '@shopgate/engage/components';
 const styles = {
   root: css({
     textAlign: 'center',
-    marginBottom: '2rem',
     marginTop: 16,
     fontSize: '.875rem',
     fontWeight: 300,
     lineHeight: 1.5,
-    marginLeft: 16,
-    marginRight: 16,
-  }),
+    padding: '0.8125rem 1rem 1rem',
+  }).toString(),
   link: css({
     textAlign: 'center',
     fontWeight: 600,
@@ -40,7 +38,7 @@ const {
 const ReviewsInfoText = ({
   reviews,
 }) => {
-  if (!reviews || reviews.length === 0 || !text) {
+  if (!Array.isArray(reviews) || reviews.length === 0 || !text) {
     return null;
   }
 

--- a/libraries/engage/reviews/components/Reviews/index.jsx
+++ b/libraries/engage/reviews/components/Reviews/index.jsx
@@ -6,6 +6,7 @@ import { PRODUCT_REVIEWS } from '@shopgate/engage/product';
 import List from './components/List';
 import Header from './components/Header';
 import AllReviewsLink from './components/AllReviewsLink';
+import ReviewsInfoText from './components/ReviewsInfoText';
 import styles from './style';
 import connect from './connector';
 
@@ -26,6 +27,7 @@ function Reviews({ productId, reviews }) {
           <Header productId={productId} />
           <List productId={productId} reviews={reviews} />
           <AllReviewsLink productId={productId} />
+          <ReviewsInfoText reviews={reviews} />
         </div>
       )}
     </SurroundPortals>

--- a/libraries/engage/reviews/components/Reviews/index.jsx
+++ b/libraries/engage/reviews/components/Reviews/index.jsx
@@ -27,7 +27,7 @@ function Reviews({ productId, reviews }) {
           <Header productId={productId} />
           <List productId={productId} reviews={reviews} />
           <AllReviewsLink productId={productId} />
-          <ReviewsInfo reviews={reviews} />
+          <ReviewsInfo />
         </div>
       )}
     </SurroundPortals>

--- a/libraries/engage/reviews/components/Reviews/index.jsx
+++ b/libraries/engage/reviews/components/Reviews/index.jsx
@@ -6,7 +6,7 @@ import { PRODUCT_REVIEWS } from '@shopgate/engage/product';
 import List from './components/List';
 import Header from './components/Header';
 import AllReviewsLink from './components/AllReviewsLink';
-import ReviewsInfoText from './components/ReviewsInfoText';
+import ReviewsInfo from './components/ReviewsInfo';
 import styles from './style';
 import connect from './connector';
 
@@ -27,7 +27,7 @@ function Reviews({ productId, reviews }) {
           <Header productId={productId} />
           <List productId={productId} reviews={reviews} />
           <AllReviewsLink productId={productId} />
-          <ReviewsInfoText reviews={reviews} />
+          <ReviewsInfo reviews={reviews} />
         </div>
       )}
     </SurroundPortals>

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -576,7 +576,7 @@
         "label": "App rating settings"
       }
     },
-    "reviewsInfoText": {
+    "reviewsInfo": {
       "type": "admin",
       "destination": "frontend",
       "default": {

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -575,6 +575,19 @@
         "type": "json",
         "label": "App rating settings"
       }
+    },
+    "reviewsInfoText": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": {
+        "text": null,
+        "linkText": null,
+        "linkUrl": null
+      },
+      "params": {
+        "type": "json",
+        "label": "An info text shown after the reviews on PDP"
+      }
     }
   }
 }

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -577,7 +577,7 @@
       }
     },
     "reviewsInfo": {
-      "type": "admin",
+      "type": "bigApi",
       "destination": "frontend",
       "default": {
         "text": null,
@@ -585,8 +585,10 @@
         "linkUrl": null
       },
       "params": {
-        "type": "json",
-        "label": "An info text shown after the reviews on PDP. The text can be extended with a link to e.g. a cms page."
+        "method": "GET",
+        "service": "config",
+        "path": "/v1/shop/%(shopId)s/gui_sg_connect_reviews_info_config?parsed=true",
+        "key": "value"
       }
     }
   }

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -586,7 +586,7 @@
       },
       "params": {
         "type": "json",
-        "label": "An info text shown after the reviews on PDP"
+        "label": "An info text shown after the reviews on PDP. The text can be extended with a link to e.g. a cms page."
       }
     }
   }

--- a/themes/theme-gmd/pages/Reviews/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/Reviews/__snapshots__/spec.jsx.snap
@@ -16,7 +16,9 @@ exports[`<Reviews> page should not crash 1`] = `
   <Reviews
     id="foo"
   >
-    <MockedView>
+    <MockedView
+      aria-hidden={false}
+    >
       <div>
         <Connect(ReviewsContent)
           productId="foo"
@@ -67,585 +69,34 @@ exports[`<Reviews> page should not crash 1`] = `
               ]
             }
           >
-            <Connect(BackBar)
+            <BackBar
               right={null}
               title="titles.reviews"
-            >
-              <BackBar
-                goBack={[Function]}
-                right={null}
-                title="titles.reviews"
-              >
-                <AppBarDefault
-                  left={[Function]}
-                  right={null}
-                  title="titles.reviews"
-                >
-                  <AppBar
-                    backgroundColor="#fff"
-                    below={
-                      <React.Fragment>
-                        <_default />
-                      </React.Fragment>
-                    }
-                    center={
-                      <AppBarTitle
-                        title="titles.reviews"
-                      />
-                    }
-                    left={[Function]}
-                    right={null}
-                    shadow={true}
-                    textColor="#000"
-                    title="titles.reviews"
-                  >
-                    <header
-                      className={
-                        Object {
-                          "data-css-1gx0ht2": "",
-                        }
-                      }
-                      data-test-id="Navigator"
-                      role="banner"
-                      style={
-                        Object {
-                          "background": "#fff",
-                          "boxShadow": "rgba(0, 0, 0, .117647) 0 1px 6px, rgba(0, 0, 0, .117647) 0 1px 4px",
-                          "color": "#000",
-                        }
-                      }
-                    >
-                      <div
-                        className={
-                          Object {
-                            "data-css-1qz3sla": "",
-                          }
-                        }
-                      >
-                        <AppBarTitle
-                          title="titles.reviews"
-                        >
-                          <div
-                            className={
-                              Object {
-                                "data-css-16ouezv": "",
-                              }
-                            }
-                          >
-                            titles.reviews
-                          </div>
-                        </AppBarTitle>
-                      </div>
-                      <_default>
-                        <Consumer>
-                          <ProgressBar
-                            pattern=""
-                            visible={true}
-                          >
-                            <ProgressBar
-                              isVisible={false}
-                            >
-                              <Transition
-                                appear={false}
-                                enter={true}
-                                exit={true}
-                                in={false}
-                                mountOnEnter={false}
-                                onEnter={[Function]}
-                                onEntered={[Function]}
-                                onEntering={[Function]}
-                                onExit={[Function]}
-                                onExited={[Function]}
-                                onExiting={[Function]}
-                                timeout={150}
-                                unmountOnExit={false}
-                              >
-                                <div
-                                  className="css-guf25f"
-                                  style={
-                                    Object {
-                                      "transform": "scale(1, 0)",
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="css-cd7tja"
-                                  />
-                                </div>
-                              </Transition>
-                            </ProgressBar>
-                          </ProgressBar>
-                        </Consumer>
-                      </_default>
-                    </header>
-                  </AppBar>
-                </AppBarDefault>
-              </BackBar>
-            </Connect(BackBar)>
-            <Component
-              productId="foo"
-              rating={
+            />
+            <SurroundPortals
+              portalName="product.reviews.all"
+              portalProps={
                 Object {
-                  "average": 50,
-                  "count": 4,
+                  "productId": "foo",
                 }
               }
-              withTopGap={true}
             >
-              div
-            </Component>
-            <List
-              productId="foo"
-              reviews={
-                Array [
+              <Component
+                productId="foo"
+                rating={
                   Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 1,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 2,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 3,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 4,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                ]
-              }
-            >
-              <div
-                className="css-1yhq1gr"
-                data-test-id="reviewTitle: "
-                key="1"
+                    "average": 50,
+                    "count": 4,
+                  }
+                }
+                withTopGap={true}
               >
-                <Title
-                  title=""
-                >
-                  <div
-                    className="css-1rmdcnr"
-                  />
-                </Title>
-                <Rating
-                  rate={100}
-                >
-                  <div
-                    className="css-15pwoui"
-                  >
-                    <RatingStars
-                      className="css-hgkz41"
-                      display="small"
-                      isSelectable={false}
-                      onSelection={[Function]}
-                      value={100}
-                    >
-                      <div
-                        aria-label="reviews.rating_stars"
-                        className="css-13azwyo css-hgkz41"
-                        data-test-id="ratedStars: 5"
-                      >
-                        <div
-                          className="css-4s85e9"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="1"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="2"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="3"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="4"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="5"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                        <div
-                          className="css-16y9zin"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="6"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="7"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="8"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="9"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="10"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                      </div>
-                    </RatingStars>
-                  </div>
-                </Rating>
-                <Text
-                  review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                >
-                  <div
-                    className="css-vkqu2k"
-                  >
-                    "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                  </div>
-                </Text>
-                <Info
-                  review={
+                div
+              </Component>
+              <List
+                productId="foo"
+                reviews={
+                  Array [
                     Object {
                       "author": "",
                       "date": "2017-09-06T12:38:51.000Z",
@@ -653,444 +104,7 @@ exports[`<Reviews> page should not crash 1`] = `
                       "rate": 100,
                       "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
                       "title": "",
-                    }
-                  }
-                >
-                  <div
-                    className="css-1dhkxb0"
-                  >
-                    <ReviewDate
-                      date="2017-09-06T12:38:51.000Z"
-                    >
-                      <FormatDate
-                        format="long"
-                        timestamp={1504701531000}
-                      >
-                        <span>
-                          d
-                        </span>
-                      </FormatDate>
-                    </ReviewDate>
-                     
-                    <Author
-                      author=""
-                    />
-                  </div>
-                </Info>
-              </div>
-              <div
-                className="css-1yhq1gr"
-                data-test-id="reviewTitle: "
-                key="2"
-              >
-                <Title
-                  title=""
-                >
-                  <div
-                    className="css-1rmdcnr"
-                  />
-                </Title>
-                <Rating
-                  rate={100}
-                >
-                  <div
-                    className="css-15pwoui"
-                  >
-                    <RatingStars
-                      className="css-hgkz41"
-                      display="small"
-                      isSelectable={false}
-                      onSelection={[Function]}
-                      value={100}
-                    >
-                      <div
-                        aria-label="reviews.rating_stars"
-                        className="css-13azwyo css-hgkz41"
-                        data-test-id="ratedStars: 5"
-                      >
-                        <div
-                          className="css-4s85e9"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="1"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="2"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="3"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="4"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="5"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                        <div
-                          className="css-16y9zin"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="6"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="7"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="8"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="9"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="10"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                      </div>
-                    </RatingStars>
-                  </div>
-                </Rating>
-                <Text
-                  review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                >
-                  <div
-                    className="css-vkqu2k"
-                  >
-                    "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                  </div>
-                </Text>
-                <Info
-                  review={
+                    },
                     Object {
                       "author": "",
                       "date": "2017-09-06T12:38:51.000Z",
@@ -1098,444 +112,7 @@ exports[`<Reviews> page should not crash 1`] = `
                       "rate": 100,
                       "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
                       "title": "",
-                    }
-                  }
-                >
-                  <div
-                    className="css-1dhkxb0"
-                  >
-                    <ReviewDate
-                      date="2017-09-06T12:38:51.000Z"
-                    >
-                      <FormatDate
-                        format="long"
-                        timestamp={1504701531000}
-                      >
-                        <span>
-                          d
-                        </span>
-                      </FormatDate>
-                    </ReviewDate>
-                     
-                    <Author
-                      author=""
-                    />
-                  </div>
-                </Info>
-              </div>
-              <div
-                className="css-1yhq1gr"
-                data-test-id="reviewTitle: "
-                key="3"
-              >
-                <Title
-                  title=""
-                >
-                  <div
-                    className="css-1rmdcnr"
-                  />
-                </Title>
-                <Rating
-                  rate={100}
-                >
-                  <div
-                    className="css-15pwoui"
-                  >
-                    <RatingStars
-                      className="css-hgkz41"
-                      display="small"
-                      isSelectable={false}
-                      onSelection={[Function]}
-                      value={100}
-                    >
-                      <div
-                        aria-label="reviews.rating_stars"
-                        className="css-13azwyo css-hgkz41"
-                        data-test-id="ratedStars: 5"
-                      >
-                        <div
-                          className="css-4s85e9"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="1"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="2"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="3"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="4"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="5"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                        <div
-                          className="css-16y9zin"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="6"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="7"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="8"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="9"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="10"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                      </div>
-                    </RatingStars>
-                  </div>
-                </Rating>
-                <Text
-                  review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                >
-                  <div
-                    className="css-vkqu2k"
-                  >
-                    "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                  </div>
-                </Text>
-                <Info
-                  review={
+                    },
                     Object {
                       "author": "",
                       "date": "2017-09-06T12:38:51.000Z",
@@ -1543,444 +120,7 @@ exports[`<Reviews> page should not crash 1`] = `
                       "rate": 100,
                       "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
                       "title": "",
-                    }
-                  }
-                >
-                  <div
-                    className="css-1dhkxb0"
-                  >
-                    <ReviewDate
-                      date="2017-09-06T12:38:51.000Z"
-                    >
-                      <FormatDate
-                        format="long"
-                        timestamp={1504701531000}
-                      >
-                        <span>
-                          d
-                        </span>
-                      </FormatDate>
-                    </ReviewDate>
-                     
-                    <Author
-                      author=""
-                    />
-                  </div>
-                </Info>
-              </div>
-              <div
-                className="css-1yhq1gr"
-                data-test-id="reviewTitle: "
-                key="4"
-              >
-                <Title
-                  title=""
-                >
-                  <div
-                    className="css-1rmdcnr"
-                  />
-                </Title>
-                <Rating
-                  rate={100}
-                >
-                  <div
-                    className="css-15pwoui"
-                  >
-                    <RatingStars
-                      className="css-hgkz41"
-                      display="small"
-                      isSelectable={false}
-                      onSelection={[Function]}
-                      value={100}
-                    >
-                      <div
-                        aria-label="reviews.rating_stars"
-                        className="css-13azwyo css-hgkz41"
-                        data-test-id="ratedStars: 5"
-                      >
-                        <div
-                          className="css-4s85e9"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="1"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="2"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="3"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="4"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="5"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                        <div
-                          className="css-16y9zin"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="6"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="7"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="8"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="9"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="10"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                      </div>
-                    </RatingStars>
-                  </div>
-                </Rating>
-                <Text
-                  review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                >
-                  <div
-                    className="css-vkqu2k"
-                  >
-                    "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                  </div>
-                </Text>
-                <Info
-                  review={
+                    },
                     Object {
                       "author": "",
                       "date": "2017-09-06T12:38:51.000Z",
@@ -1988,43 +128,1909 @@ exports[`<Reviews> page should not crash 1`] = `
                       "rate": 100,
                       "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
                       "title": "",
-                    }
-                  }
+                    },
+                  ]
+                }
+              >
+                <ul
+                  className="engage__reviews__list"
                 >
-                  <div
-                    className="css-1dhkxb0"
+                  <li
+                    className="css-1yhq1gr"
+                    data-test-id="reviewTitle: "
+                    key="1"
                   >
-                    <ReviewDate
-                      date="2017-09-06T12:38:51.000Z"
+                    <SurroundPortals
+                      portalName="product.reviews.entry"
+                      portalProps={
+                        Object {
+                          "review": Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 1,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          },
+                        }
+                      }
                     >
-                      <FormatDate
-                        format="long"
-                        timestamp={1504701531000}
+                      <Title
+                        title=""
                       >
-                        <span>
-                          d
-                        </span>
-                      </FormatDate>
-                    </ReviewDate>
-                     
-                    <Author
-                      author=""
-                    />
-                  </div>
-                </Info>
-              </div>
-            </List>
-            <Connect(LoadMore)
-              productId="foo"
-            >
-              <LoadMore
-                currentReviewCount={4}
-                fetchReviews={[Function]}
-                isFetching={false}
+                        <div
+                          className="css-1rmdcnr"
+                        />
+                      </Title>
+                      <Rating
+                        rate={100}
+                      >
+                        <div
+                          className="css-15pwoui"
+                        >
+                          <RatingStars
+                            className="css-hgkz41"
+                            display="small"
+                            isSelectable={false}
+                            onSelection={[Function]}
+                            value={100}
+                          >
+                            <div
+                              aria-label="reviews.rating_stars"
+                              className="css-13azwyo css-hgkz41 ui-shared__rating-stars"
+                              data-test-id="ratedStars: 5"
+                              role="text"
+                            >
+                              <div
+                                className="css-4s85e9 rating-stars-empty"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="1"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="2"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="3"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="4"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="5"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                              <div
+                                className="css-16y9zin rating-stars-filled"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="6"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="7"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="8"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="9"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="10"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                            </div>
+                          </RatingStars>
+                        </div>
+                      </Rating>
+                      <Text
+                        review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                      >
+                        <div
+                          className="css-vkqu2k"
+                        >
+                          "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                        </div>
+                      </Text>
+                      <Info
+                        review={
+                          Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 1,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          }
+                        }
+                      >
+                        <div
+                          className="css-1dhkxb0"
+                          role="text"
+                        >
+                          <ReviewDate
+                            date="2017-09-06T12:38:51.000Z"
+                          >
+                            <FormatDate
+                              format="long"
+                              timestamp={1504701531000}
+                            >
+                              d
+                            </FormatDate>
+                          </ReviewDate>
+                           
+                          <Author
+                            author=""
+                          />
+                        </div>
+                      </Info>
+                    </SurroundPortals>
+                  </li>
+                  <li
+                    className="css-1yhq1gr"
+                    data-test-id="reviewTitle: "
+                    key="2"
+                  >
+                    <SurroundPortals
+                      portalName="product.reviews.entry"
+                      portalProps={
+                        Object {
+                          "review": Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 2,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          },
+                        }
+                      }
+                    >
+                      <Title
+                        title=""
+                      >
+                        <div
+                          className="css-1rmdcnr"
+                        />
+                      </Title>
+                      <Rating
+                        rate={100}
+                      >
+                        <div
+                          className="css-15pwoui"
+                        >
+                          <RatingStars
+                            className="css-hgkz41"
+                            display="small"
+                            isSelectable={false}
+                            onSelection={[Function]}
+                            value={100}
+                          >
+                            <div
+                              aria-label="reviews.rating_stars"
+                              className="css-13azwyo css-hgkz41 ui-shared__rating-stars"
+                              data-test-id="ratedStars: 5"
+                              role="text"
+                            >
+                              <div
+                                className="css-4s85e9 rating-stars-empty"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="1"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="2"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="3"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="4"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="5"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                              <div
+                                className="css-16y9zin rating-stars-filled"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="6"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="7"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="8"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="9"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="10"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                            </div>
+                          </RatingStars>
+                        </div>
+                      </Rating>
+                      <Text
+                        review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                      >
+                        <div
+                          className="css-vkqu2k"
+                        >
+                          "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                        </div>
+                      </Text>
+                      <Info
+                        review={
+                          Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 2,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          }
+                        }
+                      >
+                        <div
+                          className="css-1dhkxb0"
+                          role="text"
+                        >
+                          <ReviewDate
+                            date="2017-09-06T12:38:51.000Z"
+                          >
+                            <FormatDate
+                              format="long"
+                              timestamp={1504701531000}
+                            >
+                              d
+                            </FormatDate>
+                          </ReviewDate>
+                           
+                          <Author
+                            author=""
+                          />
+                        </div>
+                      </Info>
+                    </SurroundPortals>
+                  </li>
+                  <li
+                    className="css-1yhq1gr"
+                    data-test-id="reviewTitle: "
+                    key="3"
+                  >
+                    <SurroundPortals
+                      portalName="product.reviews.entry"
+                      portalProps={
+                        Object {
+                          "review": Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 3,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          },
+                        }
+                      }
+                    >
+                      <Title
+                        title=""
+                      >
+                        <div
+                          className="css-1rmdcnr"
+                        />
+                      </Title>
+                      <Rating
+                        rate={100}
+                      >
+                        <div
+                          className="css-15pwoui"
+                        >
+                          <RatingStars
+                            className="css-hgkz41"
+                            display="small"
+                            isSelectable={false}
+                            onSelection={[Function]}
+                            value={100}
+                          >
+                            <div
+                              aria-label="reviews.rating_stars"
+                              className="css-13azwyo css-hgkz41 ui-shared__rating-stars"
+                              data-test-id="ratedStars: 5"
+                              role="text"
+                            >
+                              <div
+                                className="css-4s85e9 rating-stars-empty"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="1"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="2"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="3"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="4"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="5"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                              <div
+                                className="css-16y9zin rating-stars-filled"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="6"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="7"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="8"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="9"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="10"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                            </div>
+                          </RatingStars>
+                        </div>
+                      </Rating>
+                      <Text
+                        review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                      >
+                        <div
+                          className="css-vkqu2k"
+                        >
+                          "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                        </div>
+                      </Text>
+                      <Info
+                        review={
+                          Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 3,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          }
+                        }
+                      >
+                        <div
+                          className="css-1dhkxb0"
+                          role="text"
+                        >
+                          <ReviewDate
+                            date="2017-09-06T12:38:51.000Z"
+                          >
+                            <FormatDate
+                              format="long"
+                              timestamp={1504701531000}
+                            >
+                              d
+                            </FormatDate>
+                          </ReviewDate>
+                           
+                          <Author
+                            author=""
+                          />
+                        </div>
+                      </Info>
+                    </SurroundPortals>
+                  </li>
+                  <li
+                    className="css-1yhq1gr"
+                    data-test-id="reviewTitle: "
+                    key="4"
+                  >
+                    <SurroundPortals
+                      portalName="product.reviews.entry"
+                      portalProps={
+                        Object {
+                          "review": Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 4,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          },
+                        }
+                      }
+                    >
+                      <Title
+                        title=""
+                      >
+                        <div
+                          className="css-1rmdcnr"
+                        />
+                      </Title>
+                      <Rating
+                        rate={100}
+                      >
+                        <div
+                          className="css-15pwoui"
+                        >
+                          <RatingStars
+                            className="css-hgkz41"
+                            display="small"
+                            isSelectable={false}
+                            onSelection={[Function]}
+                            value={100}
+                          >
+                            <div
+                              aria-label="reviews.rating_stars"
+                              className="css-13azwyo css-hgkz41 ui-shared__rating-stars"
+                              data-test-id="ratedStars: 5"
+                              role="text"
+                            >
+                              <div
+                                className="css-4s85e9 rating-stars-empty"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="1"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="2"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="3"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="4"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="5"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                              <div
+                                className="css-16y9zin rating-stars-filled"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="6"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="7"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="8"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="9"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="10"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                            </div>
+                          </RatingStars>
+                        </div>
+                      </Rating>
+                      <Text
+                        review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                      >
+                        <div
+                          className="css-vkqu2k"
+                        >
+                          "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                        </div>
+                      </Text>
+                      <Info
+                        review={
+                          Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 4,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          }
+                        }
+                      >
+                        <div
+                          className="css-1dhkxb0"
+                          role="text"
+                        >
+                          <ReviewDate
+                            date="2017-09-06T12:38:51.000Z"
+                          >
+                            <FormatDate
+                              format="long"
+                              timestamp={1504701531000}
+                            >
+                              d
+                            </FormatDate>
+                          </ReviewDate>
+                           
+                          <Author
+                            author=""
+                          />
+                        </div>
+                      </Info>
+                    </SurroundPortals>
+                  </li>
+                </ul>
+              </List>
+              <Connect(LoadMore)
                 productId="foo"
-                totalReviewCount={4}
+              >
+                <LoadMore
+                  currentReviewCount={4}
+                  fetchReviews={[Function]}
+                  isFetching={false}
+                  productId="foo"
+                  totalReviewCount={4}
+                />
+              </Connect(LoadMore)>
+              <ReviewsInfo
+                reviews={
+                  Array [
+                    Object {
+                      "author": "",
+                      "date": "2017-09-06T12:38:51.000Z",
+                      "id": 1,
+                      "rate": 100,
+                      "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                      "title": "",
+                    },
+                    Object {
+                      "author": "",
+                      "date": "2017-09-06T12:38:51.000Z",
+                      "id": 2,
+                      "rate": 100,
+                      "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                      "title": "",
+                    },
+                    Object {
+                      "author": "",
+                      "date": "2017-09-06T12:38:51.000Z",
+                      "id": 3,
+                      "rate": 100,
+                      "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                      "title": "",
+                    },
+                    Object {
+                      "author": "",
+                      "date": "2017-09-06T12:38:51.000Z",
+                      "id": 4,
+                      "rate": 100,
+                      "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                      "title": "",
+                    },
+                  ]
+                }
               />
-            </Connect(LoadMore)>
+            </SurroundPortals>
           </ReviewsContent>
         </Connect(ReviewsContent)>
       </div>

--- a/themes/theme-gmd/pages/Reviews/components/Content/index.jsx
+++ b/themes/theme-gmd/pages/Reviews/components/Content/index.jsx
@@ -4,6 +4,7 @@ import { SurroundPortals } from '@shopgate/engage/components';
 import { PRODUCT_REVIEWS_ALL } from '@shopgate/engage/reviews';
 import Header from '@shopgate/engage/reviews/components/Reviews/components/Header';
 import List from '@shopgate/engage/reviews/components/Reviews/components/List';
+import ReviewsInfo from '@shopgate/engage/reviews/components/Reviews/components/ReviewsInfo';
 import { BackBar } from 'Components/AppBar/presets';
 import LoadMoreButton from '../LoadMore';
 import connect from './connector';
@@ -22,6 +23,7 @@ const ReviewsContent = ({ productId, rating, reviews }) => (
       <Header productId={productId} rating={rating} withTopGap />
       <List productId={productId} reviews={reviews} />
       <LoadMoreButton productId={productId} />
+      <ReviewsInfo reviews={reviews} />
     </SurroundPortals>
   </Fragment>
 );

--- a/themes/theme-gmd/pages/Reviews/spec.jsx
+++ b/themes/theme-gmd/pages/Reviews/spec.jsx
@@ -9,6 +9,9 @@ import { UnwrappedReviews as Reviews } from './index';
 const mockedStore = configureStore();
 jest.mock('@shopgate/engage/components');
 jest.mock('@shopgate/engage/reviews/components/Reviews/components/Header', () => () => 'div');
+jest.mock('Components/AppBar/presets', () => ({
+  BackBar: () => null,
+}));
 
 /**
  * Creates component
@@ -21,13 +24,13 @@ const createComponent = () => mount(
   mockRenderOptions
 );
 
-describe.skip('<Reviews> page', () => {
+describe('<Reviews> page', () => {
   it('should not crash', () => {
     const component = createComponent();
     expect(component).toMatchSnapshot();
     expect(component.find('Reviews').exists()).toBe(true);
     expect(component.find('RatingStars').exists()).toBe(true);
     expect(component.find('LoadMore').exists()).toBe(true);
-    expect(component.find('List > div').length).toEqual(4);
+    expect(component.find('List li').length).toEqual(4);
   });
 });

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -586,7 +586,7 @@
         "label": "App rating settings"
       }
     },
-    "reviewsInfoText": {
+    "reviewsInfo": {
       "type": "admin",
       "destination": "frontend",
       "default": {

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -585,6 +585,19 @@
         "type": "json",
         "label": "App rating settings"
       }
+    },
+    "reviewsInfoText": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": {
+        "text": null,
+        "linkText": null,
+        "linkUrl": null
+      },
+      "params": {
+        "type": "json",
+        "label": "An info text shown after the reviews on PDP"
+      }
     }
   }
 }

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -587,7 +587,7 @@
       }
     },
     "reviewsInfo": {
-      "type": "admin",
+      "type": "bigApi",
       "destination": "frontend",
       "default": {
         "text": null,
@@ -595,8 +595,10 @@
         "linkUrl": null
       },
       "params": {
-        "type": "json",
-        "label": "An info text shown after the reviews on PDP. The text can be extended with a link to e.g. a cms page."
+        "method": "GET",
+        "service": "config",
+        "path": "/v1/shop/%(shopId)s/gui_sg_connect_reviews_info_config?parsed=true",
+        "key": "value"
       }
     }
   }

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -596,7 +596,7 @@
       },
       "params": {
         "type": "json",
-        "label": "An info text shown after the reviews on PDP"
+        "label": "An info text shown after the reviews on PDP. The text can be extended with a link to e.g. a cms page."
       }
     }
   }

--- a/themes/theme-ios11/pages/Reviews/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/Reviews/__snapshots__/spec.jsx.snap
@@ -16,7 +16,9 @@ exports[`<Reviews> page should not crash 1`] = `
   <Reviews
     id="foo"
   >
-    <MockedView>
+    <MockedView
+      aria-hidden={false}
+    >
       <div>
         <Connect(ReviewsContent)
           productId="foo"
@@ -67,585 +69,34 @@ exports[`<Reviews> page should not crash 1`] = `
               ]
             }
           >
-            <Connect(BackBar)
+            <BackBar
               right={null}
               title="titles.reviews"
-            >
-              <BackBar
-                goBack={[Function]}
-                right={null}
-                title="titles.reviews"
-              >
-                <AppBarDefault
-                  left={[Function]}
-                  right={null}
-                  title="titles.reviews"
-                >
-                  <AppBar
-                    backgroundColor="#fff"
-                    below={
-                      <React.Fragment>
-                        <_default />
-                      </React.Fragment>
-                    }
-                    center={
-                      <AppBarTitle
-                        title="titles.reviews"
-                      />
-                    }
-                    left={[Function]}
-                    right={null}
-                    shadow={true}
-                    textColor="#000"
-                    title="titles.reviews"
-                  >
-                    <header
-                      className={
-                        Object {
-                          "data-css-1gx0ht2": "",
-                        }
-                      }
-                      data-test-id="Navigator"
-                      role="banner"
-                      style={
-                        Object {
-                          "background": "#fff",
-                          "boxShadow": "rgba(0, 0, 0, .117647) 0 1px 6px, rgba(0, 0, 0, .117647) 0 1px 4px",
-                          "color": "#000",
-                        }
-                      }
-                    >
-                      <div
-                        className={
-                          Object {
-                            "data-css-1qz3sla": "",
-                          }
-                        }
-                      >
-                        <AppBarTitle
-                          title="titles.reviews"
-                        >
-                          <div
-                            className={
-                              Object {
-                                "data-css-16ouezv": "",
-                              }
-                            }
-                          >
-                            titles.reviews
-                          </div>
-                        </AppBarTitle>
-                      </div>
-                      <_default>
-                        <Consumer>
-                          <ProgressBar
-                            pattern=""
-                            visible={true}
-                          >
-                            <ProgressBar
-                              isVisible={false}
-                            >
-                              <Transition
-                                appear={false}
-                                enter={true}
-                                exit={true}
-                                in={false}
-                                mountOnEnter={false}
-                                onEnter={[Function]}
-                                onEntered={[Function]}
-                                onEntering={[Function]}
-                                onExit={[Function]}
-                                onExited={[Function]}
-                                onExiting={[Function]}
-                                timeout={150}
-                                unmountOnExit={false}
-                              >
-                                <div
-                                  className="css-guf25f"
-                                  style={
-                                    Object {
-                                      "transform": "scale(1, 0)",
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="css-cd7tja"
-                                  />
-                                </div>
-                              </Transition>
-                            </ProgressBar>
-                          </ProgressBar>
-                        </Consumer>
-                      </_default>
-                    </header>
-                  </AppBar>
-                </AppBarDefault>
-              </BackBar>
-            </Connect(BackBar)>
-            <Component
-              productId="foo"
-              rating={
+            />
+            <SurroundPortals
+              portalName="product.reviews.all"
+              portalProps={
                 Object {
-                  "average": 50,
-                  "count": 4,
+                  "productId": "foo",
                 }
               }
-              withTopGap={true}
             >
-              div
-            </Component>
-            <List
-              productId="foo"
-              reviews={
-                Array [
+              <Component
+                productId="foo"
+                rating={
                   Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 1,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 2,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 3,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                  Object {
-                    "author": "",
-                    "date": "2017-09-06T12:38:51.000Z",
-                    "id": 4,
-                    "rate": 100,
-                    "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
-                    "title": "",
-                  },
-                ]
-              }
-            >
-              <div
-                className="css-1yhq1gr"
-                data-test-id="reviewTitle: "
-                key="1"
+                    "average": 50,
+                    "count": 4,
+                  }
+                }
+                withTopGap={true}
               >
-                <Title
-                  title=""
-                >
-                  <div
-                    className="css-1rmdcnr"
-                  />
-                </Title>
-                <Rating
-                  rate={100}
-                >
-                  <div
-                    className="css-15pwoui"
-                  >
-                    <RatingStars
-                      className="css-hgkz41"
-                      display="small"
-                      isSelectable={false}
-                      onSelection={[Function]}
-                      value={100}
-                    >
-                      <div
-                        aria-label="reviews.rating_stars"
-                        className="css-13azwyo css-hgkz41"
-                        data-test-id="ratedStars: 5"
-                      >
-                        <div
-                          className="css-4s85e9"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="1"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="2"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="3"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="4"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="5"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                        <div
-                          className="css-16y9zin"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="6"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="7"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="8"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="9"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="10"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                      </div>
-                    </RatingStars>
-                  </div>
-                </Rating>
-                <Text
-                  review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                >
-                  <div
-                    className="css-vkqu2k"
-                  >
-                    "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                  </div>
-                </Text>
-                <Info
-                  review={
+                div
+              </Component>
+              <List
+                productId="foo"
+                reviews={
+                  Array [
                     Object {
                       "author": "",
                       "date": "2017-09-06T12:38:51.000Z",
@@ -653,444 +104,7 @@ exports[`<Reviews> page should not crash 1`] = `
                       "rate": 100,
                       "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
                       "title": "",
-                    }
-                  }
-                >
-                  <div
-                    className="css-1dhkxb0"
-                  >
-                    <ReviewDate
-                      date="2017-09-06T12:38:51.000Z"
-                    >
-                      <FormatDate
-                        format="long"
-                        timestamp={1504701531000}
-                      >
-                        <span>
-                          d
-                        </span>
-                      </FormatDate>
-                    </ReviewDate>
-                     
-                    <Author
-                      author=""
-                    />
-                  </div>
-                </Info>
-              </div>
-              <div
-                className="css-1yhq1gr"
-                data-test-id="reviewTitle: "
-                key="2"
-              >
-                <Title
-                  title=""
-                >
-                  <div
-                    className="css-1rmdcnr"
-                  />
-                </Title>
-                <Rating
-                  rate={100}
-                >
-                  <div
-                    className="css-15pwoui"
-                  >
-                    <RatingStars
-                      className="css-hgkz41"
-                      display="small"
-                      isSelectable={false}
-                      onSelection={[Function]}
-                      value={100}
-                    >
-                      <div
-                        aria-label="reviews.rating_stars"
-                        className="css-13azwyo css-hgkz41"
-                        data-test-id="ratedStars: 5"
-                      >
-                        <div
-                          className="css-4s85e9"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="1"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="2"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="3"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="4"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="5"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                        <div
-                          className="css-16y9zin"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="6"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="7"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="8"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="9"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="10"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                      </div>
-                    </RatingStars>
-                  </div>
-                </Rating>
-                <Text
-                  review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                >
-                  <div
-                    className="css-vkqu2k"
-                  >
-                    "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                  </div>
-                </Text>
-                <Info
-                  review={
+                    },
                     Object {
                       "author": "",
                       "date": "2017-09-06T12:38:51.000Z",
@@ -1098,444 +112,7 @@ exports[`<Reviews> page should not crash 1`] = `
                       "rate": 100,
                       "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
                       "title": "",
-                    }
-                  }
-                >
-                  <div
-                    className="css-1dhkxb0"
-                  >
-                    <ReviewDate
-                      date="2017-09-06T12:38:51.000Z"
-                    >
-                      <FormatDate
-                        format="long"
-                        timestamp={1504701531000}
-                      >
-                        <span>
-                          d
-                        </span>
-                      </FormatDate>
-                    </ReviewDate>
-                     
-                    <Author
-                      author=""
-                    />
-                  </div>
-                </Info>
-              </div>
-              <div
-                className="css-1yhq1gr"
-                data-test-id="reviewTitle: "
-                key="3"
-              >
-                <Title
-                  title=""
-                >
-                  <div
-                    className="css-1rmdcnr"
-                  />
-                </Title>
-                <Rating
-                  rate={100}
-                >
-                  <div
-                    className="css-15pwoui"
-                  >
-                    <RatingStars
-                      className="css-hgkz41"
-                      display="small"
-                      isSelectable={false}
-                      onSelection={[Function]}
-                      value={100}
-                    >
-                      <div
-                        aria-label="reviews.rating_stars"
-                        className="css-13azwyo css-hgkz41"
-                        data-test-id="ratedStars: 5"
-                      >
-                        <div
-                          className="css-4s85e9"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="1"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="2"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="3"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="4"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="5"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                        <div
-                          className="css-16y9zin"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="6"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="7"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="8"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="9"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="10"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                      </div>
-                    </RatingStars>
-                  </div>
-                </Rating>
-                <Text
-                  review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                >
-                  <div
-                    className="css-vkqu2k"
-                  >
-                    "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                  </div>
-                </Text>
-                <Info
-                  review={
+                    },
                     Object {
                       "author": "",
                       "date": "2017-09-06T12:38:51.000Z",
@@ -1543,444 +120,7 @@ exports[`<Reviews> page should not crash 1`] = `
                       "rate": 100,
                       "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
                       "title": "",
-                    }
-                  }
-                >
-                  <div
-                    className="css-1dhkxb0"
-                  >
-                    <ReviewDate
-                      date="2017-09-06T12:38:51.000Z"
-                    >
-                      <FormatDate
-                        format="long"
-                        timestamp={1504701531000}
-                      >
-                        <span>
-                          d
-                        </span>
-                      </FormatDate>
-                    </ReviewDate>
-                     
-                    <Author
-                      author=""
-                    />
-                  </div>
-                </Info>
-              </div>
-              <div
-                className="css-1yhq1gr"
-                data-test-id="reviewTitle: "
-                key="4"
-              >
-                <Title
-                  title=""
-                >
-                  <div
-                    className="css-1rmdcnr"
-                  />
-                </Title>
-                <Rating
-                  rate={100}
-                >
-                  <div
-                    className="css-15pwoui"
-                  >
-                    <RatingStars
-                      className="css-hgkz41"
-                      display="small"
-                      isSelectable={false}
-                      onSelection={[Function]}
-                      value={100}
-                    >
-                      <div
-                        aria-label="reviews.rating_stars"
-                        className="css-13azwyo css-hgkz41"
-                        data-test-id="ratedStars: 5"
-                      >
-                        <div
-                          className="css-4s85e9"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="1"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="2"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="3"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="4"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="5"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                        <div
-                          className="css-16y9zin"
-                        >
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="6"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="7"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="8"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="9"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                          <div
-                            className="css-kdb68h css-q4owmg"
-                            key="10"
-                          >
-                            <Star
-                              className=""
-                              color={null}
-                              size="1em"
-                              viewBox="0 0 24 24"
-                            >
-                              <Icon
-                                className=""
-                                color={null}
-                                content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
-                                size="1em"
-                                viewBox="0 0 24 24"
-                              >
-                                <svg
-                                  className="css-yys9hb "
-                                  dangerouslySetInnerHTML={
-                                    Object {
-                                      "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "fill": null,
-                                      "fontSize": "1em",
-                                    }
-                                  }
-                                  viewBox="0 0 24 24"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </Icon>
-                            </Star>
-                          </div>
-                        </div>
-                      </div>
-                    </RatingStars>
-                  </div>
-                </Rating>
-                <Text
-                  review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                >
-                  <div
-                    className="css-vkqu2k"
-                  >
-                    "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
-                  </div>
-                </Text>
-                <Info
-                  review={
+                    },
                     Object {
                       "author": "",
                       "date": "2017-09-06T12:38:51.000Z",
@@ -1988,43 +128,1909 @@ exports[`<Reviews> page should not crash 1`] = `
                       "rate": 100,
                       "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
                       "title": "",
-                    }
-                  }
+                    },
+                  ]
+                }
+              >
+                <ul
+                  className="engage__reviews__list"
                 >
-                  <div
-                    className="css-1dhkxb0"
+                  <li
+                    className="css-1yhq1gr"
+                    data-test-id="reviewTitle: "
+                    key="1"
                   >
-                    <ReviewDate
-                      date="2017-09-06T12:38:51.000Z"
+                    <SurroundPortals
+                      portalName="product.reviews.entry"
+                      portalProps={
+                        Object {
+                          "review": Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 1,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          },
+                        }
+                      }
                     >
-                      <FormatDate
-                        format="long"
-                        timestamp={1504701531000}
+                      <Title
+                        title=""
                       >
-                        <span>
-                          d
-                        </span>
-                      </FormatDate>
-                    </ReviewDate>
-                     
-                    <Author
-                      author=""
-                    />
-                  </div>
-                </Info>
-              </div>
-            </List>
-            <Connect(LoadMore)
-              productId="foo"
-            >
-              <LoadMore
-                currentReviewCount={4}
-                fetchReviews={[Function]}
-                isFetching={false}
+                        <div
+                          className="css-1rmdcnr"
+                        />
+                      </Title>
+                      <Rating
+                        rate={100}
+                      >
+                        <div
+                          className="css-15pwoui"
+                        >
+                          <RatingStars
+                            className="css-hgkz41"
+                            display="small"
+                            isSelectable={false}
+                            onSelection={[Function]}
+                            value={100}
+                          >
+                            <div
+                              aria-label="reviews.rating_stars"
+                              className="css-13azwyo css-hgkz41 ui-shared__rating-stars"
+                              data-test-id="ratedStars: 5"
+                              role="text"
+                            >
+                              <div
+                                className="css-4s85e9 rating-stars-empty"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="1"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="2"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="3"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="4"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="5"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                              <div
+                                className="css-16y9zin rating-stars-filled"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="6"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="7"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="8"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="9"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="10"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                            </div>
+                          </RatingStars>
+                        </div>
+                      </Rating>
+                      <Text
+                        review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                      >
+                        <div
+                          className="css-vkqu2k"
+                        >
+                          "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                        </div>
+                      </Text>
+                      <Info
+                        review={
+                          Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 1,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          }
+                        }
+                      >
+                        <div
+                          className="css-1dhkxb0"
+                          role="text"
+                        >
+                          <ReviewDate
+                            date="2017-09-06T12:38:51.000Z"
+                          >
+                            <FormatDate
+                              format="long"
+                              timestamp={1504701531000}
+                            >
+                              d
+                            </FormatDate>
+                          </ReviewDate>
+                           
+                          <Author
+                            author=""
+                          />
+                        </div>
+                      </Info>
+                    </SurroundPortals>
+                  </li>
+                  <li
+                    className="css-1yhq1gr"
+                    data-test-id="reviewTitle: "
+                    key="2"
+                  >
+                    <SurroundPortals
+                      portalName="product.reviews.entry"
+                      portalProps={
+                        Object {
+                          "review": Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 2,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          },
+                        }
+                      }
+                    >
+                      <Title
+                        title=""
+                      >
+                        <div
+                          className="css-1rmdcnr"
+                        />
+                      </Title>
+                      <Rating
+                        rate={100}
+                      >
+                        <div
+                          className="css-15pwoui"
+                        >
+                          <RatingStars
+                            className="css-hgkz41"
+                            display="small"
+                            isSelectable={false}
+                            onSelection={[Function]}
+                            value={100}
+                          >
+                            <div
+                              aria-label="reviews.rating_stars"
+                              className="css-13azwyo css-hgkz41 ui-shared__rating-stars"
+                              data-test-id="ratedStars: 5"
+                              role="text"
+                            >
+                              <div
+                                className="css-4s85e9 rating-stars-empty"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="1"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="2"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="3"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="4"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="5"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                              <div
+                                className="css-16y9zin rating-stars-filled"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="6"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="7"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="8"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="9"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="10"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                            </div>
+                          </RatingStars>
+                        </div>
+                      </Rating>
+                      <Text
+                        review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                      >
+                        <div
+                          className="css-vkqu2k"
+                        >
+                          "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                        </div>
+                      </Text>
+                      <Info
+                        review={
+                          Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 2,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          }
+                        }
+                      >
+                        <div
+                          className="css-1dhkxb0"
+                          role="text"
+                        >
+                          <ReviewDate
+                            date="2017-09-06T12:38:51.000Z"
+                          >
+                            <FormatDate
+                              format="long"
+                              timestamp={1504701531000}
+                            >
+                              d
+                            </FormatDate>
+                          </ReviewDate>
+                           
+                          <Author
+                            author=""
+                          />
+                        </div>
+                      </Info>
+                    </SurroundPortals>
+                  </li>
+                  <li
+                    className="css-1yhq1gr"
+                    data-test-id="reviewTitle: "
+                    key="3"
+                  >
+                    <SurroundPortals
+                      portalName="product.reviews.entry"
+                      portalProps={
+                        Object {
+                          "review": Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 3,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          },
+                        }
+                      }
+                    >
+                      <Title
+                        title=""
+                      >
+                        <div
+                          className="css-1rmdcnr"
+                        />
+                      </Title>
+                      <Rating
+                        rate={100}
+                      >
+                        <div
+                          className="css-15pwoui"
+                        >
+                          <RatingStars
+                            className="css-hgkz41"
+                            display="small"
+                            isSelectable={false}
+                            onSelection={[Function]}
+                            value={100}
+                          >
+                            <div
+                              aria-label="reviews.rating_stars"
+                              className="css-13azwyo css-hgkz41 ui-shared__rating-stars"
+                              data-test-id="ratedStars: 5"
+                              role="text"
+                            >
+                              <div
+                                className="css-4s85e9 rating-stars-empty"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="1"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="2"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="3"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="4"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="5"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                              <div
+                                className="css-16y9zin rating-stars-filled"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="6"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="7"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="8"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="9"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="10"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                            </div>
+                          </RatingStars>
+                        </div>
+                      </Rating>
+                      <Text
+                        review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                      >
+                        <div
+                          className="css-vkqu2k"
+                        >
+                          "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                        </div>
+                      </Text>
+                      <Info
+                        review={
+                          Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 3,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          }
+                        }
+                      >
+                        <div
+                          className="css-1dhkxb0"
+                          role="text"
+                        >
+                          <ReviewDate
+                            date="2017-09-06T12:38:51.000Z"
+                          >
+                            <FormatDate
+                              format="long"
+                              timestamp={1504701531000}
+                            >
+                              d
+                            </FormatDate>
+                          </ReviewDate>
+                           
+                          <Author
+                            author=""
+                          />
+                        </div>
+                      </Info>
+                    </SurroundPortals>
+                  </li>
+                  <li
+                    className="css-1yhq1gr"
+                    data-test-id="reviewTitle: "
+                    key="4"
+                  >
+                    <SurroundPortals
+                      portalName="product.reviews.entry"
+                      portalProps={
+                        Object {
+                          "review": Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 4,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          },
+                        }
+                      }
+                    >
+                      <Title
+                        title=""
+                      >
+                        <div
+                          className="css-1rmdcnr"
+                        />
+                      </Title>
+                      <Rating
+                        rate={100}
+                      >
+                        <div
+                          className="css-15pwoui"
+                        >
+                          <RatingStars
+                            className="css-hgkz41"
+                            display="small"
+                            isSelectable={false}
+                            onSelection={[Function]}
+                            value={100}
+                          >
+                            <div
+                              aria-label="reviews.rating_stars"
+                              className="css-13azwyo css-hgkz41 ui-shared__rating-stars"
+                              data-test-id="ratedStars: 5"
+                              role="text"
+                            >
+                              <div
+                                className="css-4s85e9 rating-stars-empty"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="1"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="2"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="3"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="4"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="5"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                              <div
+                                className="css-16y9zin rating-stars-filled"
+                              >
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="6"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="7"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="8"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="9"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                                <div
+                                  className="css-kdb68h css-q4owmg"
+                                  key="10"
+                                >
+                                  <Star
+                                    className=""
+                                    color={null}
+                                    size="1em"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <Icon
+                                      className=""
+                                      color={null}
+                                      content="<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>"
+                                      size="1em"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <svg
+                                        className="css-yys9hb  common__icon"
+                                        dangerouslySetInnerHTML={
+                                          Object {
+                                            "__html": "<path d=\\"M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z\\"/>",
+                                          }
+                                        }
+                                        style={
+                                          Object {
+                                            "fill": null,
+                                            "fontSize": "1em",
+                                          }
+                                        }
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </Icon>
+                                  </Star>
+                                </div>
+                              </div>
+                            </div>
+                          </RatingStars>
+                        </div>
+                      </Rating>
+                      <Text
+                        review="No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                      >
+                        <div
+                          className="css-vkqu2k"
+                        >
+                          "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet."
+                        </div>
+                      </Text>
+                      <Info
+                        review={
+                          Object {
+                            "author": "",
+                            "date": "2017-09-06T12:38:51.000Z",
+                            "id": 4,
+                            "rate": 100,
+                            "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                            "title": "",
+                          }
+                        }
+                      >
+                        <div
+                          className="css-1dhkxb0"
+                          role="text"
+                        >
+                          <ReviewDate
+                            date="2017-09-06T12:38:51.000Z"
+                          >
+                            <FormatDate
+                              format="long"
+                              timestamp={1504701531000}
+                            >
+                              d
+                            </FormatDate>
+                          </ReviewDate>
+                           
+                          <Author
+                            author=""
+                          />
+                        </div>
+                      </Info>
+                    </SurroundPortals>
+                  </li>
+                </ul>
+              </List>
+              <Connect(LoadMore)
                 productId="foo"
-                totalReviewCount={4}
+              >
+                <LoadMore
+                  currentReviewCount={4}
+                  fetchReviews={[Function]}
+                  isFetching={false}
+                  productId="foo"
+                  totalReviewCount={4}
+                />
+              </Connect(LoadMore)>
+              <ReviewsInfo
+                reviews={
+                  Array [
+                    Object {
+                      "author": "",
+                      "date": "2017-09-06T12:38:51.000Z",
+                      "id": 1,
+                      "rate": 100,
+                      "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                      "title": "",
+                    },
+                    Object {
+                      "author": "",
+                      "date": "2017-09-06T12:38:51.000Z",
+                      "id": 2,
+                      "rate": 100,
+                      "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                      "title": "",
+                    },
+                    Object {
+                      "author": "",
+                      "date": "2017-09-06T12:38:51.000Z",
+                      "id": 3,
+                      "rate": 100,
+                      "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                      "title": "",
+                    },
+                    Object {
+                      "author": "",
+                      "date": "2017-09-06T12:38:51.000Z",
+                      "id": 4,
+                      "rate": 100,
+                      "review": "No Name and Title Lorem ipsum dolor sit amet, con… takimata sanctus est Lorem ipsum dolor sit amet.",
+                      "title": "",
+                    },
+                  ]
+                }
               />
-            </Connect(LoadMore)>
+            </SurroundPortals>
           </ReviewsContent>
         </Connect(ReviewsContent)>
       </div>

--- a/themes/theme-ios11/pages/Reviews/components/Content/index.jsx
+++ b/themes/theme-ios11/pages/Reviews/components/Content/index.jsx
@@ -4,6 +4,7 @@ import { SurroundPortals } from '@shopgate/engage/components';
 import { PRODUCT_REVIEWS_ALL } from '@shopgate/engage/reviews';
 import Header from '@shopgate/engage/reviews/components/Reviews/components/Header';
 import List from '@shopgate/engage/reviews/components/Reviews/components/List';
+import ReviewsInfo from '@shopgate/engage/reviews/components/Reviews/components/ReviewsInfo';
 import { BackBar } from 'Components/AppBar/presets';
 import LoadMoreButton from '../LoadMore';
 import connect from './connector';
@@ -22,6 +23,7 @@ const ReviewsContent = ({ productId, rating, reviews }) => (
       <Header productId={productId} rating={rating} withTopGap />
       <List productId={productId} reviews={reviews} />
       <LoadMoreButton productId={productId} />
+      <ReviewsInfo reviews={reviews} />
     </SurroundPortals>
   </Fragment>
 );

--- a/themes/theme-ios11/pages/Reviews/spec.jsx
+++ b/themes/theme-ios11/pages/Reviews/spec.jsx
@@ -9,6 +9,9 @@ import { UnwrappedReviews as Reviews } from './index';
 const mockedStore = configureStore();
 jest.mock('@shopgate/engage/components');
 jest.mock('@shopgate/engage/reviews/components/Reviews/components/Header', () => () => 'div');
+jest.mock('Components/AppBar/presets', () => ({
+  BackBar: () => null,
+}));
 
 /**
  * Creates component
@@ -21,13 +24,13 @@ const createComponent = () => mount(
   mockRenderOptions
 );
 
-describe.skip('<Reviews> page', () => {
+describe('<Reviews> page', () => {
   it('should not crash', () => {
     const component = createComponent();
     expect(component).toMatchSnapshot();
     expect(component.find('Reviews').exists()).toBe(true);
     expect(component.find('RatingStars').exists()).toBe(true);
     expect(component.find('LoadMore').exists()).toBe(true);
-    expect(component.find('List > div').length).toEqual(4);
+    expect(component.find('List li').length).toEqual(4);
   });
 });


### PR DESCRIPTION
# Description
This ticket adds a configureable text block below the review list. This block can be configured via the theme config with the `reviewsInfo` setting. The setting allows to configure the text and an optional link that can lead to a page with further information.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
