### PR TITLE
Added theme config to disable auto logout modal

### DIFF
--- a/libraries/common/subscriptions/user.js
+++ b/libraries/common/subscriptions/user.js
@@ -1,6 +1,7 @@
 import { getCurrentRoute } from '@shopgate/pwa-common/selectors/router';
 import event from '@shopgate/pwa-core/classes/Event';
 import registerEvents from '@shopgate/pwa-core/commands/registerEvents';
+import appConfig from '../helpers/config';
 import { LoadingProvider } from '../providers';
 import { fetchUser } from '../actions/user';
 import { successLogin } from '../action-creators';
@@ -53,6 +54,11 @@ export default function user(subscribe) {
     }
 
     const isAutoLogout = action.autoLogout;
+
+    if (isAutoLogout && appConfig?.disableAutoLogoutModal === true) {
+      // Prevent showing auto logout modal when turned off
+      return;
+    }
 
     const confirmed = await dispatch(showModal({
       confirm: 'modal.ok',

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -639,6 +639,15 @@
         "type": "json",
         "label": "App rating settings"
       }
+    },
+    "disableAutoLogoutModal": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "json",
+        "label": "Disable the modal that is shown after automatic logout"
+      }
     }
   }
 }

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -642,6 +642,15 @@
         "type": "json",
         "label": "App rating settings"
       }
+    },
+    "disableAutoLogoutModal": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "json",
+        "label": "Disable the modal that is shown after automatic logout"
+      }
     }
   }
 }


### PR DESCRIPTION
# Description

The ticket adds a new setting to the themes that allows to disable the modal that usually informs users about the automatic logout.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

