### PR TITLE
Add config to change the portal position of the Delete Account Button

### DIFF
--- a/extensions/@shopgate-user-privacy/README.md
+++ b/extensions/@shopgate-user-privacy/README.md
@@ -3,6 +3,31 @@
 To comply to the new data privacy laws, we need to offer a button for the user to delete his account.
 Delete account requests are later processed by shopgate backend system. 
 
+## Configuration
+
+* `deleteAccountTarget` - (string) Target position for the Delete Account Button (choose one from the list below). 
+
+
+
+### Available target positions for Delete User Button
+
+```json
+"nav-menu.logout.after",
+"nav-menu.shipping.after",
+"nav-menu.payment.after",
+"nav-menu.terms.after",
+"nav-menu.privacy.after",
+"nav-menu.return-policy.after",
+"nav-menu.imprint.after"
+```
+
+### Example configuration
+
+```json
+{
+  "deleteAccountTarget": "nav-menu.logout.after"
+}
+```
 
 ## About Shopgate
 Shopgate is the leading mobile commerce platform.

--- a/extensions/@shopgate-user-privacy/extension-config.json
+++ b/extensions/@shopgate-user-privacy/extension-config.json
@@ -12,6 +12,15 @@
         "path": "/v1/shop/%(shopId)s/has_user_account_deletion?parsed=true",
         "key": "value"
       }
+    },
+    "deleteAccountTarget": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": "nav-menu.logout.after",
+      "params": {
+        "type": "json",
+        "label": "Configuration to show delete account button at given portal positions"
+      }
     }
   },
   "components": [
@@ -19,7 +28,15 @@
       "type": "portals",
       "id": "DeleteAccount",
       "path": "frontend/DeleteAccount/index.jsx",
-      "target": "nav-menu.logout.after"
+      "target": [
+        "nav-menu.logout.after",
+        "nav-menu.shipping.after",
+        "nav-menu.payment.after",
+        "nav-menu.terms.after",
+        "nav-menu.privacy.after",
+        "nav-menu.return-policy.after",
+        "nav-menu.imprint.after"
+      ]
     },
     {
       "id": "DeleteAccountSubscribers",

--- a/extensions/@shopgate-user-privacy/frontend/DeleteAccount/connector.js
+++ b/extensions/@shopgate-user-privacy/frontend/DeleteAccount/connector.js
@@ -4,11 +4,15 @@ import config from '../config';
 
 /**
  * @param {Object} state The current application state
+ * @param {Object} props Props
  * @return {{isShown: boolean}}
  */
-const mapStateToProps = state => ({
-  isShown: config.isActive && isUserLoggedIn(state),
-});
+const mapStateToProps = (state, props) => {
+  const isPortal = props.name === config.deleteAccountTarget;
+  return {
+    isShown: config.isActive && isUserLoggedIn(state) && isPortal,
+  };
+};
 
 /**
  * @param {Function} dispatch The redux dispatch function.


### PR DESCRIPTION
# Description

This is an adaption for the `@shopgate/user-privacy` extension, which is part of the pwa. The adaptions adds a configuration and the logic to change the portal position of the "Delete Account" Button in the "More" menu.
 
## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please login and check the position of the "Delete Account" Button in the "More" menu. You can change the position via the extension config for the `@shopgate/user-privacy` extension
