### PR TITLE
Removed Back-In-Stock button on notifications list for "triggered" notifications

### DIFF
--- a/libraries/engage/back-in-stock/components/Subscriptions/components/List/index.jsx
+++ b/libraries/engage/back-in-stock/components/Subscriptions/components/List/index.jsx
@@ -19,10 +19,6 @@ const styles = {
   }).toString(),
   emptyText: css({
     marginBottom: 16,
-    textAlign: 'center',
-  }).toString(),
-  listTitle: css({
-    fontWeight: '700',
   }).toString(),
 };
 
@@ -37,7 +33,7 @@ const List = () => {
   } = useBackInStockSubscriptions();
 
   const renderLabel = useCallback(groupKey =>
-    <div className={styles.listTitle}>
+    <div>
       {i18n.text(`back_in_stock.list_states.${groupKey}`)}
     </div>, []);
 

--- a/libraries/engage/back-in-stock/components/Subscriptions/components/Subscription/index.jsx
+++ b/libraries/engage/back-in-stock/components/Subscriptions/components/Subscription/index.jsx
@@ -94,10 +94,11 @@ const styles = {
 const Subscription = ({
   subscription,
 }) => {
-  const { subscriptionCode, product } = subscription;
+  const { subscriptionCode, product, productCode } = subscription;
   const {
     removeBackInStockSubscription,
   } = useBackInStockSubscriptions();
+
   const { ListImage: gridResolutions } = getThemeSettings('AppImages') || {};
   const currency = product.price?.currency || 'EUR';
   const defaultPrice = product.price?.unitPrice || 0;
@@ -157,10 +158,12 @@ const Subscription = ({
             showWhenAvailable={false}
             className={styles.availabilityText}
           />
-          <BackInStockButton
-            subscription={subscription}
-            onClick={() => {}}
-          />
+          {subscription?.status === 'active' && (
+            <BackInStockButton
+              subscription={subscription}
+              productId={productCode}
+            />
+          )}
         </div>
         <div className={styles.priceContainerRow}>
           {hasStrikePrice ? (

--- a/libraries/engage/core/actions/__tests__/getGeolocation.spec.js
+++ b/libraries/engage/core/actions/__tests__/getGeolocation.spec.js
@@ -21,7 +21,7 @@ jest.mock('../../classes/GeolocationRequest', () => class Foo {
   }
 });
 
-describe('engage > core > actions > grantCameraPermissions', () => {
+describe('engage > core > actions > getGeolocation', () => {
   const dispatch = jest.fn(action => action);
 
   beforeEach(() => {

--- a/themes/theme-gmd/pages/BackInStock/index.jsx
+++ b/themes/theme-gmd/pages/BackInStock/index.jsx
@@ -3,13 +3,16 @@ import React from 'react';
 import { i18n } from '@shopgate/engage/core';
 import { BackBar } from 'Components/AppBar/presets';
 import { BackInStockReminders } from '@shopgate/engage/back-in-stock/components';
+import { themeConfig } from '@shopgate/pwa-common/helpers/config';
+
+const { colors } = themeConfig;
 
 /**
  * The BackInStockPage component.
  * @returns {JSX}
  */
 const BackInStockPage = () => (
-  <View aria-hidden={false}>
+  <View aria-hidden={false} background={colors.background}>
     <BackBar title={i18n.text('titles.back_in_stock')} />
     <BackInStockReminders />
   </View>

--- a/themes/theme-gmd/pages/subscriptions.js
+++ b/themes/theme-gmd/pages/subscriptions.js
@@ -56,7 +56,7 @@ export default function app(subscribe) {
 
       const { params: { pathname } } = action;
 
-      dispatch(grantCameraPermissions())
+      dispatch(grantCameraPermissions({ useSettingsModal: true }))
         .then((granted) => {
           resolve(granted ? pathname : null);
         });

--- a/themes/theme-ios11/pages/BackInStock/index.jsx
+++ b/themes/theme-ios11/pages/BackInStock/index.jsx
@@ -3,13 +3,16 @@ import React from 'react';
 import { i18n } from '@shopgate/engage/core';
 import { BackBar } from 'Components/AppBar/presets';
 import { BackInStockReminders } from '@shopgate/engage/back-in-stock/components';
+import { themeConfig } from '@shopgate/pwa-common/helpers/config';
+
+const { colors } = themeConfig;
 
 /**
  * The BackInStockPage component.
  * @returns {JSX}
  */
 const BackInStockPage = () => (
-  <View aria-hidden={false}>
+  <View aria-hidden={false} background={colors.background}>
     <BackBar title={i18n.text('titles.back_in_stock')} />
     <BackInStockReminders />
   </View>

--- a/themes/theme-ios11/pages/subscriptions.js
+++ b/themes/theme-ios11/pages/subscriptions.js
@@ -54,7 +54,7 @@ export default function app(subscribe) {
 
       const { params: { pathname } } = action;
 
-      dispatch(grantCameraPermissions())
+      dispatch(grantCameraPermissions({ useSettingsModal: true }))
         .then((granted) => {
           resolve(granted ? pathname : null);
         });


### PR DESCRIPTION
# Description
This PR removes the BackInStockButton component from the notifications list for "triggered" notifications, since it doesn't make much sense to provide the option to subscribe for notifications from already triggered notifications.

Additionally it adjusts the styling of the notifications list to match the styling of the (multiple) favourites list.

As as side quest it reactivates the "Settings Modal" inside the scanner route redirect, so that users who want to open the scanner without sufficient camera permissions are informed that they can change the permissions inside the app settings. 

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
