### PR TITLE
Make comfort cookies toggle optional

### DIFF
--- a/libraries/engage/tracking/components/PrivacySettings/index.jsx
+++ b/libraries/engage/tracking/components/PrivacySettings/index.jsx
@@ -28,6 +28,7 @@ const PrivacySettings = ({
       settingsStatisticsTitle,
       settingsRequiredText,
       settingsRequiredTitle,
+      showComfortCookiesToggle,
     } = {},
   } = appConfig;
 
@@ -55,18 +56,20 @@ const PrivacySettings = ({
   return (
     <Grid component="div" className={styles.container}>
       <Grid.Item component="div" className={styles.item}>
-        <Grid.Item component="div" className={styles.switchWrapper}>
-          <Switch
-            onChange={handleChangeComfortCookies}
-            checked={areComfortCookiesSelected}
-            a11yFallbackText={`${i18n.text(settingsComfortTitle || 'cookieSettings.comfortTitle')}. ${i18n.text(settingsComfortText || 'cookieSettings.comfort')}`}
-          >
-            <span className={styles.title}>
-              {<I18n.Text string={settingsComfortTitle || 'cookieSettings.comfortTitle'} />}
-            </span>
-            <span>{<I18n.Text string={settingsComfortText || 'cookieSettings.comfort'} />}</span>
-          </Switch>
-        </Grid.Item>
+        {showComfortCookiesToggle ? (
+          <Grid.Item component="div" className={styles.switchWrapper}>
+            <Switch
+              onChange={handleChangeComfortCookies}
+              checked={areComfortCookiesSelected}
+              a11yFallbackText={`${i18n.text(settingsComfortTitle || 'cookieSettings.comfortTitle')}. ${i18n.text(settingsComfortText || 'cookieSettings.comfort')}`}
+            >
+              <span className={styles.title}>
+                {<I18n.Text string={settingsComfortTitle || 'cookieSettings.comfortTitle'} />}
+              </span>
+              <span>{<I18n.Text string={settingsComfortText || 'cookieSettings.comfort'} />}</span>
+            </Switch>
+          </Grid.Item>
+        ) : null}
         <Grid.Item component="div" className={styles.switchWrapper}>
           <Switch
             onChange={handleChangeStatisticsCookies}

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -656,6 +656,7 @@
         "modalImageURL": null,
         "modalImageSVG": null,
         "showRequiredCookiesButton": false,
+        "showComfortCookiesToggle": false,
         "settingsComfortText": null,
         "settingsComfortTitle": null,
         "settingsStatisticsText": null,

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -666,6 +666,7 @@
         "modalImageURL": null,
         "modalImageSVG": null,
         "showRequiredCookiesButton": false,
+        "showComfortCookiesToggle": false,
         "settingsComfortText": null,
         "settingsComfortTitle": null,
         "settingsStatisticsText": null,


### PR DESCRIPTION
# Description

On the privacy settings screen, the toggle to select comfort cookies for tracking is now optional as not all merchant would use this type of tracking. It can be configured via the merchant settings.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

