### PR TITLE
Fixed product inventory fetching for productId list based widgets

### DIFF
--- a/libraries/commerce/product/actions/fetchProductsByQuery.js
+++ b/libraries/commerce/product/actions/fetchProductsByQuery.js
@@ -16,7 +16,7 @@ const fetchProductsByQuery = (type, value, options = {}, id = null) => (dispatch
    * and not supposed to be used for the actual products request.
    */
   const {
-    useProductHashForProductIds = false,
+    useDefaultRequestForProductIds = false,
     ...sanitizedOptions
   } = options;
 
@@ -56,13 +56,13 @@ const fetchProductsByQuery = (type, value, options = {}, id = null) => (dispatch
        * just request the products that are not available in Redux yet.
        * This can cause update issues in the UI, since selectors might not return fresh data when
        * Redux changes.
-       * So when the "useProductHashForProductIds" flag is active, the regular request system is
+       * So when the "useDefaultRequestForProductIds" flag is active, the regular request system is
        * used and whenever the fetch params change, new product data fill be fetched.
        *
        * ATTENTION: To make the system work completely, also the "getProductsResult" selector helper
        * needs to be called with this parameter.
        */
-      if (useProductHashForProductIds) {
+      if (useDefaultRequestForProductIds) {
         const params = {
           productIds: value,
           ...sanitizedOptions,

--- a/libraries/commerce/product/actions/fetchProductsByQuery.js
+++ b/libraries/commerce/product/actions/fetchProductsByQuery.js
@@ -11,11 +11,20 @@ import fetchProductsById from './fetchProductsById';
  * @return {Function} A Redux Thunk
  */
 const fetchProductsByQuery = (type, value, options = {}, id = null) => (dispatch) => {
+  /**
+   * Remove all properties from the options which are just intended to be used inside this function
+   * and not supposed to be used for the actual products request.
+   */
+  const {
+    useProductHashForProductIds = false,
+    ...sanitizedOptions
+  } = options;
+
   switch (type) {
     // Product highlights
     case 1: {
       const params = {
-        ...options,
+        ...sanitizedOptions,
       };
 
       dispatch(fetchHighlightProducts({
@@ -30,7 +39,7 @@ const fetchProductsByQuery = (type, value, options = {}, id = null) => (dispatch
     case 3: {
       const params = {
         searchPhrase: value,
-        ...options,
+        ...sanitizedOptions,
       };
 
       return dispatch(fetchProducts({
@@ -42,7 +51,36 @@ const fetchProductsByQuery = (type, value, options = {}, id = null) => (dispatch
 
     // Product ID's
     case 4: {
-      dispatch(fetchProductsById(value, id));
+      /**
+       * By default the productIds query type bypasses the regular product request logic. It will
+       * just request the products that are not available in Redux yet.
+       * This can cause update issues in the UI, since selectors might not return fresh data when
+       * Redux changes.
+       * So when the "useProductHashForProductIds" flag is active, the regular request system is
+       * used and whenever the fetch params change, new product data fill be fetched.
+       *
+       * ATTENTION: To make the system work completely, also the "getProductsResult" selector helper
+       * needs to be called with this parameter.
+       */
+      if (useProductHashForProductIds) {
+        const params = {
+          productIds: value,
+          ...sanitizedOptions,
+        };
+
+        // Limit and offset are not fully supported for product requests with productId list
+        delete params.limit;
+        delete params.offset;
+
+        dispatch(fetchProducts({
+          params,
+          ...id && { id },
+          includeFilters: false,
+        }));
+      } else {
+        dispatch(fetchProductsById(value, id));
+      }
+
       break;
     }
 
@@ -50,7 +88,7 @@ const fetchProductsByQuery = (type, value, options = {}, id = null) => (dispatch
     case 5: {
       const params = {
         categoryId: value,
-        ...options,
+        ...sanitizedOptions,
       };
 
       return dispatch(fetchProducts({

--- a/libraries/engage/locations/helpers/index.js
+++ b/libraries/engage/locations/helpers/index.js
@@ -2,3 +2,4 @@
 export { default as createOrder } from './createOrder';
 export { default as getAvailabilitySettings } from './getAvailabilitySettings';
 export { isProductAvailable } from './productInventory';
+export * from './showInventoryInLists';

--- a/themes/theme-gmd/widgets/Products/connector.js
+++ b/themes/theme-gmd/widgets/Products/connector.js
@@ -27,7 +27,7 @@ const mapStateToProps = (state, props) => {
        * works as expected.
        */
       ...(hasInventoryInLists ? {
-        useProductHashForProductIds: true,
+        useDefaultRequestForProductIds: true,
       } : null),
     },
     props.id,
@@ -56,7 +56,7 @@ const mapDispatchToProps = dispatch => ({
            * request and select data like the other widget types so that inventory data fetching
            * works as expected.
            */
-          useProductHashForProductIds: true,
+          useDefaultRequestForProductIds: true,
         } : null),
       }, id));
     });

--- a/themes/theme-gmd/widgets/selectors.js
+++ b/themes/theme-gmd/widgets/selectors.js
@@ -157,11 +157,11 @@ export const getProductsResult = (state, type, params, id) => {
    * just request the products that are not available in Redux yet.
    * This can cause update issues in the UI, since selectors might not return fresh data when
    * Redux changes.
-   * So when the "useProductHashForProductIds" flag is active, the regular request system is
+   * So when the "useDefaultRequestForProductIds" flag is active, the regular request system is
    * used and whenever the fetch params change, new product data fill be fetched. Additionally
    * the default selector logic needs to be used which selects all data from the regular request.
    */
-  if (type === 4 && !params?.useProductHashForProductIds) {
+  if (type === 4 && !params?.useDefaultRequestForProductIds) {
     return getProductsResultsWithIds(state, type, params, id);
   }
 

--- a/themes/theme-gmd/widgets/selectors.js
+++ b/themes/theme-gmd/widgets/selectors.js
@@ -136,7 +136,6 @@ export const getProductsResultsWithIds = (state, type, params, id) => {
   if (transformedSort === SORT_PRICE_DESC) {
     products = products.sort((p1, p2) => p2.price.unitPrice - p1.price.unitPrice);
   }
-
   return {
     products,
     totalProductCount: products.length,
@@ -153,7 +152,16 @@ export const getProductsResultsWithIds = (state, type, params, id) => {
  * @return {Object} The product result.
  */
 export const getProductsResult = (state, type, params, id) => {
-  if (type === 4) {
+  /**
+   * By default the productIds query type bypasses the regular product request logic. It will
+   * just request the products that are not available in Redux yet.
+   * This can cause update issues in the UI, since selectors might not return fresh data when
+   * Redux changes.
+   * So when the "useProductHashForProductIds" flag is active, the regular request system is
+   * used and whenever the fetch params change, new product data fill be fetched. Additionally
+   * the default selector logic needs to be used which selects all data from the regular request.
+   */
+  if (type === 4 && !params?.useProductHashForProductIds) {
     return getProductsResultsWithIds(state, type, params, id);
   }
 

--- a/themes/theme-ios11/widgets/Products/connector.js
+++ b/themes/theme-ios11/widgets/Products/connector.js
@@ -27,7 +27,7 @@ const mapStateToProps = (state, props) => {
        * works as expected.
        */
       ...(hasInventoryInLists ? {
-        useProductHashForProductIds: true,
+        useDefaultRequestForProductIds: true,
       } : null),
     },
     props.id,
@@ -56,7 +56,7 @@ const mapDispatchToProps = dispatch => ({
            * request and select data like the other widget types so that inventory data fetching
            * works as expected.
            */
-          useProductHashForProductIds: true,
+          useDefaultRequestForProductIds: true,
         } : null),
       }, id));
     });

--- a/themes/theme-ios11/widgets/selectors.js
+++ b/themes/theme-ios11/widgets/selectors.js
@@ -152,7 +152,16 @@ export const getProductsResultsWithIds = (state, type, params, id) => {
  * @return {Object} The product result.
  */
 export const getProductsResult = (state, type, params, id) => {
-  if (type === 4) {
+  /**
+   * By default the productIds query type bypasses the regular product request logic. It will
+   * just request the products that are not available in Redux yet.
+   * This can cause update issues in the UI, since selectors might not return fresh data when
+   * Redux changes.
+   * So when the "useProductHashForProductIds" flag is active, the regular request system is
+   * used and whenever the fetch params change, new product data fill be fetched. Additionally
+   * the default selector logic needs to be used which selects all data from the regular request.
+   */
+  if (type === 4 && !params?.useProductHashForProductIds) {
     return getProductsResultsWithIds(state, type, params, id);
   }
 

--- a/themes/theme-ios11/widgets/selectors.js
+++ b/themes/theme-ios11/widgets/selectors.js
@@ -157,11 +157,11 @@ export const getProductsResult = (state, type, params, id) => {
    * just request the products that are not available in Redux yet.
    * This can cause update issues in the UI, since selectors might not return fresh data when
    * Redux changes.
-   * So when the "useProductHashForProductIds" flag is active, the regular request system is
+   * So when the "useDefaultRequestForProductIds" flag is active, the regular request system is
    * used and whenever the fetch params change, new product data fill be fetched. Additionally
    * the default selector logic needs to be used which selects all data from the regular request.
    */
-  if (type === 4 && !params?.useProductHashForProductIds) {
+  if (type === 4 && !params?.useDefaultRequestForProductIds) {
     return getProductsResultsWithIds(state, type, params, id);
   }
 


### PR DESCRIPTION
# Description
By default widgets that are based on productId lists only fetch fresh products that are not stored in Redux already. Since fetching of fresh inventory happens after product fetching and only fetches the inventory for the products from the product request, inventory is not always updated properly at widgets based on productIds.

This pull request introduces a new parameter for product widget related request actions and selectors (`useProductHashForProductIds`) to activate the default request system for productId based widgets. This parameter is now set to `true` at product widgets when the `showInventoryInLists` feature is active.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
