### PR TITLE
Add safe-area inset to modal component

### DIFF
--- a/libraries/common/components/Modal/index.jsx
+++ b/libraries/common/components/Modal/index.jsx
@@ -7,7 +7,7 @@ import styles from './style';
 /**
  * The Modal component.
  * @param {Object} props The component props.
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 const Modal = ({ children, classes }) => (
   <Portal isOpened>

--- a/libraries/common/components/Modal/style.js
+++ b/libraries/common/components/Modal/style.js
@@ -1,4 +1,5 @@
 import { css } from 'glamor';
+import { themeColors } from '@shopgate/pwa-common/helpers/config';
 
 const container = css({
   position: 'fixed',
@@ -16,9 +17,12 @@ const layout = css({
   alignItems: 'center',
   justifyContent: 'center',
   height: '100%',
+  backgroundColor: themeColors.lightOverlay,
 }).toString();
 
 const content = css({
+  paddingTop: 'var(--safe-area-inset-top)',
+  overflowY: 'scroll',
   position: 'relative',
   maxWidth: '100vw',
   maxHeight: '100vh',

--- a/libraries/common/components/Modal/style.js
+++ b/libraries/common/components/Modal/style.js
@@ -22,10 +22,9 @@ const layout = css({
 
 const content = css({
   paddingTop: 'var(--safe-area-inset-top)',
+  paddingBottom: 'var(--safe-area-inset-bottom)',
   overflowY: 'scroll',
   position: 'relative',
-  maxWidth: '100vw',
-  maxHeight: '100vh',
 }).toString();
 
 export default {

--- a/libraries/engage/push-opt-in/components/PushOptInModal/style.js
+++ b/libraries/engage/push-opt-in/components/PushOptInModal/style.js
@@ -7,7 +7,6 @@ const modalContent = css({
 
 const container = css({
   backgroundColor: themeColors.lightOverlay,
-  height: '100vh',
   textAlign: 'center',
   padding: '30px',
   justifyContent: 'center',

--- a/libraries/engage/tracking/components/CookieConsentModal/style.js
+++ b/libraries/engage/tracking/components/CookieConsentModal/style.js
@@ -7,7 +7,6 @@ const modalContent = css({
 
 const container = css({
   backgroundColor: themeColors.lightOverlay,
-  height: '100vh',
   padding: '30px',
   justifyContent: 'center',
   display: 'flex',


### PR DESCRIPTION
# Description

Until now the Modal component did not consider save area insets. Since we use this component for dialogs as well as for the tracking opt in and the cookie consent where we show complex content inside it, we need to implement handling the insets. Additionally the component also needs to handle content that is higher than the viewport.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

