### PR TITLE
Added new theme setting to configure whether new wishlist items are supposed to be added on top of the list

### DIFF
--- a/libraries/commerce/favorites/reducers/products.js
+++ b/libraries/commerce/favorites/reducers/products.js
@@ -1,4 +1,5 @@
 import { uniq } from 'lodash';
+import appConfig from '@shopgate/pwa-common/helpers/config';
 import {
   REQUEST_ADD_FAVORITES,
   SUCCESS_ADD_FAVORITES,
@@ -18,6 +19,8 @@ import {
   ERROR_FAVORITES_IDS,
   FLUSH_FAVORITES,
 } from '../constants';
+
+const { addNewFavoritesOnTop = false } = appConfig;
 
 const defaultState = {
   byList: {},
@@ -143,8 +146,9 @@ const products = (state = defaultState, action) => {
           [action.listId]: {
             ...list,
             ids: uniq([
+              ...(addNewFavoritesOnTop ? [action.productId] : []),
               ...list.ids,
-              action.productId,
+              ...(addNewFavoritesOnTop ? [] : [action.productId]),
             ]),
             lastChange: Date.now(),
             syncCount: list.syncCount + 1,
@@ -213,7 +217,11 @@ const products = (state = defaultState, action) => {
           ...state.byList,
           [action.listId]: {
             ...list,
-            ids: uniq([...state.ids, action.productId]),
+            ids: uniq([
+              ...(addNewFavoritesOnTop ? [action.productId] : []),
+              ...state.ids,
+              ...(addNewFavoritesOnTop ? [] : [action.productId]),
+            ]),
             lastChange: Date.now(),
             syncCount: list.syncCount - 1,
           },

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -557,6 +557,15 @@
         "label": "Favorites Settings"
       }
     },
+    "addNewFavoritesOnTop": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "json",
+        "label": "Whether to add new favorites on top of the list, instead at the bottom."
+      }
+    },
     "appRating": {
       "type": "admin",
       "destination": "frontend",

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -567,6 +567,15 @@
         "label": "Favorites Settings"
       }
     },
+    "addNewFavoritesOnTop": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "json",
+        "label": "Whether to add new favorites on top of the list, instead at the bottom."
+      }
+    },
     "appRating": {
       "type": "admin",
       "destination": "frontend",


### PR DESCRIPTION
# Description

This pull request introduces a new theme setting (`addNewFavoritesOnTop`) which allows to configure, if new wishlist items supposed to be added to the top of the list, instead of the bottom (default).

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
