### PR TITLE
Fixed an issue with the historyReplace router action

### DIFF
--- a/libraries/common/actions/router/historyReplace.js
+++ b/libraries/common/actions/router/historyReplace.js
@@ -5,11 +5,28 @@ import { mutable } from '../../helpers/redux';
 /**
  * @mixes {MutableFunction}
  * @param {Object} params The history params.
+ * @param {Object} [options={}] Additional options for the action
+ * @param {boolean} [options.remountRoute=true] When set to "true", the target route will be forced
+ * to remount.
  * @return {Function} The dispatched action.
  */
-export const historyReplace = mutable(params => (dispatch) => {
+export const historyReplace = mutable((params, options = {}) => (dispatch) => {
   dispatch(navigate({
     ...params,
+    ...(options?.remountRoute !== false && {
+      state: {
+        ...params.state,
+        /**
+         * When a route is "replaced" the router doesn't assign a new route id to the old route
+         * stack entry. This can cause issues when a route is replaced by itself, since the content
+         * will not remount out of the box.
+         *
+         * When the "replaceRouteId" state prop is injected, the Route component performs logic
+         * to enforce re-remounting routes which where replaced by itself.
+         */
+        replaceRouteId: Math.random().toString(36).substring(2, 7),
+      },
+    }),
     action: ACTION_REPLACE,
   }));
 });

--- a/libraries/common/components/Link/connector.js
+++ b/libraries/common/components/Link/connector.js
@@ -2,8 +2,8 @@ import { connect } from 'react-redux';
 import { historyPush, historyReplace } from '../../actions/router';
 
 const mapDispatchToProps = {
-  historyPush: params => historyPush(params),
-  historyReplace: params => historyReplace(params),
+  historyPush,
+  historyReplace,
 };
 
 export default connect(null, mapDispatchToProps);

--- a/libraries/common/components/Route/index.jsx
+++ b/libraries/common/components/Route/index.jsx
@@ -70,10 +70,19 @@ class Route extends React.Component {
       const { setPattern, ...context } = route;
       context.open = true;
       context.visible = route.id === this.currentRoute.id;
+      /**
+       * When a route is "replaced" the router doesn't assign a new route id to the old route
+       * stack entry. This can cause issues when a route is replaced by itself, since the content
+       * will not remount out of the box.
+       *
+       * The "replaceRouteId" state prop is injected by the "historyReplace" action. It's used
+       * to enforce re-remounting routes which where replaced by itself.
+       */
+      const replaceRouteId = context?.state?.replaceRouteId || '';
 
       return (
-        <ErrorBoundary key={`error.${route.id}`}>
-          <RouteContext.Provider key={route.id} value={context}>
+        <ErrorBoundary key={`error.${route.id}_${replaceRouteId}`}>
+          <RouteContext.Provider key={`${route.id}_${replaceRouteId}`} value={context}>
             <Suspense fallback={<Loading />}>
               <Component />
             </Suspense>

--- a/libraries/common/helpers/redux/mutable.js
+++ b/libraries/common/helpers/redux/mutable.js
@@ -62,8 +62,9 @@ export const mutableActions = {
 
 /**
  * Takes a function and makes it mutable.
- * @param {Function} func Original function to convert to a mutable
- * @returns {Function}
+ * @template {Function} T
+ * @param {T} func Original function to convert to a mutable
+ * @returns {T}
  */
 export const mutable = (func) => {
   const original = func;


### PR DESCRIPTION
# Description
This ticket fixes an issue that occurred when a route was replaced by its own via the `historyReplace` action. Till now the Route and the underlying components where just updated, but didn't remount.

From now on the Route and its content components will remount to prevents issues where internal states of the route where messed up, since they where not properly reset.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
