### PR TITLE
Fix comfort cookies update depending on config

### DIFF
--- a/libraries/engage/tracking/action-creators/cookieConsent.js
+++ b/libraries/engage/tracking/action-creators/cookieConsent.js
@@ -23,6 +23,7 @@ export const hideCookieConsentModal = () => ({
 });
 
 const { cookieConsent: { showComfortCookiesToggle } = {} } = appConfig;
+
 /**
  * action to be dispatched when the user accepted the selected cookies in the custom modal
  * @param {Object} params Action params

--- a/libraries/engage/tracking/action-creators/cookieConsent.js
+++ b/libraries/engage/tracking/action-creators/cookieConsent.js
@@ -1,3 +1,4 @@
+import { appConfig } from '@shopgate/engage';
 import {
   UPDATE_COOKIE_CONSENT,
   COOKIE_CONSENT_HANDLED,
@@ -21,6 +22,7 @@ export const hideCookieConsentModal = () => ({
   type: HIDE_COOKIE_CONSENT_MODAL,
 });
 
+const { cookieConsent: { showComfortCookiesToggle } = {} } = appConfig;
 /**
  * action to be dispatched when the user accepted the selected cookies in the custom modal
  * @param {Object} params Action params
@@ -35,7 +37,9 @@ export const updateCookieConsent = ({
   statisticsCookiesAccepted = false,
 }) => ({
   type: UPDATE_COOKIE_CONSENT,
-  comfortCookiesAccepted,
+  comfortCookiesAccepted: showComfortCookiesToggle === true
+    ? comfortCookiesAccepted
+    : true,
   statisticsCookiesAccepted,
 });
 

--- a/libraries/engage/tracking/reducers/cookieSettings.js
+++ b/libraries/engage/tracking/reducers/cookieSettings.js
@@ -1,9 +1,12 @@
+import { appConfig } from '@shopgate/engage';
 import { UPDATE_COOKIE_CONSENT } from '../constants';
 
 const defaultState = {
   comfortCookiesAccepted: null,
   statisticsCookiesAccepted: null,
 };
+
+const { cookieConsent: { showComfortCookiesToggle } = {} } = appConfig;
 
 /**
  * Stores all states of the cookie settings.
@@ -16,7 +19,9 @@ const cookieSettingsReducer = (state = defaultState, action) => {
     case UPDATE_COOKIE_CONSENT: {
       return {
         ...state,
-        comfortCookiesAccepted: action.comfortCookiesAccepted,
+        comfortCookiesAccepted: showComfortCookiesToggle === true
+          ? action.comfortCookiesAccepted
+          : true,
         statisticsCookiesAccepted: action.statisticsCookiesAccepted,
       };
     }

--- a/libraries/engage/tracking/reducers/cookieSettings.js
+++ b/libraries/engage/tracking/reducers/cookieSettings.js
@@ -1,12 +1,9 @@
-import { appConfig } from '@shopgate/engage';
 import { UPDATE_COOKIE_CONSENT } from '../constants';
 
 const defaultState = {
   comfortCookiesAccepted: null,
   statisticsCookiesAccepted: null,
 };
-
-const { cookieConsent: { showComfortCookiesToggle } = {} } = appConfig;
 
 /**
  * Stores all states of the cookie settings.
@@ -19,9 +16,7 @@ const cookieSettingsReducer = (state = defaultState, action) => {
     case UPDATE_COOKIE_CONSENT: {
       return {
         ...state,
-        comfortCookiesAccepted: showComfortCookiesToggle === true
-          ? action.comfortCookiesAccepted
-          : true,
+        comfortCookiesAccepted: action.comfortCookiesAccepted,
         statisticsCookiesAccepted: action.statisticsCookiesAccepted,
       };
     }

--- a/libraries/engage/tracking/selectors/cookieConsent.js
+++ b/libraries/engage/tracking/selectors/cookieConsent.js
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import { appConfig } from '@shopgate/engage';
 
 /**
  * Selects the cookie consent modal state.
@@ -36,6 +37,8 @@ export const getAreStatisticsCookiesAcceptedInternal = createSelector(
   settingsState => settingsState.statisticsCookiesAccepted
 );
 
+const { cookieConsent: { showComfortCookiesToggle } = {} } = appConfig;
+
 /**
  * Determines if comfort cookies where accepted in the cookie consent process. When cookie
  * consent is inactive, the selector will also return true.
@@ -44,7 +47,9 @@ export const getAreStatisticsCookiesAcceptedInternal = createSelector(
 export const getAreComfortCookiesAccepted = createSelector(
   getCookieSettingsState,
   (settingsState) => {
-    if (settingsState.comfortCookiesAccepted === null) return true;
+    if (
+      settingsState.comfortCookiesAccepted === null || showComfortCookiesToggle === false
+    ) return true;
     return settingsState.comfortCookiesAccepted;
   }
 );

--- a/libraries/engage/tracking/selectors/cookieConsent.js
+++ b/libraries/engage/tracking/selectors/cookieConsent.js
@@ -37,7 +37,7 @@ export const getAreStatisticsCookiesAcceptedInternal = createSelector(
   settingsState => settingsState.statisticsCookiesAccepted
 );
 
-const { cookieConsent: { showComfortCookiesToggle } = {} } = appConfig;
+const { cookieConsent: { showComfortCookiesToggle, isCookieConsentActivated } = {} } = appConfig;
 
 /**
  * Determines if comfort cookies where accepted in the cookie consent process. When cookie
@@ -47,9 +47,8 @@ const { cookieConsent: { showComfortCookiesToggle } = {} } = appConfig;
 export const getAreComfortCookiesAccepted = createSelector(
   getCookieSettingsState,
   (settingsState) => {
-    if (
-      settingsState.comfortCookiesAccepted === null || showComfortCookiesToggle === false
-    ) return true;
+    if (!isCookieConsentActivated || !showComfortCookiesToggle) return true;
+    if (settingsState.comfortCookiesAccepted === null) return true;
     return settingsState.comfortCookiesAccepted;
   }
 );
@@ -62,6 +61,7 @@ export const getAreComfortCookiesAccepted = createSelector(
 export const getAreStatisticsCookiesAccepted = createSelector(
   getCookieSettingsState,
   (settingsState) => {
+    if (!isCookieConsentActivated) return true;
     if (settingsState.statisticsCookiesAccepted === null) return true;
     return settingsState.statisticsCookiesAccepted;
   }

--- a/libraries/engage/tracking/streams/cookieConsent.spec.js
+++ b/libraries/engage/tracking/streams/cookieConsent.spec.js
@@ -17,6 +17,15 @@ import {
   statisticsCookiesDeclined$,
 } from './cookieConsent';
 
+jest.mock('@shopgate/engage', () => ({
+  appConfig: {
+    cookieConsent: {
+      showComfortCookiesToggle: true,
+      isCookieConsentActivated: true,
+    },
+  },
+}));
+
 describe('Cookie Consent Streams', () => {
   let subscriber;
   let subscription;


### PR DESCRIPTION
# Description

Depending on the configuration of the theme config, the comfort cookies should be set accordingly.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
