### PR TITLE
Converted inventories Redux actions to mutable actions

### DIFF
--- a/libraries/commerce/favorites/actions/fetchFavorites.js
+++ b/libraries/commerce/favorites/actions/fetchFavorites.js
@@ -44,11 +44,11 @@ function fetchFavorites(ignoreCache = false, listId = undefined) {
 
     try {
       const result = await request;
-      dispatch(receiveFavorites(result.items, timestamp, takenListId));
       dispatch(receiveProducts({
         products: result.items.map(({ product }) => product),
         fetchInventory: false,
       }));
+      dispatch(receiveFavorites(result.items, timestamp, takenListId));
       return result;
     } catch (err) {
       dispatch(errorFetchFavorites(err, takenListId));

--- a/libraries/common/helpers/redux/mutable.js
+++ b/libraries/common/helpers/redux/mutable.js
@@ -62,8 +62,9 @@ export const mutableActions = {
 
 /**
  * Takes a function and makes it mutable.
- * @param {Function} func Original function to convert to a mutable
- * @returns {Function}
+ * @template {Function} T
+ * @param {T} func Original function to convert to a mutable
+ * @returns {T}
  */
 export const mutable = (func) => {
   const original = func;

--- a/libraries/engage/locations/actions/fetchFulfillmentSlots.js
+++ b/libraries/engage/locations/actions/fetchFulfillmentSlots.js
@@ -1,11 +1,14 @@
 import PipelineRequest from '@shopgate/pwa-core/classes/PipelineRequest';
+import { mutable } from '@shopgate/pwa-common/helpers/redux';
 import {
   FETCH_FULFILLMENT_SLOTS_ERROR,
   FETCH_FULFILLMENT_SLOTS_SUCCESS,
 } from '../constants/ActionTypes';
 
 /**
- * @param {Object} params params.
+ * Fetches fulfillment slots of a location
+ * @param {Object} params Function params
+ * @param {string} params.locationCode A location code
  * @returns {Function} A redux thunk.
  */
 function fetchFulfillmentSlots({ locationCode }) {
@@ -32,4 +35,5 @@ function fetchFulfillmentSlots({ locationCode }) {
   };
 }
 
-export default fetchFulfillmentSlots;
+/** @mixes {MutableFunction} */
+export default mutable(fetchFulfillmentSlots);

--- a/libraries/engage/locations/actions/fetchFulfillmentSlots.js
+++ b/libraries/engage/locations/actions/fetchFulfillmentSlots.js
@@ -3,7 +3,7 @@ import { mutable } from '@shopgate/pwa-common/helpers/redux';
 import {
   FETCH_FULFILLMENT_SLOTS_ERROR,
   FETCH_FULFILLMENT_SLOTS_SUCCESS,
-} from '../constants/ActionTypes';
+} from '../constants';
 
 /**
  * Fetches fulfillment slots of a location

--- a/libraries/engage/locations/actions/fetchInventories.js
+++ b/libraries/engage/locations/actions/fetchInventories.js
@@ -1,5 +1,6 @@
 import { logger } from '@shopgate/pwa-core/helpers';
 import PipelineRequest from '@shopgate/pwa-core/classes/PipelineRequest';
+import { mutable } from '@shopgate/pwa-common/helpers/redux';
 import {
   requestInventories,
   receiveInventories,
@@ -9,21 +10,22 @@ import { SHOPGATE_STOREFRONT_GET_INVENTORIES } from '../constants';
 import { getPreferredLocation } from '../selectors';
 
 /**
- * @param {string} productCodes The product IDs to fetch inventories for.
- * @param {string} [locationCode] locationCode.
+ * Fetches location inventory for a list of products.
+ * @param {string[]} productCodes The product IDs to fetch inventories for.
+ * @param {string} [locationCode] A location code
  * @returns {Function} A redux thunk.
  */
 function fetchInventories(productCodes, locationCode = null) {
   return (dispatch, getState) => {
     if (!productCodes || !productCodes.length) {
-      return;
+      return undefined;
     }
 
     const state = getState();
 
     const locationFilter = locationCode || getPreferredLocation(state)?.code;
     if (!locationFilter) {
-      return;
+      return undefined;
     }
 
     const filters = {
@@ -52,4 +54,5 @@ function fetchInventories(productCodes, locationCode = null) {
   };
 }
 
-export default fetchInventories;
+/** @mixes {MutableFunction} */
+export default mutable(fetchInventories);

--- a/libraries/engage/locations/actions/fetchLocations.js
+++ b/libraries/engage/locations/actions/fetchLocations.js
@@ -1,5 +1,6 @@
 import { logger } from '@shopgate/pwa-core/helpers';
 import PipelineRequest from '@shopgate/pwa-core/classes/PipelineRequest';
+import { mutable } from '@shopgate/pwa-common/helpers/redux';
 import {
   requestLocations,
   receiveLocations,
@@ -8,7 +9,22 @@ import {
 import { SHOPGATE_STOREFRONT_GET_LOCATIONS } from '../constants';
 
 /**
- * @param {Object} params params.
+ * Returns a list of locations based on search options & defaults. Including geographical radial
+ * distance & other merchant configurations
+ * @param {Object} params Function params
+ * @param {string} [params.postalCode] A postal code
+ * @param {string} [params.countryCode] Indicates to which country the postal code belongs.
+ * Is required if the postalCode parameter is set
+ * @param {Object} [params.geolocation] A geolocation object
+ * @param {string} params.geolocation.longitude Longitude to search by coordinates. Works only in
+ * combination with radius and latitude.
+ * @param {string} params.geolocation.latitude Latitude to search by coordinates. Works only in
+ * combination with radius and longitude.
+ * @param {number} [params.radius] Used only with geolocation.longitude & geolocation.latitude.
+ * @param {string[]} [params.codes] Search by location codes. This cannot be combined with
+ * coordinate search or a postal code search
+ * @param {boolean} [params.enableInLocationFinder=false] When set to `true` only locations are
+ * returned which are enabled for the location finder.
  * @returns {Function} A redux thunk.
  */
 function fetchLocations(params) {
@@ -53,4 +69,5 @@ function fetchLocations(params) {
   };
 }
 
-export default fetchLocations;
+/** @mixes {MutableFunction} */
+export default mutable(fetchLocations);

--- a/libraries/engage/locations/actions/fetchProductInventories.js
+++ b/libraries/engage/locations/actions/fetchProductInventories.js
@@ -1,5 +1,6 @@
 import { logger } from '@shopgate/pwa-core/helpers';
 import PipelineRequest from '@shopgate/pwa-core/classes/PipelineRequest';
+import { mutable } from '@shopgate/pwa-common/helpers/redux';
 import {
   requestProductInventories,
   receiveProductInventories,
@@ -8,8 +9,10 @@ import {
 import { SHOPGATE_STOREFRONT_GET_PRODUCT_INVENTORIES } from '../constants';
 
 /**
+ * Fetches inventories for a product
  * @param {string} productCode The product ID to fetch inventories for.
  * @param {Object} [params={}] Optional params for the inventories request.
+ * @param {string[]} params.locationCodes A list of location codes.
  * @returns {Function} A redux thunk.
  */
 function fetchProductInventories(productCode, params = {}) {
@@ -40,4 +43,5 @@ function fetchProductInventories(productCode, params = {}) {
   };
 }
 
-export default fetchProductInventories;
+/** @mixes {MutableFunction} */
+export default mutable(fetchProductInventories);

--- a/libraries/engage/locations/actions/fetchProductLocations.js
+++ b/libraries/engage/locations/actions/fetchProductLocations.js
@@ -1,4 +1,5 @@
 import PipelineRequest from '@shopgate/pwa-core/classes/PipelineRequest';
+import { mutable } from '@shopgate/pwa-common/helpers/redux';
 import {
   requestProductLocations,
   receiveProductLocations,
@@ -7,8 +8,15 @@ import {
 import { SHOPGATE_STOREFRONT_GET_PRODUCT_LOCATIONS } from '../constants';
 
 /**
+ * Returns a list of locations and item availability for a given product
  * @param {string} productCode The product ID to fetch locations for.
  * @param {Object} [params={}] Optional params for the location request.
+ * @param {string} [params.postalCode] A postal code
+ * @param {Object} [params.geolocation] A geolocation object
+ * @param {string} params.geolocation.longitude Longitude to search by coordinates. Works only in
+ * combination with latitude.
+ * @param {string} params.geolocation.latitude Latitude to search by coordinates. Works only in
+ * combination with longitude.
  * @returns {Function} A redux thunk.
  */
 function fetchProductLocations(productCode, params = {}) {
@@ -47,4 +55,5 @@ function fetchProductLocations(productCode, params = {}) {
   };
 }
 
-export default fetchProductLocations;
+/** @mixes {MutableFunction} */
+export default mutable(fetchProductLocations);

--- a/libraries/engage/locations/actions/index.js
+++ b/libraries/engage/locations/actions/index.js
@@ -1,6 +1,9 @@
 import { SET_LOCATIONS_PENDING } from '../constants/ActionTypes';
 
+export { default as fetchFulfillmentSlots } from './fetchFulfillmentSlots';
+export { default as fetchInventories } from './fetchInventories';
 export { default as fetchLocations } from './fetchLocations';
+export { default as fetchProductInventories } from './fetchProductInventories';
 export { default as fetchProductLocations } from './fetchProductLocations';
 export { default as submitReservation } from './submitReservation';
 export { default as setUserSearchGeolocation } from './setUserSearchGeolocation';

--- a/libraries/engage/locations/actions/submitReservation.js
+++ b/libraries/engage/locations/actions/submitReservation.js
@@ -1,5 +1,6 @@
 import { logger } from '@shopgate/pwa-core/helpers';
 import PipelineRequest from '@shopgate/pwa-core/classes/PipelineRequest';
+import { mutable } from '@shopgate/pwa-common/helpers/redux';
 import {
   submitReservationRequest,
   submitReservationSuccess,
@@ -44,4 +45,5 @@ function submitReservation(values, product) {
   };
 }
 
-export default submitReservation;
+/** @mixes {MutableFunction} */
+export default mutable(submitReservation);

--- a/libraries/engage/product/hocs/withProductListEntryProduct.jsx
+++ b/libraries/engage/product/hocs/withProductListEntryProduct.jsx
@@ -8,12 +8,12 @@ import { getProduct } from '../selectors/product';
  * property name can be configured via the HOC options.
  * @param {Function} WrappedComponent The react component to wrap.
  * @param {Object} [options={}] Options for the HOC.
- * @param {string} [options.prop="productListEntryProduct"] An optional prop name to inject the
+ * @param {string} [options.prop="product"] An optional prop name to inject the
  * product into the wrapped component.
  * @returns {JSX}
  */
 export default function withProductListEntryProduct(WrappedComponent, options = {}) {
-  const injectedProp = options.prop || 'productListEntryProduct';
+  const injectedProp = options.prop || 'product';
   /**
    * @return {Function} The extended component props.
    */

--- a/libraries/engage/product/hocs/withProductListEntryProduct.jsx
+++ b/libraries/engage/product/hocs/withProductListEntryProduct.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import withProductListEntry from './withProductListEntry';
+import { getProduct } from '../selectors/product';
+
+/**
+ * Injects the product from the ProductListEntryContext into the wrapped component. The product
+ * property name can be configured via the HOC options.
+ * @param {Function} WrappedComponent The react component to wrap.
+ * @param {Object} [options={}] Options for the HOC.
+ * @param {string} [options.prop="productListEntryProduct"] An optional prop name to inject the
+ * product into the wrapped component.
+ * @returns {JSX}
+ */
+export default function withProductListEntryProduct(WrappedComponent, options = {}) {
+  const injectedProp = options.prop || 'productListEntryProduct';
+  /**
+   * @return {Function} The extended component props.
+   */
+  const makeMapStateToProps = () => (state, props) => {
+    const propProductId = props?.product?.id;
+    const productListEntryProductId = props?.productListEntry?.productId;
+
+    // Only select a new product from Redux when the current props don't contain a product yet
+    const selectNewProduct =
+      typeof propProductId === 'undefined' ||
+      propProductId !== productListEntryProductId;
+
+    return {
+      [injectedProp]: selectNewProduct
+        ? getProduct(state, { productId: productListEntryProductId })
+        : props.product,
+    };
+  };
+
+  const connector = connect(makeMapStateToProps);
+
+  return (props) => {
+    const Connected = withProductListEntry(connector(WrappedComponent));
+
+    return (<Connected {...props} />);
+  };
+}

--- a/libraries/engage/product/hocs/withProductListEntryProduct.jsx
+++ b/libraries/engage/product/hocs/withProductListEntryProduct.jsx
@@ -10,7 +10,7 @@ import { getProduct } from '../selectors/product';
  * @param {Object} [options={}] Options for the HOC.
  * @param {string} [options.prop="product"] An optional prop name to inject the
  * product into the wrapped component.
- * @returns {JSX}
+ * @returns {Function}
  */
 export default function withProductListEntryProduct(WrappedComponent, options = {}) {
   const injectedProp = options.prop || 'product';

--- a/libraries/engage/product/index.js
+++ b/libraries/engage/product/index.js
@@ -93,6 +93,7 @@ export { default as withProductStock } from './hocs/withProductStock';
 export { default as withProduct } from './hocs/withProduct';
 export { default as withProductListType } from './hocs/withProductListType';
 export { default as withProductListEntry } from './hocs/withProductListEntry';
+export { default as withProductListEntryProduct } from './hocs/withProductListEntryProduct';
 
 // HOOKs
 export { useLoadProductImage } from './hooks/useLoadProductImage';


### PR DESCRIPTION
# Description
Within this ticket converts all Redux actions which are related to inventories to "mutable" actions. From now on extensions can modify action parameters before the actual pipeline request happens.

Additionally a new HOC called `withProductListEntryProduct` was added to `engage/product` which injects the product entity from the `ProductListEntryContext` into the wrapped component.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
