### PR TITLE
Favlist undo toast does not disappear

### DIFF
--- a/libraries/commerce/favorites/action-creators/index.js
+++ b/libraries/commerce/favorites/action-creators/index.js
@@ -31,14 +31,16 @@ import { makeGetFavorites } from '../selectors';
  * @param {string} listId List identifier.
  * @param {number} quantity New favorites quantity to set
  * @param {string} notes New favorites notes to set
+ * @param {boolean} showToast Whether to show a confirmation toast after product was added
  * @returns {Object}
  */
-export const addProductToFavorites = (productId, listId, quantity, notes) => ({
+export const addProductToFavorites = (productId, listId, quantity, notes, showToast = true) => ({
   type: ADD_PRODUCT_TO_FAVORITES,
   productId,
   listId,
   quantity,
   notes,
+  showToast,
 });
 
 /**

--- a/libraries/commerce/favorites/action-creators/index.js
+++ b/libraries/commerce/favorites/action-creators/index.js
@@ -103,26 +103,30 @@ export const errorFavorites = (productId, error) => ({
  * @param {string} listId List identifier.
  * @param {number} quantity New favorites quantity to set
  * @param {string} notes New favorites notes to set
+ * @param {boolean} showToast Whether to show a confirmation toast after product was added
  * @returns {Object}
  */
-export const requestAddFavorites = (productId, listId, quantity, notes) => ({
+export const requestAddFavorites = (productId, listId, quantity, notes, showToast = true) => ({
   type: REQUEST_ADD_FAVORITES,
   productId,
   listId,
   quantity,
   notes,
+  showToast,
 });
 
 /**
  * Action to be triggered upon successful addFavorites pipeline call.
  * @param {string} productId Product identifier.
  * @param {string} listId List identifier.
+ * @param {boolean} showToast Whether to show a confirmation toast after product was added
  * @returns {Object}
  */
-export const successAddFavorites = (productId, listId) => ({
+export const successAddFavorites = (productId, listId, showToast = true) => ({
   type: SUCCESS_ADD_FAVORITES,
   productId,
   listId,
+  showToast,
 });
 
 /**

--- a/libraries/commerce/favorites/actions/addFavorites.js
+++ b/libraries/commerce/favorites/actions/addFavorites.js
@@ -8,9 +8,10 @@ import { successAddFavorites, errorAddFavorites } from '../action-creators';
  * @param {string} listId Id of the list to be added.
  * @param {number} quantity New favorites quantity to set
  * @param {string} notes New favorites notes to set
+ * @param {boolean} showToast Whether to show a confirmation toast after product was added
  * @returns {Function} A redux thunk.
  */
-function addFavorites(productId, listId = null, quantity, notes) {
+function addFavorites(productId, listId = null, quantity, notes, showToast = true) {
   return async (dispatch, getState) => {
     // Fallback for deprecated calls without list id.
     const { lists } = getState().favorites.lists;
@@ -29,7 +30,7 @@ function addFavorites(productId, listId = null, quantity, notes) {
 
     try {
       await request;
-      dispatch(successAddFavorites(productId, takenListId));
+      dispatch(successAddFavorites(productId, takenListId, showToast));
     } catch (error) {
       dispatch(errorAddFavorites(productId, error, takenListId));
     }

--- a/libraries/commerce/favorites/actions/toggleFavorites.js
+++ b/libraries/commerce/favorites/actions/toggleFavorites.js
@@ -26,9 +26,15 @@ import fetchFavoritesListsWithItems from './fetchFavoritesListsWithItems';
  * @param {string} notes New favorites notes to set
  * @return {Function}
  */
-export const addFavorite = mutable((productId, listId, quantity, notes) => (dispatch, getState) => {
+export const addFavorite = mutable((
+  productId,
+  listId,
+  quantity,
+  notes,
+  showToast = true
+) => (dispatch, getState) => {
   const defaultList = getFavoritesDefaultList(getState());
-  dispatch(addProductToFavorites(productId, listId || defaultList.id, quantity, notes));
+  dispatch(addProductToFavorites(productId, listId || defaultList.id, quantity, notes, showToast));
 });
 
 /**

--- a/libraries/commerce/favorites/actions/toggleFavorites.js
+++ b/libraries/commerce/favorites/actions/toggleFavorites.js
@@ -24,6 +24,7 @@ import fetchFavoritesListsWithItems from './fetchFavoritesListsWithItems';
  * @param {string} listId List identifier.
  * @param {number} quantity New favorites quantity to set
  * @param {string} notes New favorites notes to set
+ * @param {boolean} showToast Whether to show a confirmation toast after product was added
  * @return {Function}
  */
 export const addFavorite = mutable((

--- a/libraries/commerce/favorites/actions/toggleFavorites.spec.js
+++ b/libraries/commerce/favorites/actions/toggleFavorites.spec.js
@@ -22,6 +22,7 @@ describe('Favorites - actions', () => {
         type: ADD_PRODUCT_TO_FAVORITES,
         productId,
         listId,
+        showToast: true,
       }];
 
       const store = mockStore(mockedGetState('then', {

--- a/libraries/commerce/favorites/subscriptions/index.js
+++ b/libraries/commerce/favorites/subscriptions/index.js
@@ -115,7 +115,13 @@ export default function favorites(subscribe) {
       error.code = FAVORITES_LIMIT_ERROR;
       dispatch(errorFavorites(action.productId, error));
     } else {
-      dispatch(requestAddFavorites(action.productId, action.listId, action.quantity, action.notes));
+      dispatch(requestAddFavorites(
+        action.productId,
+        action.listId,
+        action.quantity,
+        action.notes,
+        action.showToast
+      ));
     }
   });
 
@@ -205,6 +211,7 @@ export default function favorites(subscribe) {
         listId,
         quantity,
         notes,
+        showToast,
       } = {}] = groupedActions;
 
       const updateActions = groupedActions
@@ -229,7 +236,7 @@ export default function favorites(subscribe) {
         // Sum up all adds and removes, based on sum dispatch add / remove
         const addRemoveBalance = addActions.length - removeActions.length;
         if (addRemoveBalance > 0) {
-          await dispatch(addFavorites(productId, listId, quantity, notes));
+          await dispatch(addFavorites(productId, listId, quantity, notes, showToast));
         }
         if (addRemoveBalance < 0) {
           await dispatch(removeFavorites(productId, listId, quantity, notes));
@@ -268,13 +275,13 @@ export default function favorites(subscribe) {
     }
   });
 
-  subscribe(favoritesDidAddItem$, ({ events, getState }) => {
+  subscribe(favoritesDidAddItem$, ({ events, getState, action }) => {
     const loadWishlistOnAppStartEnabled = getLoadWishlistOnAppStartEnabled(getState());
 
     // When wish list loading on app start is enabled, toast is shown after the add action from
     // the buffer system is dispatched. We wait for that since the item might have been removed
     // again within the debounce time.
-    if (loadWishlistOnAppStartEnabled) {
+    if (loadWishlistOnAppStartEnabled && action?.showToast !== false) {
       events.emit(ToastProvider.ADD, {
         id: 'favorites.added',
         message: 'favorites.added',

--- a/libraries/commerce/favorites/subscriptions/index.js
+++ b/libraries/commerce/favorites/subscriptions/index.js
@@ -254,13 +254,13 @@ export default function favorites(subscribe) {
     LoadingProvider.resetLoading(FAVORITES_PATH);
   });
 
-  subscribe(addProductToFavorites$, ({ events, getState }) => {
+  subscribe(addProductToFavorites$, ({ events, getState, action }) => {
     const loadWishlistOnAppStartEnabled = getLoadWishlistOnAppStartEnabled(getState());
 
     // When wish list loading on app start is disabled, toast is shown instantly after the add
     // action was dispatched. We don't have to wait for the "debounced" action, since
     // removal of wishlist items is not possible.
-    if (!loadWishlistOnAppStartEnabled) {
+    if (!loadWishlistOnAppStartEnabled && action?.showToast !== false) {
       events.emit(ToastProvider.ADD, {
         id: 'favorites.added',
         message: 'favorites.added',

--- a/themes/theme-gmd/pages/Favorites/subscriptions.js
+++ b/themes/theme-gmd/pages/Favorites/subscriptions.js
@@ -17,7 +17,9 @@ export default function favorites(subscribe) {
           action.productId,
           action.listId,
           action.quantity,
-          action.notes
+          action.notes,
+          // No toast to prevent issue with SnackBar when toast is triggered by another toast
+          false
         )),
         actionLabel: 'common.undo',
       });

--- a/themes/theme-ios11/pages/Favorites/subscriptions.js
+++ b/themes/theme-ios11/pages/Favorites/subscriptions.js
@@ -17,7 +17,9 @@ export default function favorites(subscribe) {
           action.productId,
           action.listId,
           action.quantity,
-          action.notes
+          action.notes,
+          // No toast to prevent issue with SnackBar when toast is triggered by another toast
+          false
         )),
         actionLabel: 'common.undo',
       });


### PR DESCRIPTION
# Description

When an item is removed from the favorites list via the trash button, a toast appears with an "undo" button. After pressing the button doesn't disappear as expected right now.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
