### PR TITLE
Fixed an issue where "page" widgets where not updated properly after config update

### DIFF
--- a/libraries/common/components/Widgets/index.jsx
+++ b/libraries/common/components/Widgets/index.jsx
@@ -121,7 +121,7 @@ class Widgets extends Component {
           return null;
         }
 
-        const key = `w${index}`;
+        const key = `w${widget?.id || index}`;
 
         if (widget.type === WIDGET_GRID_TYPE) {
           // If it's a grid just create it and pass the child widgets.


### PR DESCRIPTION
# Description
This pull request fixes an issue where "page" widgets where not updated properly in some edge cases after the widget config was updated. The issue occurred due to usage of an array index as React component key.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
