### PR TITLE
Add safe area insets to modal component

### DIFF
--- a/libraries/common/components/Modal/index.jsx
+++ b/libraries/common/components/Modal/index.jsx
@@ -7,7 +7,7 @@ import styles from './style';
 /**
  * The Modal component.
  * @param {Object} props The component props.
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 const Modal = ({ children, classes }) => (
   <Portal isOpened>

--- a/libraries/common/components/Modal/style.js
+++ b/libraries/common/components/Modal/style.js
@@ -1,4 +1,5 @@
 import { css } from 'glamor';
+import { themeColors } from '@shopgate/pwa-common/helpers/config';
 
 const container = css({
   position: 'fixed',
@@ -8,6 +9,7 @@ const container = css({
   right: 0,
   overflow: 'hidden',
   zIndex: 2000,
+  backgroundColor: themeColors.lightOverlay,
 }).toString();
 
 const layout = css({
@@ -22,6 +24,9 @@ const content = css({
   position: 'relative',
   maxWidth: '100vw',
   maxHeight: '100vh',
+  paddingTop: 'var(--safe-area-inset-top)',
+  paddingBottom: 'var(--safe-area-inset-bottom)',
+  overflowY: 'scroll',
 }).toString();
 
 export default {

--- a/libraries/common/components/Modal/style.js
+++ b/libraries/common/components/Modal/style.js
@@ -1,5 +1,4 @@
 import { css } from 'glamor';
-import { themeColors } from '@shopgate/pwa-common/helpers/config';
 
 const container = css({
   position: 'fixed',
@@ -9,7 +8,6 @@ const container = css({
   right: 0,
   overflow: 'hidden',
   zIndex: 2000,
-  backgroundColor: themeColors.lightOverlay,
 }).toString();
 
 const layout = css({


### PR DESCRIPTION
# Description

Until now the Modal component did not consider save area insets. Since we use this component for dialogs and might show complex content inside it, we need to implement handling the insets. Additionally the component also needs to handle content that is higher than the viewport.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

