### PR TITLE
Fixed endless loading spinner in product lists with few products

### DIFF
--- a/libraries/common/components/InfiniteContainer/index.jsx
+++ b/libraries/common/components/InfiniteContainer/index.jsx
@@ -240,19 +240,23 @@ class InfiniteContainer extends Component {
    * @returns {boolean}
    */
   allItemsAreRendered(props = this.props) {
+    const { totalItems, items } = props;
     const [offset, limit] = this.state.offset;
 
     if (props.enablePromiseBasedLoading) {
-      const { totalItems } = props;
       // At promise based loading the offset is increased after the response came in.
       // This method is invoked to evaluate if a new request needs to be dispatched, so we check
       // against the current offset state.
-      return totalItems !== null && (offset >= totalItems);
+      return (
+        totalItems !== null &&
+        (offset >= totalItems ||
+          (offset === 0 && Array.isArray(items) && items.length === totalItems))
+      );
     }
 
     return (
       !this.needsToReceiveItems(props) &&
-      offset + limit >= props.totalItems
+      offset + limit >= totalItems
     );
   }
 


### PR DESCRIPTION
# Description

This ticket fixes an issue within the `InfiniteContainer` component that caused a never disappearing loading spinner. The issue occurred in situations where all available category products where already loaded at the first "page" of products. 

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

