### PR TITLE
Change back-in-stock subscription link to button

### DIFF
--- a/libraries/engage/back-in-stock/components/BackInStockButton/index.jsx
+++ b/libraries/engage/back-in-stock/components/BackInStockButton/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { themeConfig } from '@shopgate/engage';
 import {
-  Link, CheckedIcon, Button,
+  Link, CheckedIcon, Button, NotificationIcon,
 } from '@shopgate/engage/components';
 import { BACK_IN_STOCK_PATTERN } from '@shopgate/engage/back-in-stock/constants';
 import { i18n } from '@shopgate/engage/core';
@@ -32,6 +32,7 @@ const BackInStockButton = ({
   addBackInStockSubscription,
   grantPushPermissions,
   alignRight,
+  showAsButton,
 }) => {
   const handleClick = useCallback(async (event) => {
     if (stopPropagation) {
@@ -67,17 +68,37 @@ const BackInStockButton = ({
       </Link>
     );
   }
+
+  if (showAsButton) {
+    return (
+      <Button
+        type="primary"
+        tabIndex={0}
+        onClick={handleClick}
+        className={styles.button}
+      >
+        <span className={styles.buttonText}>
+          {i18n.text('back_in_stock.get_notified')}
+        </span>
+      </Button>
+    );
+  }
   return (
-    <Button
-      type="primary"
+    // eslint-disable-next-line jsx-a11y/anchor-is-valid,jsx-a11y/click-events-have-key-events
+    <a
+      role="button"
       tabIndex={0}
       onClick={handleClick}
-      className={styles.button}
+      className={classNames(
+        styles.button,
+        { [styles.rightAligned]: alignRight }
+      )}
     >
+      <NotificationIcon color={colors.primary} className={styles.icon} />
       <span className={styles.buttonText}>
         {i18n.text('back_in_stock.get_notified')}
       </span>
-    </Button>
+    </a>
   );
 };
 
@@ -87,6 +108,7 @@ BackInStockButton.propTypes = {
   alignRight: PropTypes.bool,
   isLinkToBackInStockEnabled: PropTypes.bool,
   productId: PropTypes.string,
+  showAsButton: PropTypes.bool,
   stopPropagation: PropTypes.bool,
   subscription: PropTypes.shape(),
 };
@@ -94,6 +116,7 @@ BackInStockButton.propTypes = {
 BackInStockButton.defaultProps = {
   stopPropagation: false,
   isLinkToBackInStockEnabled: false,
+  showAsButton: false,
   alignRight: false,
   subscription: null,
   productId: null,

--- a/libraries/engage/back-in-stock/components/BackInStockButton/index.jsx
+++ b/libraries/engage/back-in-stock/components/BackInStockButton/index.jsx
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { themeConfig } from '@shopgate/engage';
 import {
-  Link,
-  CheckedIcon,
-  NotificationIcon,
+  Link, CheckedIcon, Button,
 } from '@shopgate/engage/components';
 import { BACK_IN_STOCK_PATTERN } from '@shopgate/engage/back-in-stock/constants';
 import { i18n } from '@shopgate/engage/core';
@@ -24,7 +22,7 @@ const { colors } = themeConfig;
  * @param {Object} props.subscription The subscription
  * @param {Function} props.addBackInStockSubscription Add product to back in stock list
  * @param {Function} props.grantPushPermissions Request / Set push permission
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const BackInStockButton = ({
   productId,
@@ -69,24 +67,18 @@ const BackInStockButton = ({
       </Link>
     );
   }
-  /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/anchor-is-valid */
   return (
-    <a
-      role="button"
+    <Button
+      type="primary"
       tabIndex={0}
       onClick={handleClick}
-      className={classNames(
-        styles.button,
-        { [styles.rightAligned]: alignRight }
-      )}
+      className={styles.button}
     >
-      <NotificationIcon color={colors.primary} className={styles.icon} />
       <span className={styles.buttonText}>
         {i18n.text('back_in_stock.get_notified')}
       </span>
-    </a>
+    </Button>
   );
-  /* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/anchor-is-valid */
 };
 
 BackInStockButton.propTypes = {

--- a/libraries/engage/back-in-stock/components/BackInStockButton/style.js
+++ b/libraries/engage/back-in-stock/components/BackInStockButton/style.js
@@ -1,10 +1,7 @@
 import { css } from 'glamor';
-import { themeConfig } from '@shopgate/engage';
 
 export default {
   button: css({
-    color: themeConfig.colors.primary,
-    display: 'flex',
     lineHeight: '16.5px',
   }).toString(),
   buttonContent: css({
@@ -16,10 +13,6 @@ export default {
     display: 'flex',
     alignItems: 'center',
     width: 'auto',
-  }).toString(),
-  rightAligned: css({
-    display: 'inline-block',
-    textAlign: 'right',
   }).toString(),
   backInStockMessage: css({
     verticalAlign: 'middle',

--- a/libraries/engage/back-in-stock/components/BackInStockButton/style.js
+++ b/libraries/engage/back-in-stock/components/BackInStockButton/style.js
@@ -1,12 +1,18 @@
 import { css } from 'glamor';
+import { themeConfig } from '@shopgate/engage';
 
 export default {
   button: css({
     lineHeight: '16.5px',
+    color: themeConfig.colors.warning,
   }).toString(),
   buttonContent: css({
     display: 'flex',
     alignItems: 'center',
+  }).toString(),
+  rightAligned: css({
+    display: 'inline-block',
+    textAlign: 'right',
   }).toString(),
   backInStockMessageContainer: css({
     lineHeight: '16.5px',

--- a/libraries/engage/back-in-stock/components/BackInStockButton/style.js
+++ b/libraries/engage/back-in-stock/components/BackInStockButton/style.js
@@ -5,20 +5,21 @@ export default {
   button: css({
     lineHeight: '16.5px',
     color: themeConfig.colors.warning,
+    width: '100%',
   }).toString(),
   buttonContent: css({
     display: 'flex',
     alignItems: 'center',
-  }).toString(),
-  rightAligned: css({
-    display: 'inline-block',
-    textAlign: 'right',
   }).toString(),
   backInStockMessageContainer: css({
     lineHeight: '16.5px',
     display: 'flex',
     alignItems: 'center',
     width: 'auto',
+  }).toString(),
+  rightAligned: css({
+    display: 'inline-block',
+    textAlign: 'right',
   }).toString(),
   backInStockMessage: css({
     verticalAlign: 'middle',

--- a/libraries/engage/back-in-stock/components/ProductInfoBackInStockButton/index.jsx
+++ b/libraries/engage/back-in-stock/components/ProductInfoBackInStockButton/index.jsx
@@ -16,7 +16,7 @@ import connect from './connector';
  * @param {string} props.variantId The variant id
  * @param {Object} props.product The product
  * @param {Object} props.subscription The subscription
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const ProductInfoBackInStockButton = ({
   productId,
@@ -41,6 +41,7 @@ const ProductInfoBackInStockButton = ({
       >
         {showBackInStockButton &&
           <BackInStockButton
+            showAsButton
             subscription={subscription}
             isLinkToBackInStockEnabled
             productId={variantId ?? productId}

--- a/themes/theme-gmd/locale/de-DE.json
+++ b/themes/theme-gmd/locale/de-DE.json
@@ -315,9 +315,9 @@
     "rejectionApprovalMessage": "Möchten Sie uns Feedback geben? Das hilft uns die App weiter zu verbessern."
   },
   "pushOptInModal": {
-    "title": "Erhalte exklusive Coupons und Angebote",
+    "title": "Erhalten Sie exklusive Coupons und Angebote",
     "buttonAllow": "Benachrichtigungen aktivieren",
     "buttonDeny": "Ich möchte keine Benachrichtigungen",
-    "message": "Aktiviere Benachrichtigungen, damit wir Ihnen Push-Mitteilungen zu neuen Angeboten, exklusiven Gutscheinen und mehr senden können."
+    "message": "Aktivieren Sie Benachrichtigungen, damit wir Ihnen Push-Mitteilungen zu neuen Angeboten, exklusiven Gutscheinen und mehr senden können."
   }
 }

--- a/themes/theme-gmd/locale/de-DE.json
+++ b/themes/theme-gmd/locale/de-DE.json
@@ -32,10 +32,10 @@
     "we_will_remind_you": "Du wirst benachrichtigt, wenn der Artikel wieder verfügbar ist",
     "add_back_in_stock_success_modal": {
       "title": "Benachrichtigung hinzugefügt!",
-      "message": "Wir senden dir eine Push-Benachrichtigung wenn das Produkt wieder verfügbar ist. Du kannst diese Benachrichtigungen über das Menü verwalten."
+      "message": "Wir senden dir eine Push-Benachrichtigung, wenn das Produkt wieder verfügbar ist. Du kannst diese Benachrichtigungen über das Menü verwalten."
     },
     "rationale": {
-      "message": "Bitte erlaube Push-Benachrichtigungen im nächsten Schritt, damit wir dir mitteilen können wenn das Produkt wieder verfügbar ist.",
+      "message": "Bitte erlaube Push-Benachrichtigungen im nächsten Schritt, damit wir dir mitteilen können, wenn das Produkt wieder verfügbar ist.",
       "confirm": "Benachrichtigungen erlauben"
     }
   },

--- a/themes/theme-gmd/locale/de-DE.json
+++ b/themes/theme-gmd/locale/de-DE.json
@@ -27,15 +27,15 @@
       "active": "Aktive Benachrichtigungen",
       "past": "Vergangene Benachrichtigungen"
     },
-    "empty_list_reminder": "Du hast keine Benachrichtigungen konfiguriert",
-    "get_notified": "Benachrichtige mich, wenn der Artikel verfügbar ist",
-    "we_will_remind_you": "Du wirst benachrichtigt, wenn der Artikel wieder verfügbar ist",
+    "empty_list_reminder": "Sie haben keine Benachrichtigungen konfiguriert",
+    "get_notified": "Benachrichtigen Sie mich, wenn der Artikel verfügbar ist",
+    "we_will_remind_you": "Sie werden benachrichtigt, wenn der Artikel wieder verfügbar ist",
     "add_back_in_stock_success_modal": {
       "title": "Benachrichtigung hinzugefügt!",
-      "message": "Wir senden dir eine Push-Benachrichtigung, wenn das Produkt wieder verfügbar ist. Du kannst diese Benachrichtigungen über das Menü verwalten."
+      "message": "Wir senden Ihnen eine Push-Benachrichtigung, wenn das Produkt wieder verfügbar ist. Sie können diese Benachrichtigungen über das Menü verwalten."
     },
     "rationale": {
-      "message": "Bitte erlaube Push-Benachrichtigungen im nächsten Schritt, damit wir dir mitteilen können, wenn das Produkt wieder verfügbar ist.",
+      "message": "Bitte erlauben Sie Push-Benachrichtigungen im nächsten Schritt, damit wir Ihnen mitteilen können, wenn das Produkt wieder verfügbar ist.",
       "confirm": "Benachrichtigungen erlauben"
     }
   },
@@ -290,8 +290,8 @@
     "access_denied": {
       "settings_button": "Einstellungen öffnen",
       "camera_message": "Diese Funktion benötigt Zugriff auf die Kamera. Bitte erlauben Sie den Zugriff in den Einstellungen.",
-      "push_message": "Du hast Push-Benachrichtigungen für diese App deaktiviert. Bitte gehe in die Einstellungen deines Gerätes um sie zu aktivieren.",
-      "geolocation_message": "Wir benötigen Zugriff auf den Standort um Filialen in der Nähe zu zeigen."
+      "push_message": "Sie haben Push-Benachrichtigungen für diese App deaktiviert. Bitte gehen Sie in die Einstellungen Ihres Gerätes, um sie zu aktivieren.",
+      "geolocation_message": "Wir benötigen Zugriff auf den Standort, um Filialen in der Nähe zu zeigen."
     }
   },
   "error": {
@@ -318,6 +318,6 @@
     "title": "Erhalte exklusive Coupons und Angebote",
     "buttonAllow": "Benachrichtigungen aktivieren",
     "buttonDeny": "Ich möchte keine Benachrichtigungen",
-    "message": "Aktiviere Benachrichtigungen, damit wir dir Push-Mitteilungen zu neuen Angeboten, exklusiven Gutscheinen und mehr senden können."
+    "message": "Aktiviere Benachrichtigungen, damit wir Ihnen Push-Mitteilungen zu neuen Angeboten, exklusiven Gutscheinen und mehr senden können."
   }
 }

--- a/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -81,12 +81,12 @@ const ProductInfo = ({ productId, options }) => (
         </Grid.Item>
         <TaxDisclaimer />
       </Grid>
+      <Grid.Item component="div">
+        <div className={styles.productInfo}>
+          <ProductInfoBackInStockButton />
+        </div>
+      </Grid.Item>
     </Portal>
-    <Grid.Item component="div">
-      <div className={styles.productInfo}>
-        <ProductInfoBackInStockButton />
-      </div>
-    </Grid.Item>
     <Portal name={PRODUCT_INFO_AFTER} />
   </Fragment>
 );

--- a/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -81,7 +81,7 @@ const ProductInfo = ({ productId, options }) => (
         </Grid.Item>
         <TaxDisclaimer />
       </Grid>
-      <Grid.Item component="div">
+      <Grid.Item component="div" className={styles.backInStockButton}>
         <div className={styles.productInfo}>
           <ProductInfoBackInStockButton />
         </div>

--- a/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -82,9 +82,7 @@ const ProductInfo = ({ productId, options }) => (
         <TaxDisclaimer />
       </Grid>
       <Grid.Item component="div" className={styles.backInStockButton}>
-        <div className={styles.productInfo}>
-          <ProductInfoBackInStockButton />
-        </div>
+        <ProductInfoBackInStockButton />
       </Grid.Item>
     </Portal>
     <Portal name={PRODUCT_INFO_AFTER} />

--- a/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -1,6 +1,8 @@
 import React, { Fragment, memo } from 'react';
 import PropTypes from 'prop-types';
-import { MapPriceHint, OrderQuantityHint, EffectivityDates } from '@shopgate/engage/product';
+import {
+  MapPriceHint, OrderQuantityHint, EffectivityDates,
+} from '@shopgate/engage/product';
 import Grid from '@shopgate/pwa-common/components/Grid';
 import Portal from '@shopgate/pwa-common/components/Portal';
 import {
@@ -24,7 +26,7 @@ import * as styles from './style';
 
 /**
  * @param {Object} props The component props.
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 const ProductInfo = ({ productId, options }) => (
   <Fragment>
@@ -59,9 +61,6 @@ const ProductInfo = ({ productId, options }) => (
             <div className={styles.productInfo}>
               <StockInfo productId={productId} />
             </div>
-            <div className={styles.productInfo}>
-              <ProductInfoBackInStockButton />
-            </div>
           </Portal>
         </Grid.Item>
         <Grid.Item component="div" className={`${styles.priceContainer} theme__product__header__product-info__row2`}>
@@ -83,6 +82,11 @@ const ProductInfo = ({ productId, options }) => (
         <TaxDisclaimer />
       </Grid>
     </Portal>
+    <Grid.Item component="div">
+      <div className={styles.productInfo}>
+        <ProductInfoBackInStockButton />
+      </div>
+    </Grid.Item>
     <Portal name={PRODUCT_INFO_AFTER} />
   </Fragment>
 );

--- a/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/style.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/style.js
@@ -11,7 +11,9 @@ export const productInfo = css({
 }).toString();
 
 export const backInStockButton = css({
-  marginTop: `${variables.gap.small}px`,
+  ':not(:empty)': {
+    marginTop: `${variables.gap.small}px`,
+  },
 }).toString();
 
 export const priceContainer = css({

--- a/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/style.js
+++ b/themes/theme-gmd/pages/Product/components/Header/components/ProductInfo/style.js
@@ -10,6 +10,10 @@ export const productInfo = css({
   },
 }).toString();
 
+export const backInStockButton = css({
+  marginTop: `${variables.gap.small}px`,
+}).toString();
+
 export const priceContainer = css({
   textAlign: 'right',
   marginLeft: variables.gap.big,

--- a/themes/theme-ios11/locale/de-DE.json
+++ b/themes/theme-ios11/locale/de-DE.json
@@ -322,9 +322,9 @@
     "rejectionApprovalMessage": "Möchten Sie uns Feedback geben? Das hilft uns die App weiter zu verbessern."
   },
   "pushOptInModal": {
-    "title": "Erhalte exklusive Coupons und Angebote",
+    "title": "Erhalten Sie exklusive Coupons und Angebote",
     "buttonAllow": "Benachrichtigungen aktivieren",
     "buttonDeny": "Ich möchte keine Benachrichtigungen",
-    "message": "Aktiviere Benachrichtigungen, damit wir Ihnen Push-Mitteilungen zu neuen Angeboten, exklusiven Gutscheinen und mehr senden können."
+    "message": "Aktivieren Sie Benachrichtigungen, damit wir Ihnen Push-Mitteilungen zu neuen Angeboten, exklusiven Gutscheinen und mehr senden können."
   }
 }

--- a/themes/theme-ios11/locale/de-DE.json
+++ b/themes/theme-ios11/locale/de-DE.json
@@ -33,10 +33,10 @@
     "we_will_remind_you": "Du wirst benachrichtigt, wenn der Artikel wieder verfügbar ist",
     "add_back_in_stock_success_modal": {
       "title": "Benachrichtigung hinzugefügt!",
-      "message": "Wir senden dir eine Push-Benachrichtigung wenn das Produkt wieder verfügbar ist. Du kannst diese Benachrichtigungen über das Menü verwalten."
+      "message": "Wir senden dir eine Push-Benachrichtigung, wenn das Produkt wieder verfügbar ist. Du kannst diese Benachrichtigungen über das Menü verwalten."
     },
     "rationale": {
-      "message": "Bitte erlaube Push-Benachrichtigungen im nächsten Schritt, damit wir dir mitteilen können wenn das Produkt wieder verfügbar ist.",
+      "message": "Bitte erlaube Push-Benachrichtigungen im nächsten Schritt, damit wir dir mitteilen können, wenn das Produkt wieder verfügbar ist.",
       "confirm": "Benachrichtigungen erlauben"
     }
   },

--- a/themes/theme-ios11/locale/de-DE.json
+++ b/themes/theme-ios11/locale/de-DE.json
@@ -28,15 +28,15 @@
       "active": "Aktive Benachrichtigungen",
       "past": "Vergangene Benachrichtigungen"
     },
-    "empty_list_reminder": "Du hast keine Benachrichtigungen konfiguriert",
-    "get_notified": "Benachrichtige mich, wenn der Artikel verfügbar ist",
-    "we_will_remind_you": "Du wirst benachrichtigt, wenn der Artikel wieder verfügbar ist",
+    "empty_list_reminder": "Sie haben keine Benachrichtigungen konfiguriert",
+    "get_notified": "Benachrichtigen Sie mich, wenn der Artikel verfügbar ist",
+    "we_will_remind_you": "Sie werden benachrichtigt, wenn der Artikel wieder verfügbar ist",
     "add_back_in_stock_success_modal": {
       "title": "Benachrichtigung hinzugefügt!",
-      "message": "Wir senden dir eine Push-Benachrichtigung, wenn das Produkt wieder verfügbar ist. Du kannst diese Benachrichtigungen über das Menü verwalten."
+      "message": "Wir senden Ihnen eine Push-Benachrichtigung, wenn das Produkt wieder verfügbar ist. Sie können diese Benachrichtigungen über das Menü verwalten."
     },
     "rationale": {
-      "message": "Bitte erlaube Push-Benachrichtigungen im nächsten Schritt, damit wir dir mitteilen können, wenn das Produkt wieder verfügbar ist.",
+      "message": "Bitte erlauben Sie Push-Benachrichtigungen im nächsten Schritt, damit wir Ihnen mitteilen können, wenn das Produkt wieder verfügbar ist.",
       "confirm": "Benachrichtigungen erlauben"
     }
   },
@@ -297,8 +297,8 @@
     "access_denied": {
       "settings_button": "Einstellungen öffnen",
       "camera_message": "Diese Funktion benötigt Zugriff auf die Kamera. Bitte erlauben Sie den Zugriff in den Einstellungen.",
-      "push_message": "Du hast Push-Benachrichtigungen für diese App deaktiviert. Bitte gehe in die Einstellungen deines Gerätes um sie zu aktivieren.",
-      "geolocation_message": "Wir benötigen Zugriff auf den Standort um Filialen in der Nähe zu zeigen."
+      "push_message": "Sie haben Push-Benachrichtigungen für diese App deaktiviert. Bitte gehen Sie in die Einstellungen Ihres Gerätes, um sie zu aktivieren.",
+      "geolocation_message": "Wir benötigen Zugriff auf den Standort, um Filialen in der Nähe zu zeigen."
     }
   },
   "error": {
@@ -325,6 +325,6 @@
     "title": "Erhalte exklusive Coupons und Angebote",
     "buttonAllow": "Benachrichtigungen aktivieren",
     "buttonDeny": "Ich möchte keine Benachrichtigungen",
-    "message": "Aktiviere Benachrichtigungen, damit wir dir Push-Mitteilungen zu neuen Angeboten, exklusiven Gutscheinen und mehr senden können."
+    "message": "Aktiviere Benachrichtigungen, damit wir Ihnen Push-Mitteilungen zu neuen Angeboten, exklusiven Gutscheinen und mehr senden können."
   }
 }

--- a/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -80,9 +80,7 @@ const ProductInfo = ({ productId, options }) => (
         <TaxDisclaimer />
       </Grid>
       <Grid.Item component="div" className={styles.backInStockButton}>
-        <div className={styles.productInfo}>
-          <ProductInfoBackInStockButton />
-        </div>
+        <ProductInfoBackInStockButton />
       </Grid.Item>
     </Portal>
     <Portal name={PRODUCT_INFO_AFTER} />

--- a/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -79,12 +79,12 @@ const ProductInfo = ({ productId, options }) => (
         </Grid.Item>
         <TaxDisclaimer />
       </Grid>
+      <Grid.Item component="div">
+        <div className={styles.productInfo}>
+          <ProductInfoBackInStockButton />
+        </div>
+      </Grid.Item>
     </Portal>
-    <Grid.Item component="div">
-      <div className={styles.productInfo}>
-        <ProductInfoBackInStockButton />
-      </div>
-    </Grid.Item>
     <Portal name={PRODUCT_INFO_AFTER} />
   </Fragment>
 );

--- a/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -79,7 +79,7 @@ const ProductInfo = ({ productId, options }) => (
         </Grid.Item>
         <TaxDisclaimer />
       </Grid>
-      <Grid.Item component="div">
+      <Grid.Item component="div" className={styles.backInStockButton}>
         <div className={styles.productInfo}>
           <ProductInfoBackInStockButton />
         </div>

--- a/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/index.jsx
@@ -59,9 +59,6 @@ const ProductInfo = ({ productId, options }) => (
             <div className={styles.productInfo}>
               <StockInfo productId={productId} />
             </div>
-            <div className={styles.productInfo}>
-              <ProductInfoBackInStockButton />
-            </div>
           </Portal>
         </Grid.Item>
         <Grid.Item component="div" className={`${styles.priceContainer} theme__product__header__product-info__row2`}>
@@ -83,6 +80,11 @@ const ProductInfo = ({ productId, options }) => (
         <TaxDisclaimer />
       </Grid>
     </Portal>
+    <Grid.Item component="div">
+      <div className={styles.productInfo}>
+        <ProductInfoBackInStockButton />
+      </div>
+    </Grid.Item>
     <Portal name={PRODUCT_INFO_AFTER} />
   </Fragment>
 );

--- a/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/style.js
+++ b/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/style.js
@@ -11,7 +11,9 @@ export const productInfo = css({
 }).toString();
 
 export const backInStockButton = css({
-  marginTop: `${variables.gap.small}px`,
+  ':not(:empty)': {
+    marginTop: `${variables.gap.small}px`,
+  },
 }).toString();
 
 export const priceContainer = css({

--- a/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/style.js
+++ b/themes/theme-ios11/pages/Product/components/Header/components/ProductInfo/style.js
@@ -10,6 +10,10 @@ export const productInfo = css({
   },
 }).toString();
 
+export const backInStockButton = css({
+  marginTop: `${variables.gap.small}px`,
+}).toString();
+
 export const priceContainer = css({
   textAlign: 'right',
   marginLeft: variables.gap.big,


### PR DESCRIPTION
# Description

If a product is out of stock, the customer can subscribe to it to be notified when it is back in stock. To make this option more visible, we changed it from a link into a button.

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [x] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Test it with a product which is out of stock to see the subscription button.
