### PR TITLE
Fixed scroll position persistence at back navigation

### DIFF
--- a/libraries/engage/components/View/components/Content/index.jsx
+++ b/libraries/engage/components/View/components/Content/index.jsx
@@ -93,7 +93,7 @@ class ViewContent extends Component {
     if (this.ref.current === window) {
       scrollTop = window.scrollY;
     } else {
-      (scrollTop = this.ref.current);
+      ({ scrollTop } = this.ref.current);
     }
 
     router.update(this.context.id, {


### PR DESCRIPTION
# Description

This ticket fixes a bug that caused scrolling to top of a page after back navigation. 

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

- open a CMS page with e.g. products
- scroll down to a product and open it
- navigate back

You should see the product list at the position where you left the page.
