### PR TITLE
CURB-3543 Improvements for fashion theme

### DIFF
--- a/libraries/engage/components/constants.js
+++ b/libraries/engage/components/constants.js
@@ -2,3 +2,4 @@ export const PORTAL_PRODUCT_IMAGE = 'component.product-image';
 export const PORTAL_PRODUCT_MEDIA = 'component.product-media';
 export const PORTAL_PRODUCT_MEDIA_SECTION = 'component.product-media-section';
 export const PORTAL_PRODUCT_BADGES = 'component.product-badges';
+export const PORTAL_PRODUCT_IMAGE_SLIDER = 'component.product-image-slider';

--- a/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -29,8 +29,8 @@ const ProductInfo = ({ productId, options }) => (
   <Fragment>
     <Portal name={PRODUCT_INFO_BEFORE} />
     <Portal name={PRODUCT_INFO}>
-      <Grid component="div">
-        <Grid.Item component="div" grow={1}>
+      <Grid component="div" className="theme__product__header__product-info">
+        <Grid.Item component="div" grow={1} className="theme__product__header__product-info__row1">
           <Portal name={PRODUCT_INFO_ROW1}>
             <div className={styles.productInfo}>
               {/* This feature is currently in BETA testing.
@@ -60,7 +60,7 @@ const ProductInfo = ({ productId, options }) => (
             </div>
           </Portal>
         </Grid.Item>
-        <Grid.Item component="div" className={styles.priceContainer}>
+        <Grid.Item component="div" className={`${styles.priceContainer} theme__product__header__product-info__row2`}>
           <Portal name={PRODUCT_INFO_ROW2}>
             <div>
               <PriceStriked productId={productId} options={options} />

--- a/themes/theme-gmd/pages/Product/components/Header/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/index.jsx
@@ -24,7 +24,7 @@ class ProductHeader extends PureComponent {
     const id = variantId || productId;
 
     return (
-      <div className={styles.content}>
+      <div className={`${styles.content} theme__product__header`}>
         <CTAButtons productId={id} />
         <Section title="product.sections.information">
           <Rating productId={productId} />

--- a/themes/theme-gmd/pages/Product/components/Media/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/index.jsx
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import { isBeta } from '@shopgate/engage/core';
 import { SurroundPortals } from '@shopgate/engage/components';
-import { PORTAL_PRODUCT_MEDIA_SECTION } from '@shopgate/engage/components/constants';
+import {
+  PORTAL_PRODUCT_MEDIA_SECTION,
+  PORTAL_PRODUCT_IMAGE_SLIDER,
+} from '@shopgate/engage/components/constants';
 import { ProductContext } from '@shopgate/engage/product';
 import ProductDiscountBadge from '@shopgate/engage/product/components/ProductDiscountBadge';
 import ProductImageSlider from './components/ProductImageSlider';
@@ -31,25 +34,32 @@ const Media = ({ 'aria-hidden': ariaHidden, className }) => (
       >
         <div className={styles.root}>
           <ProductDiscountBadge productId={productId} />
-
-          {/* MediaSlider feature is currently in BETA testing.
+          <SurroundPortals
+            portalName={PORTAL_PRODUCT_IMAGE_SLIDER}
+            portalProps={{
+              productId,
+              variantId,
+            }}
+          >
+            {/* MediaSlider feature is currently in BETA testing.
               It should only be used for approved BETA Client Projects */}
-          {isBeta() ? (
-            <ProductMediaSlider
-              productId={productId}
-              variantId={variantId}
-              characteristics={characteristics}
-              aria-hidden={ariaHidden}
-              className={className}
-            />
-          ) : (
-            <ProductImageSlider
-              productId={productId}
-              variantId={variantId}
-              aria-hidden={ariaHidden}
-              className={className}
-            />
-          )}
+            {isBeta() ? (
+              <ProductMediaSlider
+                productId={productId}
+                variantId={variantId}
+                characteristics={characteristics}
+                aria-hidden={ariaHidden}
+                className={className}
+              />
+            ) : (
+              <ProductImageSlider
+                productId={productId}
+                variantId={variantId}
+                aria-hidden={ariaHidden}
+                className={className}
+              />
+            )}
+          </SurroundPortals>
         </div>
       </SurroundPortals>
     )}

--- a/themes/theme-ios11/pages/Product/components/Header/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/index.jsx
@@ -5,6 +5,7 @@ import {
   PRODUCT_HEADER_AFTER,
   PRODUCT_HEADER_BEFORE,
 } from '@shopgate/pwa-common-commerce/product/constants/Portals';
+import { Section } from '@shopgate/engage/a11y';
 import { ProductContext, Rating } from '@shopgate/engage/product';
 import CTAButtons from './components/CTAButtons';
 import Name from './components/Name';
@@ -25,9 +26,11 @@ class ProductHeader extends PureComponent {
     return (
       <div className={`${styles.content} theme__product__header`}>
         <CTAButtons productId={id} />
-        <Rating productId={productId} />
-        <Name productId={id} />
-        <ProductInfo productId={id} options={options} />
+        <Section title="product.sections.information">
+          <Rating productId={productId} />
+          <Name productId={id} />
+          <ProductInfo productId={id} options={options} />
+        </Section>
       </div>
     );
   }

--- a/themes/theme-ios11/pages/Product/components/Media/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/index.jsx
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import { isBeta } from '@shopgate/engage/core';
 import { SurroundPortals } from '@shopgate/engage/components';
-import { PORTAL_PRODUCT_MEDIA_SECTION } from '@shopgate/engage/components/constants';
+import {
+  PORTAL_PRODUCT_MEDIA_SECTION,
+  PORTAL_PRODUCT_IMAGE_SLIDER,
+} from '@shopgate/engage/components/constants';
 import { ProductContext } from '@shopgate/engage/product';
 import ProductDiscountBadge from '@shopgate/engage/product/components/ProductDiscountBadge';
 import ProductImageSlider from './components/ProductImageSlider';
@@ -32,24 +35,32 @@ const Media = ({ 'aria-hidden': ariaHidden, className }) => (
         <div className={styles.root}>
           <ProductDiscountBadge productId={productId} />
 
-          {/* MediaSlider feature is currently in BETA testing.
+          <SurroundPortals
+            portalName={PORTAL_PRODUCT_IMAGE_SLIDER}
+            portalProps={{
+              productId,
+              variantId,
+            }}
+          >
+            {/* MediaSlider feature is currently in BETA testing.
               It should only be used for approved BETA Client Projects */}
-          {isBeta() ? (
-            <ProductMediaSlider
-              productId={productId}
-              variantId={variantId}
-              characteristics={characteristics}
-              aria-hidden={ariaHidden}
-              className={className}
-            />
-          ) : (
-            <ProductImageSlider
-              productId={productId}
-              variantId={variantId}
-              aria-hidden={ariaHidden}
-              className={className}
-            />
-          )}
+            {isBeta() ? (
+              <ProductMediaSlider
+                productId={productId}
+                variantId={variantId}
+                characteristics={characteristics}
+                aria-hidden={ariaHidden}
+                className={className}
+              />
+            ) : (
+              <ProductImageSlider
+                productId={productId}
+                variantId={variantId}
+                aria-hidden={ariaHidden}
+                className={className}
+              />
+            )}
+          </SurroundPortals>
         </div>
       </SurroundPortals>
     )}


### PR DESCRIPTION
# Description
This pull request contains some core changes that supports usage of the fashion theme extensions.
It adds a new portal around the PDP sliders that can be used by extensions to manipulated props of the sliders. Additionally it adds some classes to the gmd theme which only existed on the ios theme.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
