### PR TITLE
Fixed an issue with getCart pipelines that don't deliver "isOrderable" and "isTaxIncluded" properties

### DIFF
--- a/libraries/commerce/cart/reducers/index.js
+++ b/libraries/commerce/cart/reducers/index.js
@@ -64,6 +64,10 @@ export default (state = defaultState, action) => {
       return {
         ...state,
         ...cart,
+        // Map cart flags to properties on root level to establish compatibility with getCart
+        // pipelines that don't return "isOrderable" and "isTaxIncluded" flags
+        isOrderable: cart?.flags?.orderable ?? true,
+        isTaxIncluded: cart?.flags?.taxIncluded ?? true,
         expires: 0,
         items: cartItems,
         isFetching: false,


### PR DESCRIPTION
# Description
This ticket fixes an issue where checkout wasn't possible due to missing `isOrderable` and `isTaxIncluded` properties in `getCart` pipeline response.
As a solution, comparable property values from the `flags` object are mapped to the missing properties within the cart reducer. 

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

