### PR TITLE
Enabled scanner support on iPads with recent app versions

### DIFF
--- a/libraries/common/selectors/client.js
+++ b/libraries/common/selectors/client.js
@@ -145,10 +145,15 @@ export const hasScannerSupport = createSelector(
   getDeviceInformation,
   isIos,
   (clientInformation, deviceInformation, deviceIsIos) => {
-    // scanner is not supported on ipads
     const { type } = deviceInformation || {};
     const isIpad = type === TYPE_TABLET && deviceIsIos;
 
+    if (isVersionAtLeast('11.0.0', clientInformation.appVersion)) {
+      // scanner is supported on all apps based on the react-native based apps
+      return true;
+    }
+
+    // scanner is not supported on iPads with the not react-native based app
     return isVersionAtLeast(SCANNER_MIN_APP_LIB_VERSION, clientInformation.libVersion) && !isIpad;
   }
 );

--- a/libraries/common/selectors/client.spec.js
+++ b/libraries/common/selectors/client.spec.js
@@ -103,6 +103,33 @@ describe('Client selectors', () => {
         const result = hasScannerSupport(createMockState({}));
         expect(result).toBeFalsy();
       });
+
+      it('should return false on iPads running with the non react-native based app', () => {
+        const result = hasScannerSupport(createMockState({
+          libVersion: SCANNER_MIN_APP_LIB_VERSION,
+          device: {
+            type: 'tablet',
+            os: {
+              platform: 'ios',
+            },
+          },
+        }));
+        expect(result).toBeFalsy();
+      });
+
+      it('should return true on iPads running with the react-native based app', () => {
+        const result = hasScannerSupport(createMockState({
+          libVersion: SCANNER_MIN_APP_LIB_VERSION,
+          appVersion: '11.0.4',
+          device: {
+            type: 'tablet',
+            os: {
+              platform: 'ios',
+            },
+          },
+        }));
+        expect(result).toBeTruthy();
+      });
     });
 
     describe('getDeviceInformation()', () => {


### PR DESCRIPTION
# Description
This ticket enables scanner support on iPads with recent app versions (from version 11.0.0).  Scanner support can be checked via the `hasScannerSupport` client selector.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
