### PR TITLE
Fixed strike price display error on wishlist

### DIFF
--- a/libraries/engage/favorites/components/Item/Item.jsx
+++ b/libraries/engage/favorites/components/Item/Item.jsx
@@ -191,8 +191,7 @@ const FavoriteItem = ({
   const currency = product.price?.currency || 'EUR';
   const defaultPrice = product.price?.unitPrice || 0;
   const specialPrice = product.price?.unitPriceStriked;
-  const hasStrikePrice = typeof specialPrice === 'number' && specialPrice !== defaultPrice;
-  const price = hasStrikePrice ? specialPrice : defaultPrice;
+  const hasStrikePrice = typeof specialPrice === 'number' && specialPrice >= defaultPrice;
   const characteristics = product?.characteristics || [];
   const productLink = `${ITEM_PATH}/${bin2hex(product.id)}`;
 
@@ -266,10 +265,10 @@ const FavoriteItem = ({
       characteristics,
       id,
       name,
-      price,
+      price: defaultPrice,
       listId,
     };
-  }, [characteristics, listId, price, product]);
+  }, [characteristics, defaultPrice, listId, product]);
 
   const ctaPortalProps = useMemo(() => ({
     isLoading: false,
@@ -361,7 +360,7 @@ const FavoriteItem = ({
                   <div className={styles.priceContainer}>
                     {hasStrikePrice ? (
                       <PriceStriked
-                        value={defaultPrice}
+                        value={specialPrice}
                         currency={currency}
                       />
                     ) : null}
@@ -369,7 +368,7 @@ const FavoriteItem = ({
                       currency={currency}
                       discounted={hasStrikePrice}
                       taxDisclaimer
-                      unitPrice={price}
+                      unitPrice={defaultPrice}
                     />
                     <PriceInfo product={product} currency={currency} className={styles.priceInfo} />
                   </div>


### PR DESCRIPTION
# Description
This pull request fixes an issue where price and strike price at wishlist items where swapped (current price striked through.)

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Add products with strike prices to the wishlist and check if prices are displayed correctly.