### PR TITLE
Cookie consent selectors return correct values while cookie consent is not handled yet

### DIFF
--- a/libraries/common/components/HtmlSanitizer/index.jsx
+++ b/libraries/common/components/HtmlSanitizer/index.jsx
@@ -55,7 +55,11 @@ class HtmlSanitizer extends Component {
    * @return {boolean}
    */
   shouldComponentUpdate(nextProps) {
-    return nextProps.children !== this.props.children;
+    return (
+      nextProps.children !== this.props.children ||
+      nextProps.comfortCookiesAccepted !== this.props.comfortCookiesAccepted ||
+      nextProps.statisticsCookiesAccepted !== this.props.statisticsCookiesAccepted
+    );
   }
 
   /**


### PR DESCRIPTION
# Description
This pull request fixes an issue where the cookie consent selectors `getAreComfortCookiesAccepted` and `getAreStatisticsCookiesAccepted` returned `true` while cookie consent modal is visible. That caused that code the relied on those selectors was falsely executed even it was supposed to be inactive at declined consents.

The pull request also fixes an issue with the `HTMLSanitizer` component. Due to an incomplete implementation of the `shouldComponentUpdate` lifecycle method, the component didn't re-render when consent values changed.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Configure an startpage HTML widget with e.g. a YouTube video. Without the code from this PR the video will be shown after comfort cookies where rejected. When the code of this PR is checked out, the video should be replaced with a consent hint as expected.