### PR TITLE
Implemented push opt-in app feature detection

### DIFF
--- a/libraries/engage/back-in-stock/selectors/index.js
+++ b/libraries/engage/back-in-stock/selectors/index.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import { makeGetProductByCharacteristics } from '@shopgate/engage/product';
+import { appSupportsPushOptIn } from '@shopgate/engage/core/helpers';
 import { appConfig } from '@shopgate/engage';
 import { getClientInformation, isIos as getIsIos } from '@shopgate/engage/core';
 import {
@@ -109,6 +110,11 @@ export const getIsBackInStockEnabled = createSelector(
   getIsIos,
   getBackInStockPushPermissionStatus,
   (clientInformation, isIos, pushPermissionStatus) => {
+    if (!appSupportsPushOptIn()) {
+      // Disabled when the app doesn't support the required features
+      return false;
+    }
+
     const isRNEngage = navigator.userAgent.includes('RN Engage');
 
     /**

--- a/libraries/engage/core/constants/appFeatures.js
+++ b/libraries/engage/core/constants/appFeatures.js
@@ -1,0 +1,1 @@
+export const APP_FEATURE_PUSH_OPT_IN = 'optIn';

--- a/libraries/engage/core/constants/index.js
+++ b/libraries/engage/core/constants/index.js
@@ -1,6 +1,7 @@
 import { INDEX_PATH, INDEX_PATH_DEEPLINK } from '@shopgate/pwa-common/constants/RoutePaths';
 
 export * from './actionTypes';
+export * from './appFeatures';
 export * from './geolocationRequest';
 
 // Core Constants

--- a/libraries/engage/core/helpers/__tests__/appFeatures.spec.js
+++ b/libraries/engage/core/helpers/__tests__/appFeatures.spec.js
@@ -1,0 +1,72 @@
+import { hasSGJavaScriptBridge } from '@shopgate/pwa-core/helpers';
+import { APP_FEATURE_PUSH_OPT_IN } from '@shopgate/engage/core/constants';
+import { appSupportsPushOptIn } from '../appFeatures';
+
+jest.mock('@shopgate/pwa-core/helpers', () => ({
+  hasSGJavaScriptBridge: jest.fn().mockReturnValue(true),
+}));
+
+describe('App Features', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('appSupportsPushOptIn()', () => {
+    /**
+     * Creates a mocked SGAppInfo object
+     * @param {Object} value The value for the object
+     */
+    const createAppInfo = (value) => {
+      Object.defineProperty(window, 'SGAppInfo', value);
+    };
+
+    beforeEach(() => {
+
+    });
+
+    it('should return true in development', () => {
+      hasSGJavaScriptBridge.mockReturnValueOnce(false);
+
+      expect(appSupportsPushOptIn()).toBe(true);
+    });
+
+    it('should return false when SGAppInfo object does not exist', () => {
+      expect(appSupportsPushOptIn()).toBe(false);
+    });
+
+    it('should return false when SGAppInfo object does contain feature flags', () => {
+      createAppInfo({
+        moduleInfo: {
+          Push: [1],
+        },
+      });
+      expect(appSupportsPushOptIn()).toBe(false);
+    });
+
+    it('should return false when the push feature flags do not contain the optIn flag', () => {
+      createAppInfo({
+        featureFlags: {
+          Push: {
+            1: {
+              flags: [],
+            },
+          },
+        },
+      });
+      expect(appSupportsPushOptIn()).toBe(false);
+    });
+
+    it('should return true when the push feature flags contain the optIn flag', () => {
+      createAppInfo({
+        featureFlags: {
+          Push: {
+            1: {
+              flags: [APP_FEATURE_PUSH_OPT_IN],
+            },
+          },
+        },
+      });
+      expect(appSupportsPushOptIn()).toBe(false);
+    });
+  });
+});

--- a/libraries/engage/core/helpers/appFeatures.js
+++ b/libraries/engage/core/helpers/appFeatures.js
@@ -1,0 +1,21 @@
+import { APP_FEATURE_PUSH_OPT_IN } from '@shopgate/engage/core/constants';
+import { hasSGJavaScriptBridge } from '@shopgate/pwa-core/helpers';
+
+/**
+ * Determines if the app supports the push opt-in feature
+ * @returns {boolean}
+ */
+export const appSupportsPushOptIn = () => {
+  if (!hasSGJavaScriptBridge()) {
+    // Always supported in development
+    return true;
+  }
+
+  if (!Array.isArray(window?.SGAppInfo?.featureFlags?.Push?.['1']?.flags)) {
+    // Not supported on app versions that don't provide the featureFlags object
+    return false;
+  }
+
+  // Supported when the feature flags contain the push opt-in flag
+  return window.SGAppInfo.featureFlags.Push['1'].flags.includes(APP_FEATURE_PUSH_OPT_IN);
+};

--- a/libraries/engage/core/helpers/index.js
+++ b/libraries/engage/core/helpers/index.js
@@ -1,0 +1,5 @@
+export * from './appFeatures';
+export { getFullImageSource } from './getFullImageSource';
+export { getImageFormat } from './getImageFormat';
+export { i18n } from './i18n';
+export { updateLegacyNavigationBar } from './updateLegacyNavigationBar';

--- a/libraries/engage/push-opt-in/subscriptions/optInTrigger.js
+++ b/libraries/engage/push-opt-in/subscriptions/optInTrigger.js
@@ -7,6 +7,7 @@ import {
   appDidStart$,
   logger,
 } from '@shopgate/engage/core';
+import { appSupportsPushOptIn } from '@shopgate/engage/core/helpers';
 import {
   PERMISSION_ID_PUSH,
   PERMISSION_STATUS_NOT_DETERMINED,
@@ -45,6 +46,11 @@ export default function pushOptIn(subscribe) {
    * @returns {void}
    */
   const showOptInAfterChecks = async ({ dispatch, getState }, configKey, increaseCountAction) => {
+    if (!appSupportsPushOptIn()) {
+      // Do nothing when the app doesn't support the features needed for the push-opt-in
+      return;
+    }
+
     const {
       pushOptIn: {
         appStarts,
@@ -64,8 +70,6 @@ export default function pushOptIn(subscribe) {
       logger.error('PushOptInTrigger - Config invalid', appConfig?.pushOptIn);
       return;
     }
-
-    // TODO add check to determine if the app supports push-opt-in (is done in CURB-3915)
 
     const pushStatus = await dispatch(requestAppPermissionStatus({
       permissionId: PERMISSION_ID_PUSH,

--- a/libraries/engage/push-opt-in/subscriptions/optInTrigger.spec.js
+++ b/libraries/engage/push-opt-in/subscriptions/optInTrigger.spec.js
@@ -11,6 +11,7 @@ import {
   PERMISSION_STATUS_DENIED,
   APP_DID_START,
 } from '@shopgate/engage/core/constants';
+import { appSupportsPushOptIn } from '@shopgate/engage/core/helpers';
 import {
   increaseAppStartCount,
   setLastPopupTimestamp,
@@ -96,6 +97,10 @@ jest.mock('@shopgate/pwa-core/commands/appPermissions', () => {
     getAppPermissions: jest.fn().mockResolvedValue([{ status: PERMISSION_STATUS_NOT_DETERMINED }]),
   };
 });
+
+jest.mock('@shopgate/engage/core/helpers', () => ({
+  appSupportsPushOptIn: jest.fn().mockReturnValue(true),
+}));
 
 describe('Push OptIn Subscriptions', () => {
   const subscribe = jest.fn();
@@ -253,6 +258,14 @@ describe('Push OptIn Subscriptions', () => {
           await callback(callbackParams);
           expect(dispatch).toHaveBeenCalledTimes(9);
           expect(showPushOptInModal).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not trigger opt-in when the app does not support push opt-in', async () => {
+          appSupportsPushOptIn.mockReturnValueOnce(false);
+          await callback(callbackParams);
+
+          expect(dispatch).not.toBeCalled();
+          expect(showPushOptInModal).not.toHaveBeenCalled();
         });
 
         it('should not trigger opt-in again till "minDaysBetweenOptIns" elapsed', async () => {


### PR DESCRIPTION
# Description
This pull request introduces an app feature detection for the push opt-in feature. It adds a new helper function that can be used to check the current status.
```js
import { appSupportsPushOptIn } from '@shopgate/engage/core/helpers';

if (appSupportsPushOptIn()) {
  // do stuff
}
```

The check is now used to detect if the back-in-stock notifications feature and the push opt-in modal feature can be used.
Additionally the pull request changes the back-in-stock feature detection, so that it can also be used in test environments.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
