### PR TITLE
Small improvements for WebCheckout extensions

### DIFF
--- a/libraries/webcheckout/actions/login.js
+++ b/libraries/webcheckout/actions/login.js
@@ -1,3 +1,4 @@
+import { mutable } from '@shopgate/pwa-common/helpers/redux';
 import HttpRequest from '@shopgate/pwa-core/classes/HttpRequest';
 import requestShopifyLogin from '../action-creators/requestShopifyLogin';
 import errorShopifyLogin from '../action-creators/errorShopifyLogin';
@@ -10,7 +11,7 @@ import { isShopify, getShopifyUrl } from '../selectors';
  * @param {string} password The login password.
  * @return {Function} A redux thunk.
  */
-export default (user, password) => (dispatch) => {
+const webCheckoutLogin = (user, password) => (dispatch) => {
   if (!isShopify()) {
     // The success is dispatched here to take care that the streams work as expected
     dispatch(successShopifyLogin());
@@ -23,6 +24,7 @@ export default (user, password) => (dispatch) => {
     .setMethod('POST')
     .setTimeout(20000)
     .setPayload({
+      // eslint-disable-next-line camelcase
       form_type: 'customer_login',
       customer: {
         email: user,
@@ -46,3 +48,6 @@ export default (user, password) => (dispatch) => {
       dispatch(errorShopifyLogin());
     });
 };
+
+/** @mixes {MutableFunction} */
+export default mutable(webCheckoutLogin);

--- a/libraries/webcheckout/actions/logout.js
+++ b/libraries/webcheckout/actions/logout.js
@@ -1,3 +1,4 @@
+import { mutable } from '@shopgate/pwa-common/helpers/redux';
 import HttpRequest from '@shopgate/pwa-core/classes/HttpRequest';
 import requestShopifyLogout from '../action-creators/requestShopifyLogout';
 import errorShopifyLogout from '../action-creators/errorShopifyLogout';
@@ -8,7 +9,7 @@ import { getLogoutUrl, getLogoutSuccessUrl } from '../selectors';
  * Log out the current user.
  * @return {Function} A redux thunk.
  */
-export default () => (dispatch) => {
+const webCheckoutLogout = () => (dispatch) => {
   const logoutUrl = getLogoutUrl();
 
   if (!logoutUrl) {
@@ -29,7 +30,7 @@ export default () => (dispatch) => {
       const logoutSuccessUrl = getLogoutSuccessUrl();
       // When a success url is available it needs to be considered at the response evaluation
       const urlCheckValid = !logoutSuccessUrl ||
-         (location && location.startsWith(logoutSuccessUrl));
+        (location && location.startsWith(logoutSuccessUrl));
 
       if (statusCode === 302 && urlCheckValid) {
         dispatch(successShopifyLogout());
@@ -41,3 +42,6 @@ export default () => (dispatch) => {
       dispatch(errorShopifyLogout());
     });
 };
+
+/** @mixes {MutableFunction} */
+export default mutable(webCheckoutLogout);

--- a/themes/theme-ios11/pages/More/components/UserMenu/components/LoggedOut/index.jsx
+++ b/themes/theme-ios11/pages/More/components/UserMenu/components/LoggedOut/index.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Grid from '@shopgate/pwa-common/components/Grid';
-import I18n from '@shopgate/pwa-common/components/I18n';
-import Link from '@shopgate/pwa-common/components/Link';
-import Button from '@shopgate/pwa-ui-shared/Button';
+import classnames from 'classnames';
+import {
+  Grid, I18n, Link, Button,
+} from '@shopgate/engage/components';
 import {
   LOGIN_PATH,
   REGISTER_PATH,
-} from '@shopgate/pwa-common/constants/RoutePaths';
+} from '@shopgate/engage/user';
 import connect from './connector';
 import styles from './style';
 
@@ -18,17 +18,27 @@ import styles from './style';
  */
 const LoggedOut = ({ isDisabled }) => (
   <div data-test-id="userMenu">
-    <Grid className={styles.grid}>
-      <Grid.Item className={styles.gridItem}>
+    <Grid className={classnames(styles.grid, 'theme__more-page__user-menu__container')}>
+      <Grid.Item className={classnames(styles.gridItem, 'theme__more-page__login-button__container')}>
         <Link href={LOGIN_PATH} disabled={isDisabled}>
-          <Button type="secondary" className={styles.button} testId="UserMenuLogin" disabled={isDisabled}>
+          <Button
+            type="secondary"
+            className={classnames(styles.button, 'theme__more-page__login-button')}
+            testId="UserMenuLogin"
+            disabled={isDisabled}
+          >
             <I18n.Text string="login.button" />
           </Button>
         </Link>
       </Grid.Item>
-      <Grid.Item className={styles.gridItem}>
+      <Grid.Item className={classnames(styles.gridItem, 'theme__more-page-register-button__container')}>
         <Link href={REGISTER_PATH} disabled={isDisabled}>
-          <Button type="secondary" className={styles.button} testId="UserMenuRegister" disabled={isDisabled}>
+          <Button
+            type="secondary"
+            className={classnames(styles.button, 'theme__more-page-register-button')}
+            testId="UserMenuRegister"
+            disabled={isDisabled}
+          >
             <I18n.Text string="login.signup" />
           </Button>
         </Link>


### PR DESCRIPTION
# Description

This pull request introduces some small improvements for WebCheckout related extensions. It adds human readable classes to the login / logout button on theme-ios11 "more" page, so that buttons can be easily hidden by an extension.

It converts login / logout actions of `webcheckout` library folder to "mutable" actions, so that their default logic can be changed by extensions.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
