### PR TITLE
Added portals to quick links menu + make them available for the @shopgate/user-privacy delete account button

### DIFF
--- a/extensions/@shopgate-user-privacy/README.md
+++ b/extensions/@shopgate-user-privacy/README.md
@@ -1,18 +1,18 @@
 # Shopgate Connect user privacy extension
 
 To comply to the new data privacy laws, we need to offer a button for the user to delete his account.
-Delete account requests are later processed by shopgate backend system. 
+Delete account requests are later processed by shopgate backend system.
 
 ## Configuration
 
-* `deleteAccountTarget` - (string) Target position for the Delete Account Button (choose one from the list below). 
+* `deleteAccountTarget` - (string) Target position for the Delete Account Button (choose one from the list below).
 
 
 
 ### Available target positions for Delete User Button
 
 ```json
- "nav-menu.logout.before",
+  "nav-menu.logout.before",
   "nav-menu.logout.after",
   "nav-menu.shipping.before",
   "nav-menu.shipping.after",

--- a/extensions/@shopgate-user-privacy/README.md
+++ b/extensions/@shopgate-user-privacy/README.md
@@ -12,13 +12,22 @@ Delete account requests are later processed by shopgate backend system.
 ### Available target positions for Delete User Button
 
 ```json
-"nav-menu.logout.after",
-"nav-menu.shipping.after",
-"nav-menu.payment.after",
-"nav-menu.terms.after",
-"nav-menu.privacy.after",
-"nav-menu.return-policy.after",
-"nav-menu.imprint.after"
+ "nav-menu.logout.before",
+  "nav-menu.logout.after",
+  "nav-menu.shipping.before",
+  "nav-menu.shipping.after",
+  "nav-menu.payment.before",
+  "nav-menu.payment.after",
+  "nav-menu.terms.before",
+  "nav-menu.terms.after",
+  "nav-menu.privacy.before",
+  "nav-menu.privacy.after",
+  "nav-menu.return-policy.before",
+  "nav-menu.return-policy.after",
+  "nav-menu.imprint.before",
+  "nav-menu.imprint.after",
+  "nav-menu.quick-links.items.before",
+  "nav-menu.quick-links.items.after"
 ```
 
 ### Example configuration

--- a/extensions/@shopgate-user-privacy/extension-config.json
+++ b/extensions/@shopgate-user-privacy/extension-config.json
@@ -29,13 +29,22 @@
       "id": "DeleteAccount",
       "path": "frontend/DeleteAccount/index.jsx",
       "target": [
+        "nav-menu.logout.before",
         "nav-menu.logout.after",
+        "nav-menu.shipping.before",
         "nav-menu.shipping.after",
+        "nav-menu.payment.before",
         "nav-menu.payment.after",
+        "nav-menu.terms.before",
         "nav-menu.terms.after",
+        "nav-menu.privacy.before",
         "nav-menu.privacy.after",
+        "nav-menu.return-policy.before",
         "nav-menu.return-policy.after",
-        "nav-menu.imprint.after"
+        "nav-menu.imprint.before",
+        "nav-menu.imprint.after",
+        "nav-menu.quick-links.items.before",
+        "nav-menu.quick-links.items.after"
       ]
     },
     {

--- a/libraries/common/constants/Portals.js
+++ b/libraries/common/constants/Portals.js
@@ -32,6 +32,7 @@ const BACK = 'back';
 const CLOSE = 'close';
 const SIMPLE = 'simple';
 const CART_BUTTON = 'cart-button';
+const ITEMS = 'items';
 
 // POSITIONS
 export const BEFORE = 'before';
@@ -77,6 +78,10 @@ export const NAV_MENU_HOME_AFTER = `${NAV_MENU}.${HOME}.${AFTER}`;
 export const NAV_MENU_QUICK_LINKS = `${NAV_MENU}.${QUICK_LINKS}`;
 export const NAV_MENU_QUICK_LINKS_BEFORE = `${NAV_MENU}.${QUICK_LINKS}.${BEFORE}`;
 export const NAV_MENU_QUICK_LINKS_AFTER = `${NAV_MENU}.${QUICK_LINKS}.${AFTER}`;
+
+export const NAV_MENU_QUICK_LINKS_ITEMS = `${NAV_MENU}.${QUICK_LINKS}.${ITEMS}`;
+export const NAV_MENU_QUICK_LINKS_ITEMS_BEFORE = `${NAV_MENU}.${QUICK_LINKS}.${ITEMS}.${BEFORE}`;
+export const NAV_MENU_QUICK_LINKS_ITEMS_AFTER = `${NAV_MENU}.${QUICK_LINKS}.${ITEMS}.${AFTER}`;
 
 export const NAV_MENU_SCANNER_BEFORE = `${NAV_MENU}.${SCANNER}.${BEFORE}`;
 export const NAV_MENU_SCANNER = `${NAV_MENU}.${SCANNER}`;

--- a/themes/theme-gmd/components/NavDrawer/components/QuickLinks/index.jsx
+++ b/themes/theme-gmd/components/NavDrawer/components/QuickLinks/index.jsx
@@ -6,6 +6,7 @@ import {
 } from '@shopgate/engage/components';
 import {
   NAV_MENU_QUICK_LINKS,
+  NAV_MENU_QUICK_LINKS_ITEMS,
 } from '@shopgate/pwa-common/constants/Portals';
 import portalProps from '../../portalProps';
 
@@ -22,25 +23,27 @@ const QuickLinks = ({ links, navigate }) => (
   (links && links.length > 0) && (
     <SurroundPortals portalName={NAV_MENU_QUICK_LINKS} portalProps={portalProps}>
       <NavDrawer.Section>
-        {links.map((link) => {
-          let icon = DescriptionIcon;
+        <SurroundPortals portalName={NAV_MENU_QUICK_LINKS_ITEMS} portalProps={portalProps}>
+          {links.map((link) => {
+            let icon = DescriptionIcon;
 
-          // Convert /page/some-link to pageSomeLink for custom icons
-          const path = camelCase(link.url);
-          if (icons[path]) {
-            icon = props => <Icon content={icons[path]} {...props} />;
-          }
+            // Convert /page/some-link to pageSomeLink for custom icons
+            const path = camelCase(link.url);
+            if (icons[path]) {
+              icon = props => <Icon content={icons[path]} {...props} />;
+            }
 
-          return (
-            <NavDrawer.Item
-              aria-hidden
-              key={link.url}
-              label={link.label}
-              onClick={() => navigate(link.url, link.label)}
-              icon={icon}
-            />
-          );
-        })}
+            return (
+              <NavDrawer.Item
+                aria-hidden
+                key={link.url}
+                label={link.label}
+                onClick={() => navigate(link.url, link.label)}
+                icon={icon}
+              />
+            );
+          })}
+        </SurroundPortals>
       </NavDrawer.Section>
     </SurroundPortals>
 

--- a/themes/theme-ios11/pages/More/components/Quicklinks/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/pages/More/components/Quicklinks/__snapshots__/index.spec.jsx.snap
@@ -124,64 +124,106 @@ exports[`<Quicklinks /> should render quicklinks 1`] = `
                 }
               }
             >
-              <MoreMenuItem
-                className={null}
-                href="/some/url"
-                key="/some/url"
-                label="Some Label"
-                onClick={null}
-                testId={null}
+              <SurroundPortals
+                portalName="nav-menu.quick-links.items"
+                portalProps={
+                  Object {
+                    "Headline": [Function],
+                    "Item": [Function],
+                    "Section": [Function],
+                  }
+                }
               >
-                <Link
-                  className="css-1hj8a57"
-                  href="/some/url"
+                <Portal
+                  name="nav-menu.quick-links.items.before"
+                  props={
+                    Object {
+                      "Headline": [Function],
+                      "Item": [Function],
+                      "Section": [Function],
+                    }
+                  }
+                />
+                <Portal
+                  name="nav-menu.quick-links.items"
+                  props={
+                    Object {
+                      "Headline": [Function],
+                      "Item": [Function],
+                      "Section": [Function],
+                    }
+                  }
                 >
-                  <div>
-                    <Translate
-                      className={null}
-                      params={Object {}}
-                      role={null}
-                      string="Some Label"
+                  <MoreMenuItem
+                    className={null}
+                    href="/some/url"
+                    key="/some/url"
+                    label="Some Label"
+                    onClick={null}
+                    testId={null}
+                  >
+                    <Link
+                      className="css-1hj8a57"
+                      href="/some/url"
                     >
-                      <span
-                        className={null}
-                        role={null}
-                      >
-                        Some Label
-                      </span>
-                    </Translate>
-                  </div>
-                </Link>
-              </MoreMenuItem>
-              <MoreMenuItem
-                className={null}
-                href="/another/url"
-                key="/another/url"
-                label="Another Label"
-                onClick={null}
-                testId={null}
-              >
-                <Link
-                  className="css-1hj8a57"
-                  href="/another/url"
-                >
-                  <div>
-                    <Translate
-                      className={null}
-                      params={Object {}}
-                      role={null}
-                      string="Another Label"
+                      <div>
+                        <Translate
+                          className={null}
+                          params={Object {}}
+                          role={null}
+                          string="Some Label"
+                        >
+                          <span
+                            className={null}
+                            role={null}
+                          >
+                            Some Label
+                          </span>
+                        </Translate>
+                      </div>
+                    </Link>
+                  </MoreMenuItem>
+                  <MoreMenuItem
+                    className={null}
+                    href="/another/url"
+                    key="/another/url"
+                    label="Another Label"
+                    onClick={null}
+                    testId={null}
+                  >
+                    <Link
+                      className="css-1hj8a57"
+                      href="/another/url"
                     >
-                      <span
-                        className={null}
-                        role={null}
-                      >
-                        Another Label
-                      </span>
-                    </Translate>
-                  </div>
-                </Link>
-              </MoreMenuItem>
+                      <div>
+                        <Translate
+                          className={null}
+                          params={Object {}}
+                          role={null}
+                          string="Another Label"
+                        >
+                          <span
+                            className={null}
+                            role={null}
+                          >
+                            Another Label
+                          </span>
+                        </Translate>
+                      </div>
+                    </Link>
+                  </MoreMenuItem>
+                </Portal>
+                <Portal
+                  name="nav-menu.quick-links.items.after"
+                  props={
+                    Object {
+                      "Headline": [Function],
+                      "Item": [Function],
+                      "Section": [Function],
+                    }
+                  }
+                />
+              </SurroundPortals>
             </div>
           </Section>
         </Portal>

--- a/themes/theme-ios11/pages/More/components/Quicklinks/index.jsx
+++ b/themes/theme-ios11/pages/More/components/Quicklinks/index.jsx
@@ -5,6 +5,7 @@ import {
 } from '@shopgate/engage/components';
 import {
   NAV_MENU_QUICK_LINKS,
+  NAV_MENU_QUICK_LINKS_ITEMS,
 } from '@shopgate/pwa-common/constants/Portals';
 import { BACK_IN_STOCK_PATTERN } from '@shopgate/engage/back-in-stock/constants';
 import portalProps from '../../portalProps';
@@ -31,9 +32,11 @@ function Quicklinks({ entries, isBackInStockEnabled }) {
   return (
     <SurroundPortals portalName={NAV_MENU_QUICK_LINKS} portalProps={portalProps}>
       <Section title="navigation.more_menu">
-        {allEntries.map(entry => (
-          <Section.Item href={entry.url} key={entry.url} label={entry.label} />
-        ))}
+        <SurroundPortals portalName={NAV_MENU_QUICK_LINKS_ITEMS} portalProps={portalProps}>
+          {allEntries.map(entry => (
+            <Section.Item href={entry.url} key={entry.url} label={entry.label} />
+          ))}
+        </SurroundPortals>
       </Section>
     </SurroundPortals>
   );


### PR DESCRIPTION
# Description

Added portals to quick links menu and make them available for the [@shopgate/user-privacy](https://github.com/shopgate/ext-user-privacy) delete account button.

New portals added:

`nav-menu.quick-links.items.before`
`nav-menu.quick-links.items`
`nav-menu.quick-links.items.after`


## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

You can now use the added portals as a target for the [@shopgate/user-privacy](https://github.com/shopgate/ext-user-privacy) delete account button. Use the `deleteAccountTarget` config to define a position.