### PR TITLE
Implemented "completedRegistration" tracking event

### DIFF
--- a/libraries/common/constants/user.js
+++ b/libraries/common/constants/user.js
@@ -1,4 +1,5 @@
 export const DEFAULT_LOGIN_STRATEGY = 'basic';
+export const REGISTRATION_FORM_LOGIN_STRATEGY = 'registrationForm';
 export const EVENT_USER_INITIALIZED = 'EVENT_USER_INITIALIZED';
 /**
  * Defines the interval to check if an expirable session is expired

--- a/libraries/engage/registration/streams/index.js
+++ b/libraries/engage/registration/streams/index.js
@@ -1,0 +1,9 @@
+import { main$ } from '@shopgate/pwa-common/streams';
+import { SUCCESS_REGISTRATION } from '../constants/actionTypes';
+
+/**
+ * Gets triggered when registration was successful via the shopgate.user.register pipeline
+ * @type {Observable}
+ */
+export const registrationSuccess$ = main$
+  .filter(({ action }) => action.type === SUCCESS_REGISTRATION);

--- a/libraries/engage/registration/subscriptions/index.js
+++ b/libraries/engage/registration/subscriptions/index.js
@@ -10,7 +10,7 @@ import { registrationSuccess$ } from '../streams';
  * @param {Function} subscribe Subscribes to an observable.
  */
 export default function registration(subscribe) {
-  subscribe(registrationSuccess$, ({ dispatch, getState, action }) => {
+  subscribe(registrationSuccess$, ({ dispatch, getState }) => {
     const currentRoute = getCurrentRoute(getState());
     let redirect;
 
@@ -29,8 +29,7 @@ export default function registration(subscribe) {
     dispatch(historyPop());
     dispatch(successLogin(
       redirect,
-      REGISTRATION_FORM_LOGIN_STRATEGY,
-      action?.response?.sessionLifetimeInSeconds
+      REGISTRATION_FORM_LOGIN_STRATEGY
     ));
   });
 }

--- a/libraries/engage/registration/subscriptions/index.js
+++ b/libraries/engage/registration/subscriptions/index.js
@@ -29,7 +29,8 @@ export default function registration(subscribe) {
     dispatch(historyPop());
     dispatch(successLogin(
       redirect,
-      REGISTRATION_FORM_LOGIN_STRATEGY
+      REGISTRATION_FORM_LOGIN_STRATEGY,
+      action?.response?.sessionLifetimeInSeconds
     ));
   });
 }

--- a/libraries/engage/registration/subscriptions/index.js
+++ b/libraries/engage/registration/subscriptions/index.js
@@ -1,18 +1,16 @@
 import {
-  main$, makeGetPrevRoute, getCurrentRoute, historyPop,
+  makeGetPrevRoute, getCurrentRoute, historyPop,
 } from '@shopgate/engage/core';
 import { LOGIN_PATH } from '@shopgate/pwa-common/constants/RoutePaths';
+import { REGISTRATION_FORM_LOGIN_STRATEGY } from '@shopgate/pwa-common/constants/user';
 import { successLogin } from '@shopgate/pwa-common/action-creators';
-import { SUCCESS_REGISTRATION } from '../constants';
+import { registrationSuccess$ } from '../streams';
 
 /**
  * @param {Function} subscribe Subscribes to an observable.
  */
 export default function registration(subscribe) {
-  const registrationSuccess$ = main$
-    .filter(({ action }) => action.type === SUCCESS_REGISTRATION);
-
-  subscribe(registrationSuccess$, ({ dispatch, getState }) => {
+  subscribe(registrationSuccess$, ({ dispatch, getState, action }) => {
     const currentRoute = getCurrentRoute(getState());
     let redirect;
 
@@ -29,7 +27,10 @@ export default function registration(subscribe) {
 
     // TODO improve navigation since the login page will be briefly visible
     dispatch(historyPop());
-    dispatch(successLogin(redirect));
+    dispatch(successLogin(
+      redirect,
+      REGISTRATION_FORM_LOGIN_STRATEGY
+    ));
   });
 }
 

--- a/libraries/engage/user/index.js
+++ b/libraries/engage/user/index.js
@@ -22,3 +22,5 @@ export * from './selectors/data';
 
 // STREAMS
 export * from '@shopgate/pwa-common/streams/user';
+
+export { registrationSuccess$ } from '@shopgate/engage/registration/streams';

--- a/libraries/tracking/streams/user.js
+++ b/libraries/tracking/streams/user.js
@@ -1,9 +1,20 @@
 import {
   userDidLogin$,
   userDataReceived$,
+  registrationSuccess$ as registrationSuccessCore$,
+  REGISTRATION_FORM_LOGIN_STRATEGY,
 } from '@shopgate/engage/user';
 
 /**
  * Gets triggered if login was successful and we received the user data.
  */
-export const loginSuccess$ = userDidLogin$.switchMap(() => userDataReceived$.first());
+export const loginSuccess$ = userDidLogin$
+  // Do not track a login when user was automatically logged in after registration
+  .filter(({ action }) => action?.strategy !== REGISTRATION_FORM_LOGIN_STRATEGY)
+  .switchMap(() => userDataReceived$.first());
+
+/**
+ * Gets triggered if registration was successful and we received the user data.
+ */
+export const registrationSuccess$ = registrationSuccessCore$
+  .switchMap(() => userDataReceived$.first());

--- a/libraries/tracking/subscriptions/user.js
+++ b/libraries/tracking/subscriptions/user.js
@@ -1,6 +1,6 @@
 import { loginDidFail$ } from '@shopgate/engage/user';
 import { makeGetUser } from '../selectors/user';
-import { loginSuccess$ } from '../streams/user';
+import { loginSuccess$, registrationSuccess$ } from '../streams/user';
 import { track } from '../helpers/index';
 
 /**
@@ -19,4 +19,9 @@ export default function user(subscribe) {
    */
   subscribe(loginDidFail$, ({ getState }) => (
     track('loginFailed', undefined, getState())));
+
+  subscribe(registrationSuccess$, ({ getState }) => (
+    track('completedRegistration', {
+      registrationType: 'E-Mail',
+    }, getState())));
 }

--- a/libraries/tracking/subscriptions/user.spec.js
+++ b/libraries/tracking/subscriptions/user.spec.js
@@ -18,7 +18,7 @@ describe('User subscriptions', () => {
   });
 
   it('should call subscribe as expected', () => {
-    expect(subscribe).toHaveBeenCalledTimes(2);
+    expect(subscribe).toHaveBeenCalledTimes(3);
   });
 
   describe('loginSuccess$', () => {


### PR DESCRIPTION
# Description

The `completedRegistration` tracking event is supposed to be dispatched after users finished a registration in the PWA. Before PWA7 there was no reason to implement the event in the code, since registration always happened outside the PWA (e.g. legacy checkout or web checkout).

However PWA now supports a "native" registration and so the event needs to be dispatched whenever users registered via the PWA based registration form.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
After a successful registration the dispatch of an `analyticsLogCompletedRegistration` app command should be visible inside the console.
