### PR TITLE
Fixed some cookie consents bugs with UI and navigation

### DIFF
--- a/libraries/engage/tracking/actions/cookieConsent.js
+++ b/libraries/engage/tracking/actions/cookieConsent.js
@@ -22,7 +22,6 @@ export const acceptAllCookies = () => async (dispatch) => {
   }));
 
   dispatch(hideCookieConsentModal());
-  dispatch(historyPush({ pathname: '/' }));
 };
 
 /**
@@ -49,7 +48,6 @@ export const acceptSelectedCookies = ({
   }));
 
   dispatch(hideCookieConsentModal());
-  dispatch(historyPush({ pathname: '/' }));
 };
 
 /**

--- a/libraries/engage/tracking/streams/cookieConsent.js
+++ b/libraries/engage/tracking/streams/cookieConsent.js
@@ -20,6 +20,28 @@ const cookieConsentSetInternal$ = main$.filter(({ action }) => (
 export const cookieConsentInitialized$ = cookieConsentSetInternal$.first();
 
 /**
+ * Gets triggered when the cookie consent was initialized / handled by user. In that case
+ * the UPDATE_COOKIE_CONSENT action is dispatched. When handled automatically the
+ * COOKIE_CONSENT_HANDLED action is dispatched.
+ */
+export const cookieConsentInitializedByUserInternal$ = cookieConsentInitialized$
+  .filter(({ action }) => action.type === UPDATE_COOKIE_CONSENT);
+
+/**
+ * Gets triggered when the user interacted with the buttons on the privacy settings page,
+ * but no settings was changed. Needed to navigate back to the previous page.
+ * When a setting was changed, the "cookieConsentUpdated$" stream triggers which will cause
+ * an app reload.
+ * @type {Observable}
+ */
+export const privacySettingsConfirmedWithoutChangeInternal$ = cookieConsentSetInternal$
+  .pairwise()
+  .filter(([{ action: actionPrev }, { action: actionCurrent }]) =>
+    actionPrev.comfortCookiesAccepted === actionCurrent.comfortCookiesAccepted
+    && actionPrev.statisticsCookiesAccepted === actionCurrent.statisticsCookiesAccepted)
+  .switchMap(([, latest]) => Observable.of(latest));
+
+/**
  * Gets triggered when cookie consent settings changed after initialization
  * @type {Observable}
  */

--- a/libraries/engage/tracking/streams/cookieConsent.spec.js
+++ b/libraries/engage/tracking/streams/cookieConsent.spec.js
@@ -8,6 +8,8 @@ import {
 import {
   cookieConsentSet$,
   cookieConsentInitialized$,
+  cookieConsentInitializedByUserInternal$,
+  privacySettingsConfirmedWithoutChangeInternal$,
   cookieConsentUpdated$,
   comfortCookiesAccepted$,
   statisticsCookiesAccepted$,
@@ -116,6 +118,94 @@ describe('Cookie Consent Streams', () => {
       }));
 
       expect(subscriber).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cookieConsentInitializedByUserInternal$', () => {
+    beforeEach(() => {
+      subscription = cookieConsentInitializedByUserInternal$.subscribe(subscriber);
+    });
+
+    it('should emit when cookie consent was initially handled by user', () => {
+      dispatch(updateCookieConsent({}));
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      dispatch(updateCookieConsent({}));
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      dispatch(handleCookieConsent({}));
+      expect(subscriber).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not emit when cookie consent was initially handled by system', () => {
+      dispatch(handleCookieConsent({}));
+      expect(subscriber).not.toBeCalled();
+      dispatch(handleCookieConsent({}));
+      expect(subscriber).not.toBeCalled();
+      dispatch(updateCookieConsent({}));
+      expect(subscriber).not.toBeCalled();
+    });
+  });
+
+  describe('privacySettingsConfirmedWithoutChangeInternal$', () => {
+    beforeEach(() => {
+      subscription = privacySettingsConfirmedWithoutChangeInternal$.subscribe(subscriber);
+    });
+
+    it('should only emit when privacy settings where confirmed without change', () => {
+      // Initial call - invoked by consent modal or when app started and consent was already given
+      dispatch(updateCookieConsent({
+        comfortCookiesAccepted: true,
+        statisticsCookiesAccepted: false,
+      }));
+
+      expect(subscriber).not.toBeCalled();
+
+      // Next call -> settings changed
+      dispatch(updateCookieConsent({
+        comfortCookiesAccepted: true,
+        statisticsCookiesAccepted: true,
+      }));
+
+      expect(subscriber).not.toBeCalled();
+
+      // Next call -> settings changed
+      dispatch(updateCookieConsent({
+        comfortCookiesAccepted: false,
+        statisticsCookiesAccepted: true,
+      }));
+
+      expect(subscriber).not.toBeCalled();
+
+      // Next call -> nothing changed - should emit
+      dispatch(updateCookieConsent({
+        comfortCookiesAccepted: false,
+        statisticsCookiesAccepted: true,
+      }));
+
+      expect(subscriber).toHaveBeenCalledTimes(1);
+
+      // Next call -> nothing changed - should emit
+      dispatch(updateCookieConsent({
+        comfortCookiesAccepted: false,
+        statisticsCookiesAccepted: true,
+      }));
+
+      expect(subscriber).toHaveBeenCalledTimes(2);
+
+      // Next call -> settings changed
+      dispatch(updateCookieConsent({
+        comfortCookiesAccepted: true,
+        statisticsCookiesAccepted: true,
+      }));
+
+      expect(subscriber).toHaveBeenCalledTimes(2);
+
+      // Next call ->  nothing changed - should emit
+      dispatch(updateCookieConsent({
+        comfortCookiesAccepted: true,
+        statisticsCookiesAccepted: true,
+      }));
+
+      expect(subscriber).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/libraries/engage/tracking/streams/index.js
+++ b/libraries/engage/tracking/streams/index.js
@@ -1,1 +1,9 @@
-export * from './cookieConsent';
+export {
+  cookieConsentInitialized$,
+  cookieConsentUpdated$,
+  cookieConsentSet$,
+  comfortCookiesAccepted$,
+  comfortCookiesDeclined$,
+  statisticsCookiesAccepted$,
+  statisticsCookiesDeclined$,
+} from './cookieConsent';

--- a/libraries/engage/tracking/subscriptions/analytics.js
+++ b/libraries/engage/tracking/subscriptions/analytics.js
@@ -3,6 +3,7 @@ import {
 } from '@shopgate/engage/core/action-creators';
 import {
   appSupportsCookieConsent,
+  hasSGJavaScriptBridge,
 } from '@shopgate/engage/core/helpers';
 import {
   analyticsSetConsent,
@@ -23,8 +24,9 @@ export default function analytics(subscribe) {
    * @param {Object} params.action Cookie consent update action
    */
   const sendConsentToApp = async ({ action }) => {
-    if (!appSupportsCookieConsent()) {
-      // Not worth to dispatch commands to an app that doesn't support them
+    if (!appSupportsCookieConsent() || !hasSGJavaScriptBridge()) {
+      // Not worth to dispatch commands to an app that doesn't support them.
+      // Within browser do not block process while waiting for an app response that will never come.
       return;
     }
 

--- a/libraries/engage/tracking/subscriptions/cookieConsent.js
+++ b/libraries/engage/tracking/subscriptions/cookieConsent.js
@@ -4,6 +4,8 @@ import { PRIVACY_SETTINGS_PATTERN } from '@shopgate/engage/tracking/constants';
 import { appSupportsCookieConsent } from '@shopgate/engage/core/helpers';
 import {
   grantAppTrackingTransparencyPermission,
+  historyReset,
+  historyPop,
 } from '@shopgate/engage/core/actions';
 import { handleCookieConsent, showCookieConsentModal } from '../action-creators';
 import {
@@ -11,6 +13,10 @@ import {
   getAreComfortCookiesAccepted,
   getAreStatisticsCookiesAccepted,
 } from '../selectors/cookieConsent';
+import {
+  cookieConsentInitializedByUserInternal$,
+  privacySettingsConfirmedWithoutChangeInternal$,
+} from '../streams/cookieConsent';
 import { appConfig } from '../../index';
 
 /**
@@ -70,5 +76,16 @@ export default function cookieConsent(subscribe) {
     if (isCookieConsentActivated && !isCookieConsentHandled) {
       dispatch(showCookieConsentModal());
     }
+  });
+
+  subscribe(cookieConsentInitializedByUserInternal$, ({ dispatch }) => {
+    // Reset history after consent initialization to guarantee an empty history
+    dispatch(historyReset());
+  });
+
+  subscribe(privacySettingsConfirmedWithoutChangeInternal$, ({ dispatch }) => {
+    // Remove privacy settings route from route stack when any button was clicked but no settings
+    // where changed. When something was changed, app will reset via the "analytics" streams.
+    dispatch(historyPop());
   });
 }

--- a/themes/theme-gmd/pages/PrivacySettings/index.jsx
+++ b/themes/theme-gmd/pages/PrivacySettings/index.jsx
@@ -12,28 +12,35 @@ import { getIsCookieConsentHandled } from '@shopgate/engage/tracking/selectors/c
  * @return {Object} The extended component props.
  */
 const mapStateToProps = state => ({
-  showTitle: getIsCookieConsentHandled(state),
+  cookieConsentHandled: getIsCookieConsentHandled(state),
 });
 
 /**
  * The CookieConsentPage component.
  * @param {Object} props The component props
- * @param {boolean} props.showTitle Whether to show the page title
+ * @param {boolean} props.cookieConsentHandled Whether to show the page title
  * @returns {JSX.Element}
  */
-const PrivacySettingsPage = ({ showTitle }) => (
+const PrivacySettingsPage = ({ cookieConsentHandled }) => (
   <View noContentPortal aria-hidden={false}>
-    <BackBar title={showTitle ? 'navigation.privacySettings' : ''} />
+    <BackBar
+      {...cookieConsentHandled ? {
+        title: 'navigation.privacySettings',
+      } : {
+        // Hide the search icon when cookie consent is not handled yet
+        right: (<></>),
+      }}
+    />
     <PrivacySettings />
   </View>
 );
 
 PrivacySettingsPage.propTypes = {
-  showTitle: PropTypes.bool,
+  cookieConsentHandled: PropTypes.bool,
 };
 
 PrivacySettingsPage.defaultProps = {
-  showTitle: false,
+  cookieConsentHandled: false,
 };
 
 export default connect(mapStateToProps)(PrivacySettingsPage);


### PR DESCRIPTION
# Description
This pull request fixes a couple of bugs in the cookie consent process.

- removed search icon from privacy settings route when cookie consent is not handled yet
- route stack is reset after cookie consent was initially handled to guarantee no leftover routes from the consent process
- privacy settings route is popped when button was pressed, but nothing has changed

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

GMD Theme
- goto "privacy settings" from cookie consent modal
- navigation bar does not contain a search icon anymore

Navigation
- goto "privacy settings" from cookie consent modal
- accept cookies
- you should not be able to swipe back in app / press back in browser and see the privacy settings again

- goto "privacy settings" after cookie consent is done
- confirm selection without changing any setting
- you should not be able to swipe back in app / press back in browser and see the privacy settings again
