### PR TITLE
Added support for product properties of type "html"

### DIFF
--- a/libraries/engage/cart/components/CartItem/__tests__/__snapshots__/CartItemQuantityPicker.spec.jsx.snap
+++ b/libraries/engage/cart/components/CartItem/__tests__/__snapshots__/CartItemQuantityPicker.spec.jsx.snap
@@ -33,12 +33,12 @@ exports[`<CartItemQuantityPicker /> Given editMode prop is handled correctly sho
         className="css-1bncmx2"
         data-test-id="quantityPicker"
         disabled={false}
-        inputMode="decimal"
+        inputMode="numeric"
         onBlur={[Function]}
         onChange={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        pattern="[0-9.,]*"
+        pattern="[0–9]*"
         value="1"
       />
     </ForwardRef>
@@ -79,12 +79,12 @@ exports[`<CartItemQuantityPicker /> Given editMode prop is handled correctly sho
         className="css-1bncmx2"
         data-test-id="quantityPicker"
         disabled={false}
-        inputMode="decimal"
+        inputMode="numeric"
         onBlur={[Function]}
         onChange={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        pattern="[0-9.,]*"
+        pattern="[0–9]*"
         value="1"
       />
     </ForwardRef>
@@ -125,12 +125,12 @@ exports[`<CartItemQuantityPicker /> Given onChange callback is triggered correct
         className="css-1bncmx2"
         data-test-id="quantityPicker"
         disabled={false}
-        inputMode="decimal"
+        inputMode="numeric"
         onBlur={[Function]}
         onChange={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        pattern="[0-9.,]*"
+        pattern="[0–9]*"
         value="2"
       />
     </ForwardRef>
@@ -185,12 +185,12 @@ exports[`<CartItemQuantityPicker /> Given onChange callback is triggered correct
         className="css-1bncmx2"
         data-test-id="quantityPicker"
         disabled={false}
-        inputMode="decimal"
+        inputMode="numeric"
         onBlur={[Function]}
         onChange={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        pattern="[0-9.,]*"
+        pattern="[0–9]*"
         value="123"
       />
     </ForwardRef>
@@ -252,12 +252,12 @@ exports[`<CartItemQuantityPicker /> Given onToggleEditMode callback is triggered
         className="css-1bncmx2"
         data-test-id="quantityPicker"
         disabled={false}
-        inputMode="decimal"
+        inputMode="numeric"
         onBlur={[Function]}
         onChange={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        pattern="[0-9.,]*"
+        pattern="[0–9]*"
         value="1"
       />
     </ForwardRef>
@@ -312,12 +312,12 @@ exports[`<CartItemQuantityPicker /> Given onToggleEditMode callback is triggered
         className="css-1bncmx2"
         data-test-id="quantityPicker"
         disabled={false}
-        inputMode="decimal"
+        inputMode="numeric"
         onBlur={[Function]}
         onChange={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        pattern="[0-9.,]*"
+        pattern="[0–9]*"
         value="1"
       />
     </ForwardRef>
@@ -401,12 +401,12 @@ exports[`<CartItemQuantityPicker /> should have an amount of 1 by default 1`] = 
         className="css-1bncmx2"
         data-test-id="quantityPicker"
         disabled={false}
-        inputMode="decimal"
+        inputMode="numeric"
         onBlur={[Function]}
         onChange={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        pattern="[0-9.,]*"
+        pattern="[0–9]*"
         value="1"
       />
     </ForwardRef>
@@ -447,12 +447,12 @@ exports[`<CartItemQuantityPicker /> should have an amount of 3 via prop 1`] = `
         className="css-1bncmx2"
         data-test-id="quantityPicker"
         disabled={false}
-        inputMode="decimal"
+        inputMode="numeric"
         onBlur={[Function]}
         onChange={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        pattern="[0-9.,]*"
+        pattern="[0–9]*"
         value="3"
       />
     </ForwardRef>
@@ -493,12 +493,12 @@ exports[`<CartItemQuantityPicker /> should have an mount of 0, if 0 is supplied 
         className="css-1bncmx2"
         data-test-id="quantityPicker"
         disabled={false}
-        inputMode="decimal"
+        inputMode="numeric"
         onBlur={[Function]}
         onChange={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        pattern="[0-9.,]*"
+        pattern="[0–9]*"
         value="0"
       />
     </ForwardRef>

--- a/libraries/engage/product/components/ProductProperties/Content.jsx
+++ b/libraries/engage/product/components/ProductProperties/Content.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { isBeta } from '../../../core';
 import { getGroupsFromProperties } from './helpers/getGroupsFromProperties';
@@ -12,11 +12,11 @@ import { groupsContainer } from './style';
  * @returns {JSX}
  */
 const Content = ({ properties }) => {
+  const groups = useMemo(() => getGroupsFromProperties(properties), [properties]);
+
   if (!properties) {
     return null;
   }
-
-  const groups = getGroupsFromProperties(properties);
 
   // Display the simple properties if no groups exist or if not in beta mode.
   if (!isBeta() || !groups || groups.length === 0) {
@@ -32,8 +32,8 @@ const Content = ({ properties }) => {
     It should only be used for approved BETA Client Projects
   */
   return (
-    <div className={groupsContainer}>
-      <GroupedProperties properties={properties} groups={groups} />
+    <div className={`${groupsContainer} engage__product__product-properties`}>
+      <GroupedProperties groups={groups} />
     </div>
   );
 };

--- a/libraries/engage/product/components/ProductProperties/Group.jsx
+++ b/libraries/engage/product/components/ProductProperties/Group.jsx
@@ -9,7 +9,9 @@ import { subgroup } from './style';
  */
 const Group = ({ group }) => (
   <tr>
-    <td colSpan="2" className={subgroup}><span dangerouslySetInnerHTML={{ __html: group }} /></td>
+    <td colSpan="2" className={subgroup}>
+      <span dangerouslySetInnerHTML={{ __html: group }} />
+    </td>
   </tr>
 );
 

--- a/libraries/engage/product/components/ProductProperties/GroupedProperties.jsx
+++ b/libraries/engage/product/components/ProductProperties/GroupedProperties.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Accordion } from '@shopgate/pwa-ui-material';
 import { i18n } from '@shopgate/engage/core';
 import Lists from './Lists';
+import ListsHTML from './ListsHTML';
 import Wrapper from './Wrapper';
 import { accordion } from './style';
 
@@ -11,22 +12,26 @@ import { accordion } from './style';
  * @param {Object} props The component props.
  * @returns {JSX}
  */
-const GroupedProperties = ({ properties, groups }) => groups
+const GroupedProperties = ({ groups }) => groups
   .map(group => (
-    <div key={group} className={accordion}>
-      <Accordion renderLabel={() => i18n.text(`product.displayGroups.${group}`)} testId={`product-properties-group-${group}`}>
-        <Wrapper dense>
-          <Lists
-            properties={properties.filter(property => property.displayGroup === group)}
-          />
+    <div key={group.key} className={accordion}>
+      <Accordion
+        renderLabel={() => group.label || i18n.text(`product.displayGroups.${group.key}`)}
+        testId={`product-properties-group-${!group.label ? group.key : `${group.key}-${group.label}`}`}
+      >
+        <Wrapper dense groupName={group.label || group.key} htmlOnly={group.htmlOnly}>
+          {group.htmlOnly ? (
+            <ListsHTML properties={group.properties} />
+          ) : (
+            <Lists properties={group.properties} />
+          )}
         </Wrapper>
       </Accordion>
     </div>
   ));
 
 GroupedProperties.propTypes = {
-  groups: PropTypes.arrayOf(PropTypes.string).isRequired,
-  properties: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+  groups: PropTypes.arrayOf(PropTypes.shape()).isRequired,
 };
 
 export default GroupedProperties;

--- a/libraries/engage/product/components/ProductProperties/ListsHTML.jsx
+++ b/libraries/engage/product/components/ProductProperties/ListsHTML.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { useNavigation } from '@shopgate/engage/core';
 import { HtmlSanitizer } from '@shopgate/engage/components';
 
 /**
@@ -7,19 +8,34 @@ import { HtmlSanitizer } from '@shopgate/engage/components';
  * @param {Object} props The component props.
  * @return {JSX.Element}
  */
-const ListsHTML = ({ properties }) => properties.map(({ label, value, type }) => (
-  <div
-    key={label}
-    className="engage__product__product-property"
-    data-type={type}
-    data-label={label}
-  >
-    <HtmlSanitizer>
-      {value}
-    </HtmlSanitizer>
-  </div>
-));
+const ListsHTML = ({ properties }) => {
+  const { push } = useNavigation();
 
+  const handleClick = useCallback((pathname, target) => {
+    push({
+      pathname,
+      ...target && { state: { target } },
+    });
+  }, [push]);
+
+  return properties.map(({ label, value, type }) => (
+    <div
+      key={label}
+      className="engage__product__product-property"
+      data-type={type}
+      data-label={label}
+    >
+      <HtmlSanitizer
+        settings={{
+          handleClick,
+          html: value,
+        }}
+      >
+        {value}
+      </HtmlSanitizer>
+    </div>
+  ));
+};
 ListsHTML.propTypes = {
   properties: PropTypes.arrayOf(PropTypes.shape()).isRequired,
 };

--- a/libraries/engage/product/components/ProductProperties/ListsHTML.jsx
+++ b/libraries/engage/product/components/ProductProperties/ListsHTML.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { HtmlSanitizer } from '@shopgate/engage/components';
+
+/**
+ * Renders a single properties row with HTML content.
+ * @param {Object} props The component props.
+ * @return {JSX.Element}
+ */
+const ListsHTML = ({ properties }) => properties.map(({ label, value, type }) => (
+  <div
+    key={label}
+    className="engage__product__product-property"
+    data-type={type}
+    data-label={label}
+  >
+    <HtmlSanitizer>
+      {value}
+    </HtmlSanitizer>
+  </div>
+));
+
+ListsHTML.propTypes = {
+  properties: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+};
+
+export default React.memo(ListsHTML);

--- a/libraries/engage/product/components/ProductProperties/Row.jsx
+++ b/libraries/engage/product/components/ProductProperties/Row.jsx
@@ -7,16 +7,25 @@ import { tableCell } from './style';
  * @param {Object} props The component props.
  * @return {JSX.Element}
  */
-const Row = ({ label, value }) => (
-  <tr key={`${label}${value}`}>
-    <td className={tableCell}><span dangerouslySetInnerHTML={{ __html: label }} /></td>
-    <td className={tableCell} data-test-id={`property: ${value}`}><span dangerouslySetInnerHTML={{ __html: value }} /></td>
+const Row = ({ label, value, type }) => (
+  <tr className="engage__product__product-property" data-type={type} data-label={label}>
+    <td className={tableCell}>
+      <span dangerouslySetInnerHTML={{ __html: label }} />
+    </td>
+    <td className={tableCell} data-test-id={`property: ${value}`}>
+      <span dangerouslySetInnerHTML={{ __html: value }} />
+    </td>
   </tr>
 );
 
 Row.propTypes = {
   label: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
+  type: PropTypes.string,
+};
+
+Row.defaultProps = {
+  type: null,
 };
 
 export default React.memo(Row);

--- a/libraries/engage/product/components/ProductProperties/RowHTML.jsx
+++ b/libraries/engage/product/components/ProductProperties/RowHTML.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { HtmlSanitizer } from '@shopgate/engage/components';
+
+/**
+ * Renders a single properties row with HTML content.
+ * @param {Object} props The component props.
+ * @return {JSX.Element}
+ */
+const RowHTML = ({ value, label }) => (
+  <tr className="engage__product__product-property" data-type="html" data-label={label}>
+    <td colSpan={2}>
+      <HtmlSanitizer>
+        {value}
+      </HtmlSanitizer>
+    </td>
+  </tr>
+);
+
+RowHTML.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+};
+
+export default React.memo(RowHTML);

--- a/libraries/engage/product/components/ProductProperties/RowHTML.jsx
+++ b/libraries/engage/product/components/ProductProperties/RowHTML.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { useNavigation } from '@shopgate/engage/core';
 import { HtmlSanitizer } from '@shopgate/engage/components';
 
 /**
@@ -7,16 +8,31 @@ import { HtmlSanitizer } from '@shopgate/engage/components';
  * @param {Object} props The component props.
  * @return {JSX.Element}
  */
-const RowHTML = ({ value, label }) => (
-  <tr className="engage__product__product-property" data-type="html" data-label={label}>
-    <td colSpan={2}>
-      <HtmlSanitizer>
-        {value}
-      </HtmlSanitizer>
-    </td>
-  </tr>
-);
+const RowHTML = ({ value, label }) => {
+  const { push } = useNavigation();
 
+  const handleClick = useCallback((pathname, target) => {
+    push({
+      pathname,
+      ...target && { state: { target } },
+    });
+  }, [push]);
+
+  return (
+    <tr className="engage__product__product-property" data-type="html" data-label={label}>
+      <td colSpan={2}>
+        <HtmlSanitizer
+          settings={{
+            handleClick,
+            html: value,
+          }}
+        >
+          {value}
+        </HtmlSanitizer>
+      </td>
+    </tr>
+  );
+};
 RowHTML.propTypes = {
   label: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,

--- a/libraries/engage/product/components/ProductProperties/Rows.jsx
+++ b/libraries/engage/product/components/ProductProperties/Rows.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Row from './Row';
+import RowHTML from './RowHTML';
 
 /**
  * Renders rows of product properties.
@@ -8,9 +9,13 @@ import Row from './Row';
  * @returns {JSX.Element}
  */
 const Rows = ({ properties }) => properties
-  .map(({ value, label }) => (
-    <Row key={`${label}-${value}`} label={label} value={value} />
-  ));
+  .map(({ value, label, type }) => {
+    if (type === 'html') {
+      return <RowHTML key={label} value={value} label={label} />;
+    }
+
+    return <Row key={`${label}-${value}`} label={label} value={value} type={type} />;
+  });
 
 Rows.propTypes = {
   properties: PropTypes.arrayOf(PropTypes.shape()).isRequired,

--- a/libraries/engage/product/components/ProductProperties/Wrapper.jsx
+++ b/libraries/engage/product/components/ProductProperties/Wrapper.jsx
@@ -8,29 +8,38 @@ import { container, containerDense } from './style';
  * @param {Object} props The component props.
  * @returns {JSX.Element}
  */
-const Wrapper = ({ children, dense }) => (
+const Wrapper = ({
+  children, dense, groupName, htmlOnly,
+}) => (
   <div
-    className={cxs({
+    className={cxs('engage__product__product-property-group', {
       [container]: !dense,
       [containerDense]: dense,
     })}
+    data-group-name={groupName.toLowerCase()}
   >
-    <table>
-      <thead />
-      <tbody>
-        {children}
-      </tbody>
-    </table>
+    { htmlOnly ? children : (
+      <table>
+        <thead />
+        <tbody>
+          {children}
+        </tbody>
+      </table>
+    )}
   </div>
 );
 
 Wrapper.propTypes = {
   children: PropTypes.node.isRequired,
   dense: PropTypes.bool,
+  groupName: PropTypes.string,
+  htmlOnly: PropTypes.bool,
 };
 
 Wrapper.defaultProps = {
   dense: false,
+  htmlOnly: false,
+  groupName: '',
 };
 
 export default React.memo(Wrapper);

--- a/libraries/engage/product/components/ProductProperties/__tests__/Content.spec.jsx
+++ b/libraries/engage/product/components/ProductProperties/__tests__/Content.spec.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { getGroupsFromProperties } from '../helpers/getGroupsFromProperties';
 import { isBeta } from '../../../../core';
 import Content from '../Content';
 
@@ -8,6 +9,10 @@ jest.mock('../../../../core', () => ({
 }));
 
 jest.mock('../GroupedProperties', () => function GroupedProperties() { return 'GroupedProperties'; });
+
+jest.mock('@shopgate/engage/components', () => ({
+  HtmlSanitizer: ({ children }) => children,
+}));
 
 const properties = [
   {
@@ -22,6 +27,12 @@ const properties = [
   },
   {
     name: 'test3',
+    type: 'html',
+    displayGroup: 'Group 1',
+    customDisplayGroupName: 'Custom Name Ignored',
+  },
+  {
+    name: 'test3',
     label: 'Test 3',
     displayGroup: 'Group 2',
   },
@@ -29,6 +40,12 @@ const properties = [
     name: 'test4',
     label: 'Test 4',
     displayGroup: 'Group 2',
+  },
+  {
+    name: 'html',
+    type: 'html',
+    displayGroup: 'custom',
+    customDisplayGroupName: 'Custom Name',
   },
 ];
 
@@ -66,7 +83,7 @@ describe('<Content />', () => {
     isBeta.mockReturnValueOnce(true);
     const wrapper = shallow(<Content properties={properties} />);
     expect(wrapper.find('GroupedProperties').length).toEqual(1);
-    expect(wrapper.find('GroupedProperties').prop('groups')).toEqual(['Group 1', 'Group 2']);
+    expect(wrapper.find('GroupedProperties').prop('groups')).toEqual(getGroupsFromProperties(properties));
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/libraries/engage/product/components/ProductProperties/__tests__/GroupedProperties.spec.jsx
+++ b/libraries/engage/product/components/ProductProperties/__tests__/GroupedProperties.spec.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { getGroupsFromProperties } from '../helpers/getGroupsFromProperties';
 import GroupedProperties from '../GroupedProperties';
+
+jest.mock('@shopgate/engage/components', () => ({
+  HtmlSanitizer: ({ children }) => children,
+}));
 
 const properties = [
   {
@@ -25,11 +30,9 @@ const properties = [
   },
 ];
 
-const groups = ['Group 1', 'Group 2'];
-
 describe('<GroupedProperties />', () => {
   it('should render as expected', () => {
-    const wrapper = shallow(<GroupedProperties properties={properties} groups={groups} />);
+    const wrapper = shallow(<GroupedProperties groups={getGroupsFromProperties(properties)} />);
     expect(wrapper.find('Wrapper').length).toEqual(2);
     expect(wrapper.find('Wrapper').at(0).prop('dense')).toEqual(true);
     expect(wrapper.find('Accordion').length).toEqual(2);

--- a/libraries/engage/product/components/ProductProperties/__tests__/ProductProperties.spec.jsx
+++ b/libraries/engage/product/components/ProductProperties/__tests__/ProductProperties.spec.jsx
@@ -19,6 +19,10 @@ jest.mock('../../../../core', () => ({
   isIOSTheme: jest.fn(() => false),
 }));
 
+jest.mock('@shopgate/engage/components', () => ({
+  HtmlSanitizer: ({ children }) => children,
+}));
+
 const properties = [
   { displayGroup: 'test' },
 ];

--- a/libraries/engage/product/components/ProductProperties/__tests__/__snapshots__/Content.spec.jsx.snap
+++ b/libraries/engage/product/components/ProductProperties/__tests__/__snapshots__/Content.spec.jsx.snap
@@ -4,40 +4,63 @@ exports[`<Content /> should not render if no props are passed 1`] = `""`;
 
 exports[`<Content /> should render grouped properties 1`] = `
 <div
-  className={
-    Object {
-      "data-css-y50mcd": "",
-    }
-  }
+  className="css-y50mcd engage__product__product-properties"
 >
   <GroupedProperties
     groups={
       Array [
-        "Group 1",
-        "Group 2",
-      ]
-    }
-    properties={
-      Array [
         Object {
-          "displayGroup": "Group 1",
-          "label": "Test 1",
-          "name": "test1",
+          "htmlOnly": false,
+          "key": "Group 1",
+          "label": null,
+          "properties": Array [
+            Object {
+              "displayGroup": "Group 1",
+              "label": "Test 1",
+              "name": "test1",
+            },
+            Object {
+              "displayGroup": "Group 1",
+              "label": "Test 2",
+              "name": "test2",
+            },
+            Object {
+              "customDisplayGroupName": "Custom Name Ignored",
+              "displayGroup": "Group 1",
+              "name": "test3",
+              "type": "html",
+            },
+          ],
         },
         Object {
-          "displayGroup": "Group 1",
-          "label": "Test 2",
-          "name": "test2",
+          "htmlOnly": false,
+          "key": "Group 2",
+          "label": null,
+          "properties": Array [
+            Object {
+              "displayGroup": "Group 2",
+              "label": "Test 3",
+              "name": "test3",
+            },
+            Object {
+              "displayGroup": "Group 2",
+              "label": "Test 4",
+              "name": "test4",
+            },
+          ],
         },
         Object {
-          "displayGroup": "Group 2",
-          "label": "Test 3",
-          "name": "test3",
-        },
-        Object {
-          "displayGroup": "Group 2",
-          "label": "Test 4",
-          "name": "test4",
+          "htmlOnly": true,
+          "key": "custom-Custom Name",
+          "label": "Custom Name",
+          "properties": Array [
+            Object {
+              "customDisplayGroupName": "Custom Name",
+              "displayGroup": "custom",
+              "name": "html",
+              "type": "html",
+            },
+          ],
         },
       ]
     }
@@ -48,6 +71,8 @@ exports[`<Content /> should render grouped properties 1`] = `
 exports[`<Content /> should render simple rows if not in beta 1`] = `
 <Wrapper
   dense={false}
+  groupName=""
+  htmlOnly={false}
 >
   <Rows
     properties={
@@ -63,6 +88,12 @@ exports[`<Content /> should render simple rows if not in beta 1`] = `
           "name": "test2",
         },
         Object {
+          "customDisplayGroupName": "Custom Name Ignored",
+          "displayGroup": "Group 1",
+          "name": "test3",
+          "type": "html",
+        },
+        Object {
           "displayGroup": "Group 2",
           "label": "Test 3",
           "name": "test3",
@@ -71,6 +102,12 @@ exports[`<Content /> should render simple rows if not in beta 1`] = `
           "displayGroup": "Group 2",
           "label": "Test 4",
           "name": "test4",
+        },
+        Object {
+          "customDisplayGroupName": "Custom Name",
+          "displayGroup": "custom",
+          "name": "html",
+          "type": "html",
         },
       ]
     }
@@ -81,6 +118,8 @@ exports[`<Content /> should render simple rows if not in beta 1`] = `
 exports[`<Content /> should render simple rows of no groups could be found 1`] = `
 <Wrapper
   dense={false}
+  groupName=""
+  htmlOnly={false}
 >
   <Rows
     properties={

--- a/libraries/engage/product/components/ProductProperties/__tests__/__snapshots__/GroupedProperties.spec.jsx.snap
+++ b/libraries/engage/product/components/ProductProperties/__tests__/__snapshots__/GroupedProperties.spec.jsx.snap
@@ -23,6 +23,8 @@ Array [
     >
       <Wrapper
         dense={true}
+        groupName="Group 1"
+        htmlOnly={false}
       >
         <Lists
           properties={
@@ -64,6 +66,8 @@ Array [
     >
       <Wrapper
         dense={true}
+        groupName="Group 2"
+        htmlOnly={false}
       >
         <Lists
           properties={

--- a/libraries/engage/product/components/ProductProperties/__tests__/__snapshots__/ProductProperties.spec.jsx.snap
+++ b/libraries/engage/product/components/ProductProperties/__tests__/__snapshots__/ProductProperties.spec.jsx.snap
@@ -190,9 +190,12 @@ exports[`<ProductProperties /> should render if properties are passed 1`] = `
         >
           <Wrapper
             dense={false}
+            groupName=""
+            htmlOnly={false}
           >
             <div
-              className="css-1x8awm9"
+              className="engage__product__product-property-group css-1x8awm9"
+              data-group-name=""
             >
               <table>
                 <thead />
@@ -208,9 +211,11 @@ exports[`<ProductProperties /> should render if properties are passed 1`] = `
                   >
                     <Row
                       key="undefined-undefined"
+                      type={null}
                     >
                       <tr
-                        key="undefinedundefined"
+                        className="engage__product__product-property"
+                        data-type={null}
                       >
                         <td
                           className={

--- a/libraries/engage/product/components/ProductProperties/__tests__/__snapshots__/Row.spec.jsx.snap
+++ b/libraries/engage/product/components/ProductProperties/__tests__/__snapshots__/Row.spec.jsx.snap
@@ -3,10 +3,13 @@
 exports[`<Row /> should render as expected 1`] = `
 <Row
   label="TestLabel"
+  type={null}
   value="TestValue"
 >
   <tr
-    key="TestLabelTestValue"
+    className="engage__product__product-property"
+    data-label="TestLabel"
+    data-type={null}
   >
     <td
       className={

--- a/libraries/engage/product/components/ProductProperties/__tests__/__snapshots__/Rows.spec.jsx.snap
+++ b/libraries/engage/product/components/ProductProperties/__tests__/__snapshots__/Rows.spec.jsx.snap
@@ -5,16 +5,19 @@ Array [
   <Row
     key="test1-123"
     label="test1"
+    type={null}
     value="123"
   />,
   <Row
     key="test2-456"
     label="test2"
+    type={null}
     value="456"
   />,
   <Row
     key="test3-789"
     label="test3"
+    type={null}
     value="789"
   />,
 ]

--- a/libraries/engage/product/components/ProductProperties/__tests__/helpers/getGroupsFromProperties.spec.js
+++ b/libraries/engage/product/components/ProductProperties/__tests__/helpers/getGroupsFromProperties.spec.js
@@ -35,7 +35,71 @@ describe('engage > product > ProductProperties', () => {
         },
       ]);
       expect(result.length).toBe(1);
-      expect(result).toEqual(['TestGroup']);
+      expect(result).toEqual([
+        {
+          key: 'TestGroup',
+          label: null,
+          properties: [
+            {
+              label: 'test1',
+              value: 'Test 1',
+              displayGroup: 'TestGroup',
+            },
+            {
+              label: 'test2',
+              value: 'Test 2',
+              displayGroup: 'TestGroup',
+            },
+          ],
+          htmlOnly: false,
+        },
+      ]);
+    });
+
+    it('should return an array including 2 groups with one which has displayGroup "custom"', () => {
+      const result = getGroupsFromProperties([
+        {
+          label: 'test1',
+          value: 'Test 1',
+          displayGroup: 'TestGroup',
+        },
+        {
+          label: 'test2',
+          value: 'Test 2',
+          type: 'html',
+          displayGroup: 'custom',
+          customDisplayGroupName: 'Custom Name',
+        },
+      ]);
+      expect(result.length).toBe(2);
+      expect(result).toEqual([
+        {
+          key: 'TestGroup',
+          label: null,
+          properties: [
+            {
+              label: 'test1',
+              value: 'Test 1',
+              displayGroup: 'TestGroup',
+            },
+          ],
+          htmlOnly: false,
+        },
+        {
+          key: 'custom-Custom Name',
+          label: 'Custom Name',
+          properties: [
+            {
+              label: 'test2',
+              value: 'Test 2',
+              type: 'html',
+              displayGroup: 'custom',
+              customDisplayGroupName: 'Custom Name',
+            },
+          ],
+          htmlOnly: true,
+        },
+      ]);
     });
   });
 });

--- a/libraries/engage/product/components/ProductProperties/helpers/getGroupsFromProperties.js
+++ b/libraries/engage/product/components/ProductProperties/helpers/getGroupsFromProperties.js
@@ -11,10 +11,43 @@ export function getGroupsFromProperties(properties = null) {
   }
 
   properties.forEach((property) => {
-    if (property.displayGroup && !groups.includes(property.displayGroup)) {
-      groups.push(property.displayGroup);
+    if (!property.displayGroup) {
+      // Do not proceed when not displayGroup is available
+      return;
     }
+
+    let key = property.displayGroup;
+    let label = null;
+
+    if (property.displayGroup === 'custom') {
+      key = `${property.displayGroup}-${property.customDisplayGroupName}`;
+
+      if (property.customDisplayGroupName) {
+        label = property.customDisplayGroupName;
+      }
+    }
+
+    // Check if the groups array already contains a group with the key
+    let existingGroup = groups.find(group => group.key === key);
+
+    if (!existingGroup) {
+      // Add a new group storage when there isn't one already
+      existingGroup = {
+        key,
+        label,
+        properties: [],
+      };
+
+      groups.push(existingGroup);
+    }
+
+    // Add current property to the storage
+    existingGroup.properties.push(property);
   });
 
-  return groups;
+  return groups.map(group => ({
+    ...group,
+    // Check if the current group just contains html properties to allow special handling
+    htmlOnly: group.properties.length ? group.properties.every(({ type }) => type === 'html') : false,
+  }));
 }

--- a/libraries/ui-material/Accordion/__snapshots__/spec.jsx.snap
+++ b/libraries/ui-material/Accordion/__snapshots__/spec.jsx.snap
@@ -46,7 +46,7 @@ exports[`<Accordion /> should render with renderLabel prop and children 1`] = `
       aria-controls="Some-Thing-content"
       aria-expanded={false}
       aria-label={null}
-      className="css-1m4mdin"
+      className="ui-material__accordion-title css-1m4mdin"
       data-test-id="Some Thing"
       key="accordion-toggle"
       onClick={[Function]}
@@ -101,11 +101,7 @@ exports[`<Accordion /> should render with renderLabel prop and children 1`] = `
     >
       <ForwardRef
         aria-hidden={true}
-        className={
-          Object {
-            "data-css-apm51k": "",
-          }
-        }
+        className="ui-material__accordion-content css-apm51k"
         id="Some-Thing-content"
         style={
           Object {
@@ -115,11 +111,7 @@ exports[`<Accordion /> should render with renderLabel prop and children 1`] = `
       >
         <div
           aria-hidden={true}
-          className={
-            Object {
-              "data-css-apm51k": "",
-            }
-          }
+          className="ui-material__accordion-content css-apm51k"
           id="Some-Thing-content"
           style={
             Object {

--- a/libraries/ui-material/Accordion/components/AccordionContent/__snapshots__/spec.jsx.snap
+++ b/libraries/ui-material/Accordion/components/AccordionContent/__snapshots__/spec.jsx.snap
@@ -8,11 +8,7 @@ exports[`<AccordionContent /> should render as closed 1`] = `
 >
   <ForwardRef
     aria-hidden={true}
-    className={
-      Object {
-        "data-css-apm51k": "",
-      }
-    }
+    className="ui-material__accordion-content css-apm51k"
     id="some-id"
     style={
       Object {
@@ -22,11 +18,7 @@ exports[`<AccordionContent /> should render as closed 1`] = `
   >
     <div
       aria-hidden={true}
-      className={
-        Object {
-          "data-css-apm51k": "",
-        }
-      }
+      className="ui-material__accordion-content css-apm51k"
       id="some-id"
       style={
         Object {
@@ -58,11 +50,7 @@ exports[`<AccordionContent /> should render as open 1`] = `
 >
   <ForwardRef
     aria-hidden={false}
-    className={
-      Object {
-        "data-css-apm51k": "",
-      }
-    }
+    className="ui-material__accordion-content css-apm51k"
     id="some-id"
     style={
       Object {
@@ -72,11 +60,7 @@ exports[`<AccordionContent /> should render as open 1`] = `
   >
     <div
       aria-hidden={false}
-      className={
-        Object {
-          "data-css-apm51k": "",
-        }
-      }
+      className="ui-material__accordion-content css-apm51k"
       id="some-id"
       style={
         Object {

--- a/libraries/ui-material/Accordion/components/AccordionContent/index.jsx
+++ b/libraries/ui-material/Accordion/components/AccordionContent/index.jsx
@@ -42,7 +42,7 @@ function AccordionContent(props: Props) {
   });
 
   return (
-    <animated.div className={styles.content} style={expand} id={id} aria-hidden={!open}>
+    <animated.div className={classnames('ui-material__accordion-content', styles.content)} style={expand} id={id} aria-hidden={!open}>
       <div ref={ref}>
         <div className={classnames(styles.contentInner, className)}>
           {children}

--- a/libraries/ui-material/Accordion/components/AccordionContent/style.js
+++ b/libraries/ui-material/Accordion/components/AccordionContent/style.js
@@ -3,7 +3,7 @@ import { css } from 'glamor';
 export const content = css({
   overflow: 'hidden',
   willChange: 'height',
-});
+}).toString();
 
 export const contentInner = css({
   padding: '0 16px 16px',

--- a/libraries/ui-material/Accordion/index.jsx
+++ b/libraries/ui-material/Accordion/index.jsx
@@ -58,6 +58,7 @@ function Accordion(props: Props) {
             <div
               {... (openWithChevron ? {} : clickHandlers)}
               className={classnames(
+                'ui-material__accordion-title',
                 className,
                 chevronPosition === 'right'
                   ? styles.toggle.toString()


### PR DESCRIPTION
# Description

This ticket is about to add support for new product property type "html". This property enables to present complete custom HTML blocks within the properties section of the product details page.

Additionally it adds support for the new "custom" display group type of product properties.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

