### PR TITLE
Add meta property to ProductListProvider

### DIFF
--- a/libraries/engage/product/providers/ProductListType/context.js
+++ b/libraries/engage/product/providers/ProductListType/context.js
@@ -20,11 +20,13 @@ export {};
  * @property {ProductListTypeContextSubType} [subType=null] Optional sub type of the active
  * ProductListTypeContext. Depending on its usage it can make a statement about in which context
  * the product list is used e.g. "widgets".
+ * @property {Object} [meta=null] Optional meta information that can be used by child components
  */
 export {};
 
 export default React.createContext({
   type: null,
   subType: null,
+  meta: null,
 });
 

--- a/libraries/engage/product/providers/ProductListType/index.jsx
+++ b/libraries/engage/product/providers/ProductListType/index.jsx
@@ -14,17 +14,20 @@ import Context from './context';
  * @param {string} param.type Type of the context e.g. "productSlider" or "productGrid".
  * @param {string} param.subType Optional sub type of the context. Depending on its usage it can
  * make a statement about in which context the product list is used e.g. "widgets".
+ * @param {Object} param.meta Optional meta information that can be used by child components
  * @returns {JSX}
  */
 function ProductListTypeProvider({
   children,
   type,
   subType,
+  meta,
 }) {
   const value = useMemo(() => ({
     type,
     subType,
-  }), [subType, type]);
+    meta,
+  }), [meta, subType, type]);
 
   return (
     <Context.Provider value={value}>
@@ -36,13 +39,14 @@ function ProductListTypeProvider({
 ProductListTypeProvider.propTypes = {
   type: PropTypes.string.isRequired,
   children: PropTypes.node,
+  meta: PropTypes.shape({}),
   subType: PropTypes.string,
 };
 
 ProductListTypeProvider.defaultProps = {
   children: null,
   subType: null,
+  meta: null,
 };
 
 export default ProductListTypeProvider;
-

--- a/libraries/engage/product/providers/ProductListType/index.jsx
+++ b/libraries/engage/product/providers/ProductListType/index.jsx
@@ -39,7 +39,7 @@ function ProductListTypeProvider({
 ProductListTypeProvider.propTypes = {
   type: PropTypes.string.isRequired,
   children: PropTypes.node,
-  meta: PropTypes.shape({}),
+  meta: PropTypes.shape(),
   subType: PropTypes.string,
 };
 

--- a/themes/theme-gmd/components/ProductSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/components/ProductSlider/__snapshots__/spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<ProductSlider /> should match snapshot 1`] = `
 <ProductListTypeProvider
+  meta={null}
   subType={null}
   type="productSlider"
 >

--- a/themes/theme-gmd/components/ProductSlider/index.jsx
+++ b/themes/theme-gmd/components/ProductSlider/index.jsx
@@ -68,7 +68,7 @@ ProductSlider.propTypes = {
    * and is intended as a description in which "context" the component is used.
    * @default null
    */
-  meta: PropTypes.shape({}),
+  meta: PropTypes.shape(),
   scope: PropTypes.string,
   slidesPerView: PropTypes.number,
   snap: PropTypes.bool,

--- a/themes/theme-gmd/components/ProductSlider/index.jsx
+++ b/themes/theme-gmd/components/ProductSlider/index.jsx
@@ -20,6 +20,7 @@ function ProductSlider(props) {
     productIds,
     snap,
     scope,
+    meta,
   } = props;
 
   const widgetSetting = useWidgetSettings(WIDGET_ID) || {};
@@ -30,7 +31,7 @@ function ProductSlider(props) {
       {({ ProductCard }) => {
         const Item = props.item || ProductCard;
         return (
-          <ProductListTypeProvider type="productSlider" subType={scope}>
+          <ProductListTypeProvider type="productSlider" subType={scope} meta={meta}>
             <Swiper
               autoPlay={autoplay}
               className={className}
@@ -67,6 +68,7 @@ ProductSlider.propTypes = {
    * and is intended as a description in which "context" the component is used.
    * @default null
    */
+  meta: PropTypes.shape({}),
   scope: PropTypes.string,
   slidesPerView: PropTypes.number,
   snap: PropTypes.bool,
@@ -80,6 +82,7 @@ ProductSlider.defaultProps = {
   slidesPerView: null,
   snap: false,
   scope: null,
+  meta: null,
 };
 
 export default ProductSlider;

--- a/themes/theme-gmd/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-gmd/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
@@ -43,6 +43,7 @@ exports[`<ProductCardRender /> should not render the discount badge when the is 
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -589,6 +590,7 @@ exports[`<ProductCardRender /> should not render the rating stars when there is 
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -858,6 +860,7 @@ exports[`<ProductCardRender /> should render as expected 1`] = `
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -1474,6 +1477,7 @@ exports[`<ProductCardRender /> should render with one row for the product name 1
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -2090,6 +2094,7 @@ exports[`<ProductCardRender /> should render without name 1`] = `
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -2691,6 +2696,7 @@ exports[`<ProductCardRender /> should render without prices 1`] = `
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -3162,6 +3168,7 @@ exports[`<ProductCardRender /> should render without rating 1`] = `
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link

--- a/themes/theme-gmd/themeApi/ProductCard/components/Render/index.jsx
+++ b/themes/theme-gmd/themeApi/ProductCard/components/Render/index.jsx
@@ -8,6 +8,7 @@ import {
   OrderQuantityHint,
   ProductImage,
   ProductBadges,
+  useProductListType,
 } from '@shopgate/engage/product';
 import Link from '@shopgate/pwa-common/components/Link';
 import RatingStars from '@shopgate/pwa-ui-shared/RatingStars';
@@ -44,9 +45,17 @@ function ProductCardRender({
   } = product;
 
   const { ListImage: gridResolutions } = getProductImageSettings();
+  const productListContext = useProductListType();
 
   return (
-    <Link tagName="a" href={url}>
+    <Link
+      tagName="a"
+      href={url}
+      state={{
+        isRecommendation: productListContext?.subType?.isRecommendation,
+        recommendationScope: productListContext?.subType?.recommendationScope,
+      }}
+    >
 
       {isBeta() && featuredMedia
         ? <FeaturedMedia

--- a/themes/theme-gmd/themeApi/ProductCard/components/Render/index.jsx
+++ b/themes/theme-gmd/themeApi/ProductCard/components/Render/index.jsx
@@ -45,15 +45,14 @@ function ProductCardRender({
   } = product;
 
   const { ListImage: gridResolutions } = getProductImageSettings();
-  const productListContext = useProductListType();
+  const { meta } = useProductListType();
 
   return (
     <Link
       tagName="a"
       href={url}
       state={{
-        isRecommendation: productListContext?.subType?.isRecommendation,
-        recommendationScope: productListContext?.subType?.recommendationScope,
+        ...meta,
       }}
     >
 

--- a/themes/theme-gmd/themeApi/ProductCard/components/Render/index.spec.jsx
+++ b/themes/theme-gmd/themeApi/ProductCard/components/Render/index.spec.jsx
@@ -21,6 +21,7 @@ jest.mock('@shopgate/engage/product', () => ({
   ProductName: ({ name }) => name,
   ProductDiscountBadge: () => null,
   ProductBadges: ({ children }) => children,
+  useProductListType: jest.fn(() => ({ meta: null })),
 }));
 jest.mock('@shopgate/engage/components');
 jest.mock('@shopgate/engage/category', () => ({

--- a/themes/theme-gmd/widgets/Liveshopping/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/widgets/Liveshopping/__snapshots__/spec.jsx.snap
@@ -12,6 +12,7 @@ exports[`<LiveshoppingWidget /> should render the widget with a slider for multi
   data-test-id="liveShoppingWidget"
 >
   <ProductListTypeProvider
+    meta={null}
     subType="widgets"
     type="liveshopping"
   >
@@ -73,6 +74,7 @@ exports[`<LiveshoppingWidget /> should render the widget with no slider for one 
   data-test-id="liveShoppingWidget"
 >
   <ProductListTypeProvider
+    meta={null}
     subType="widgets"
     type="liveshopping"
   >

--- a/themes/theme-ios11/components/ProductSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/components/ProductSlider/__snapshots__/spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<ProductSlider /> should match snapshot 1`] = `
 <ProductListTypeProvider
+  meta={null}
   subType={null}
   type="productSlider"
 >

--- a/themes/theme-ios11/components/ProductSlider/index.jsx
+++ b/themes/theme-ios11/components/ProductSlider/index.jsx
@@ -20,6 +20,7 @@ function ProductSlider(props) {
     productIds,
     snap,
     scope,
+    meta,
   } = props;
 
   const widgetSettings = useWidgetSettings(WIDGET_ID) || {};
@@ -30,7 +31,7 @@ function ProductSlider(props) {
       {({ ProductCard }) => {
         const Item = props.item || ProductCard;
         return (
-          <ProductListTypeProvider type="productSlider" subType={scope}>
+          <ProductListTypeProvider type="productSlider" subType={scope} meta={meta}>
             <Swiper
               autoPlay={autoplay}
               className={className}
@@ -67,6 +68,7 @@ ProductSlider.propTypes = {
    * and is intended as a description in which "context" the component is used.
    * @default null
    */
+  meta: PropTypes.shape({}),
   scope: PropTypes.string,
   slidesPerView: PropTypes.number,
   snap: PropTypes.bool,
@@ -80,6 +82,7 @@ ProductSlider.defaultProps = {
   slidesPerView: null,
   snap: false,
   scope: null,
+  meta: null,
 };
 
 export default ProductSlider;

--- a/themes/theme-ios11/components/ProductSlider/index.jsx
+++ b/themes/theme-ios11/components/ProductSlider/index.jsx
@@ -68,7 +68,7 @@ ProductSlider.propTypes = {
    * and is intended as a description in which "context" the component is used.
    * @default null
    */
-  meta: PropTypes.shape({}),
+  meta: PropTypes.shape(),
   scope: PropTypes.string,
   slidesPerView: PropTypes.number,
   snap: PropTypes.bool,

--- a/themes/theme-ios11/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/themeApi/ProductCard/components/Render/__snapshots__/index.spec.jsx.snap
@@ -43,6 +43,7 @@ exports[`<ProductCardRender /> should not render the discount badge when the is 
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -589,6 +590,7 @@ exports[`<ProductCardRender /> should not render the rating stars when there is 
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -858,6 +860,7 @@ exports[`<ProductCardRender /> should render as expected 1`] = `
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -1474,6 +1477,7 @@ exports[`<ProductCardRender /> should render with one row for the product name 1
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -2090,6 +2094,7 @@ exports[`<ProductCardRender /> should render without name 1`] = `
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -2691,6 +2696,7 @@ exports[`<ProductCardRender /> should render without prices 1`] = `
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link
@@ -3162,6 +3168,7 @@ exports[`<ProductCardRender /> should render without rating 1`] = `
   >
     <Connect(Link)
       href="/some/url"
+      state={Object {}}
       tagName="a"
     >
       <Link

--- a/themes/theme-ios11/themeApi/ProductCard/components/Render/index.jsx
+++ b/themes/theme-ios11/themeApi/ProductCard/components/Render/index.jsx
@@ -8,6 +8,7 @@ import {
   OrderQuantityHint,
   ProductImage,
   ProductBadges,
+  useProductListType,
 } from '@shopgate/engage/product';
 import Link from '@shopgate/pwa-common/components/Link';
 import RatingStars from '@shopgate/pwa-ui-shared/RatingStars';
@@ -44,9 +45,17 @@ function ProductCardRender({
   } = product;
 
   const { ListImage: gridResolutions } = getProductImageSettings();
+  const productListContext = useProductListType();
 
   return (
-    <Link tagName="a" href={url}>
+    <Link
+      tagName="a"
+      href={url}
+      state={{
+        isRecommendation: productListContext?.subType?.isRecommendation,
+        recommendationScope: productListContext?.subType?.recommendationScope,
+      }}
+    >
 
       {isBeta() && featuredMedia
         ? <FeaturedMedia

--- a/themes/theme-ios11/themeApi/ProductCard/components/Render/index.jsx
+++ b/themes/theme-ios11/themeApi/ProductCard/components/Render/index.jsx
@@ -45,15 +45,14 @@ function ProductCardRender({
   } = product;
 
   const { ListImage: gridResolutions } = getProductImageSettings();
-  const productListContext = useProductListType();
+  const { meta } = useProductListType();
 
   return (
     <Link
       tagName="a"
       href={url}
       state={{
-        isRecommendation: productListContext?.subType?.isRecommendation,
-        recommendationScope: productListContext?.subType?.recommendationScope,
+        ...meta,
       }}
     >
 

--- a/themes/theme-ios11/themeApi/ProductCard/components/Render/index.spec.jsx
+++ b/themes/theme-ios11/themeApi/ProductCard/components/Render/index.spec.jsx
@@ -21,6 +21,7 @@ jest.mock('@shopgate/engage/product', () => ({
   ProductName: ({ name }) => name,
   ProductDiscountBadge: () => null,
   ProductBadges: ({ children }) => children,
+  useProductListType: jest.fn(() => ({ meta: null })),
 }));
 jest.mock('@shopgate/engage/components');
 jest.mock('@shopgate/engage/category', () => ({

--- a/themes/theme-ios11/widgets/Liveshopping/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/widgets/Liveshopping/__snapshots__/spec.jsx.snap
@@ -30,6 +30,7 @@ exports[`<LiveshoppingWidget /> should render the widget with a slider for multi
     zoom={false}
   >
     <ProductListTypeProvider
+      meta={null}
       subType="widgets"
       type="liveshopping"
     >
@@ -72,6 +73,7 @@ exports[`<LiveshoppingWidget /> should render the widget with no slider for one 
   data-test-id="liveShoppingWidget"
 >
   <ProductListTypeProvider
+    meta={null}
     subType="widgets"
     type="liveshopping"
   >


### PR DESCRIPTION
# Description

Add a new property "meta" to the ProductListTypeProvider.
Links in the ProductCard are now enriched with this meta data.

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
 
Needs ext-dynamic-yield and ext-product-recommendations extension. Click on a recommended product and check if tracking request is send.
