### PR TITLE
Added new theme setting to configure whether new wishlist items are supposed to be added on top of the list

### DIFF
--- a/libraries/commerce/favorites/reducers/products.js
+++ b/libraries/commerce/favorites/reducers/products.js
@@ -1,6 +1,7 @@
 import { produce } from 'immer';
 import isNumber from 'lodash/isNumber';
 import isString from 'lodash/isString';
+import appConfig from '@shopgate/pwa-common/helpers/config';
 import {
   REQUEST_ADD_FAVORITES,
   SUCCESS_ADD_FAVORITES,
@@ -20,6 +21,8 @@ import {
   ERROR_UPDATE_FAVORITES,
   RECEIVE_FAVORITES_LISTS,
 } from '../constants';
+
+const { addNewFavoritesOnTop = false } = appConfig;
 
 /**
  * Favorites reducer.
@@ -98,11 +101,17 @@ const products = (state = {
           matchingItem.notes = typeof action.notes === 'string' ? action.notes : matchingItem.notes;
           matchingItem.quantity = typeof action.quantity === 'number' ? matchingItem.quantity + action.quantity : matchingItem.quantity + 1;
         } else {
-          list.items.push({
+          const newEntry = {
             notes: action.notes || '',
             quantity: action.quantity || 1,
             productId: action.productId,
-          });
+          };
+
+          if (addNewFavoritesOnTop) {
+            list.items.unshift(newEntry);
+          } else {
+            list.items.push(newEntry);
+          }
         }
         list.lastChange = Date.now();
         list.syncCount += 1;
@@ -165,11 +174,18 @@ const products = (state = {
       // Handle deletion failure by adding the product back in to the list.
       case ERROR_REMOVE_FAVORITES: {
         const list = draft.byList[action.listId];
-        list.items.push({
+        const newEntry = {
           productId: action.productId,
           quantity: action.quantity || 1,
           notes: action.notes || '',
-        });
+        };
+
+        if (addNewFavoritesOnTop) {
+          list.items.unshift(newEntry);
+        } else {
+          list.items.push(newEntry);
+        }
+
         list.lastChange = Date.now();
         list.syncCount -= 1;
         break;

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -518,6 +518,15 @@
         "label": "Favorites settings: limits, etc"
       }
     },
+    "addNewFavoritesOnTop": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "json",
+        "label": "Whether to add new favorites on top of the list, instead at the bottom."
+      }
+    },
     "hideProductImageShadow": {
       "type": "admin",
       "destination": "frontend",

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -521,6 +521,15 @@
         "label": "Favorites settings: limits, etc"
       }
     },
+    "addNewFavoritesOnTop": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "json",
+        "label": "Whether to add new favorites on top of the list, instead at the bottom."
+      }
+    },
     "hideProductImageShadow": {
       "type": "admin",
       "destination": "frontend",


### PR DESCRIPTION
# Description
This pull request introduces a new theme setting (`addNewFavoritesOnTop`) which allows to configure, if new wishlist items supposed to be added to the top of the list, instead of the bottom (default).

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
