### PR TITLE
Limited login session lifetime is now also set after registration

### DIFF
--- a/libraries/engage/registration/subscriptions/index.js
+++ b/libraries/engage/registration/subscriptions/index.js
@@ -10,7 +10,7 @@ import { registrationSuccess$ } from '../streams';
  * @param {Function} subscribe Subscribes to an observable.
  */
 export default function registration(subscribe) {
-  subscribe(registrationSuccess$, ({ dispatch, getState }) => {
+  subscribe(registrationSuccess$, ({ dispatch, getState, action }) => {
     const currentRoute = getCurrentRoute(getState());
     let redirect;
 
@@ -29,7 +29,8 @@ export default function registration(subscribe) {
     dispatch(historyPop());
     dispatch(successLogin(
       redirect,
-      REGISTRATION_FORM_LOGIN_STRATEGY
+      REGISTRATION_FORM_LOGIN_STRATEGY,
+      action?.response?.sessionLifetimeInSeconds
     ));
   });
 }


### PR DESCRIPTION
# Description
Since a while login sessions can be limited by the `sessionLifetimeInSeconds` property from the `shopgate.user.login` pipeline response. When this property contains a number, users will be automatically logged out after the declared amount of seconds.

This system wasn't implemented yet for the `shopgate.user.register` pipeline. After a successful registration, users are automatically logged in at the backend, and no additional `shopgate.user.login` request is necessary. With the updated `@shopgate/connect-trusted` extension this property will be also returned with the `shopgate.user.register` pipeline response when configured.

This pull requests handles the extended pipeline response and sets the session timeout as expected.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Configure a value for the `sessionLifetimeInSeconds` extension config in the `@shopgate/connect-trusted` extension and perform a registration. When the recent version of the extension is running in your backend process, you'll be logged out after the configured amount of seconds.
