### PR TITLE
Center checked icon for back in stock subscription

### DIFF
--- a/libraries/engage/back-in-stock/components/BackInStockButton/index.jsx
+++ b/libraries/engage/back-in-stock/components/BackInStockButton/index.jsx
@@ -63,7 +63,10 @@ const BackInStockButton = ({
         )}
         tag="span"
       >
-        <CheckedIcon color={colors.success} className={styles.icon} />
+        <CheckedIcon
+          color={colors.success}
+          className={alignRight ? styles.icon : classNames(styles.iconCentered, styles.icon)}
+        />
         <span className={styles.backInStockMessage}>{i18n.text('back_in_stock.we_will_remind_you')}</span>
       </Link>
     );

--- a/libraries/engage/back-in-stock/components/BackInStockButton/style.js
+++ b/libraries/engage/back-in-stock/components/BackInStockButton/style.js
@@ -37,8 +37,8 @@ export default {
     display: 'inline-flex',
   }).toString(),
   iconCentered: css({
-    margin: 'auto',
+    alignSelf: 'center',
+    marginLeft: '-1px',
     marginRight: '8px',
-    display: 'block',
   }).toString(),
 };

--- a/libraries/engage/back-in-stock/components/BackInStockButton/style.js
+++ b/libraries/engage/back-in-stock/components/BackInStockButton/style.js
@@ -27,7 +27,6 @@ export default {
   }).toString(),
   buttonText: css({
     fontSize: '0.875rem',
-
   }).toString(),
   icon: css({
     marginRight: 4,
@@ -36,5 +35,10 @@ export default {
     flexShrink: 0,
     alignSelf: 'flex-start',
     display: 'inline-flex',
+  }).toString(),
+  iconCentered: css({
+    margin: 'auto',
+    marginRight: '8px',
+    display: 'block',
   }).toString(),
 };


### PR DESCRIPTION
# Description

we aligned the checked icon to center for the back in stock subscription info

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

it appears after subscribing to back in stock notifications
