### PR TITLE
Adjust colours to match pwa6 styles

### DIFF
--- a/extensions/@shopgate-product-reviews/frontend/RatingStars/components/Stars/style.js
+++ b/extensions/@shopgate-product-reviews/frontend/RatingStars/components/Stars/style.js
@@ -21,7 +21,7 @@ const emptyStars = css({
 const filledStars = css({
   position: 'absolute',
   // Before the custom properties the primary color was used for this class.
-  color: `var(--color-secondary, ${colors.primary})`,
+  color: `var(--color-primary, ${colors.secondary})`,
   top: 0,
 }).toString();
 

--- a/extensions/@shopgate-product-reviews/frontend/RatingStars/components/Stars/style.js
+++ b/extensions/@shopgate-product-reviews/frontend/RatingStars/components/Stars/style.js
@@ -20,7 +20,7 @@ const emptyStars = css({
 
 const filledStars = css({
   position: 'absolute',
-  color: `var(--color-primary, ${colors.secondary})`,
+  color: `var(--color-primary, ${colors.primary})`,
   top: 0,
 }).toString();
 

--- a/extensions/@shopgate-product-reviews/frontend/RatingStars/components/Stars/style.js
+++ b/extensions/@shopgate-product-reviews/frontend/RatingStars/components/Stars/style.js
@@ -20,7 +20,6 @@ const emptyStars = css({
 
 const filledStars = css({
   position: 'absolute',
-  // Before the custom properties the primary color was used for this class.
   color: `var(--color-primary, ${colors.secondary})`,
   top: 0,
 }).toString();

--- a/libraries/engage/filter/components/PriceSlider/style.js
+++ b/libraries/engage/filter/components/PriceSlider/style.js
@@ -9,7 +9,6 @@ const wrapper = css({
 }).toString();
 
 const price = css({
-  // Before the custom properties the accent color was used for this class.
   color: `var(--color-primary, ${colors.secondary})`,
   display: 'inline-block',
   fontWeight: 500,
@@ -62,7 +61,6 @@ const rangeSlider = {
   }).toString(),
 
   range: css({
-    // Before the custom properties the accent color was used for this class.
     background: `var(--color-primary, ${colors.secondary})`,
     position: 'absolute',
     height: '100%',

--- a/libraries/engage/filter/components/PriceSlider/style.js
+++ b/libraries/engage/filter/components/PriceSlider/style.js
@@ -9,7 +9,7 @@ const wrapper = css({
 }).toString();
 
 const price = css({
-  color: `var(--color-secondary, ${colors.primary})`,
+  color: `var(--color-secondary, ${colors.accent})`,
   display: 'inline-block',
   fontWeight: 500,
   textAlign: 'center',
@@ -61,7 +61,7 @@ const rangeSlider = {
   }).toString(),
 
   range: css({
-    background: `var(--color-secondary, ${colors.primary})`,
+    background: `var(--color-secondary, ${colors.accent})`,
     position: 'absolute',
     height: '100%',
     marginLeft: variables.gap.small,

--- a/libraries/engage/filter/components/PriceSlider/style.js
+++ b/libraries/engage/filter/components/PriceSlider/style.js
@@ -10,7 +10,7 @@ const wrapper = css({
 
 const price = css({
   // Before the custom properties the accent color was used for this class.
-  color: `var(--color-primary, ${colors.accent})`,
+  color: `var(--color-primary, ${colors.secondary})`,
   display: 'inline-block',
   fontWeight: 500,
   textAlign: 'center',
@@ -63,7 +63,7 @@ const rangeSlider = {
 
   range: css({
     // Before the custom properties the accent color was used for this class.
-    background: `var(--color-primary, ${colors.accent})`,
+    background: `var(--color-primary, ${colors.secondary})`,
     position: 'absolute',
     height: '100%',
     marginLeft: variables.gap.small,

--- a/libraries/engage/filter/components/PriceSlider/style.js
+++ b/libraries/engage/filter/components/PriceSlider/style.js
@@ -9,7 +9,7 @@ const wrapper = css({
 }).toString();
 
 const price = css({
-  color: `var(--color-primary, ${colors.secondary})`,
+  color: `var(--color-secondary, ${colors.primary})`,
   display: 'inline-block',
   fontWeight: 500,
   textAlign: 'center',
@@ -61,7 +61,7 @@ const rangeSlider = {
   }).toString(),
 
   range: css({
-    background: `var(--color-primary, ${colors.secondary})`,
+    background: `var(--color-secondary, ${colors.primary})`,
     position: 'absolute',
     height: '100%',
     marginLeft: variables.gap.small,

--- a/libraries/engage/reviews/components/Reviews/components/Header/components/ReviewsExcerpt/style.js
+++ b/libraries/engage/reviews/components/Reviews/components/Header/components/ReviewsExcerpt/style.js
@@ -21,7 +21,6 @@ export const reviewsLine = css({
 });
 
 export const averageRatingNumber = css({
-  // Before the custom properties the primary color was used for this class.
   color: `var(--color-primary, ${colors.secondary})`,
   marginLeft: variables.gap.small,
 }).toString();

--- a/libraries/engage/reviews/components/Reviews/components/Header/components/ReviewsExcerpt/style.js
+++ b/libraries/engage/reviews/components/Reviews/components/Header/components/ReviewsExcerpt/style.js
@@ -22,7 +22,7 @@ export const reviewsLine = css({
 
 export const averageRatingNumber = css({
   // Before the custom properties the primary color was used for this class.
-  color: `var(--color-secondary, ${colors.primary})`,
+  color: `var(--color-primary, ${colors.secondary})`,
   marginLeft: variables.gap.small,
 }).toString();
 

--- a/libraries/engage/reviews/components/Reviews/components/Header/components/ReviewsExcerpt/style.js
+++ b/libraries/engage/reviews/components/Reviews/components/Header/components/ReviewsExcerpt/style.js
@@ -21,7 +21,7 @@ export const reviewsLine = css({
 });
 
 export const averageRatingNumber = css({
-  color: `var(--color-primary, ${colors.secondary})`,
+  color: `var(--color-primary, ${colors.primary})`,
   marginLeft: variables.gap.small,
 }).toString();
 

--- a/libraries/engage/reviews/components/Reviews/components/RatingCount/style.js
+++ b/libraries/engage/reviews/components/Reviews/components/RatingCount/style.js
@@ -17,7 +17,6 @@ const greyStyle = css({
 
 const prominentStyle = css({
   ...main,
-  // Before the custom properties the primary color was used for this class.
   color: `var(--color-primary, ${colors.secondary})`,
 }).toString();
 

--- a/libraries/engage/reviews/components/Reviews/components/RatingCount/style.js
+++ b/libraries/engage/reviews/components/Reviews/components/RatingCount/style.js
@@ -18,7 +18,7 @@ const greyStyle = css({
 const prominentStyle = css({
   ...main,
   // Before the custom properties the primary color was used for this class.
-  color: `var(--color-secondary, ${colors.primary})`,
+  color: `var(--color-primary, ${colors.secondary})`,
 }).toString();
 
 export {

--- a/libraries/engage/reviews/components/Reviews/components/RatingCount/style.js
+++ b/libraries/engage/reviews/components/Reviews/components/RatingCount/style.js
@@ -17,7 +17,7 @@ const greyStyle = css({
 
 const prominentStyle = css({
   ...main,
-  color: `var(--color-primary, ${colors.secondary})`,
+  color: `var(--color-primary, ${colors.primary})`,
 }).toString();
 
 export {

--- a/libraries/ui-shared/DiscountBadge/style.js
+++ b/libraries/ui-shared/DiscountBadge/style.js
@@ -3,7 +3,7 @@ import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 
 const { colors } = themeConfig;
 const badge = {
-  background: `var(--color-primary, ${colors.secondary})`,
+  background: `var(--color-primary, ${colors.primary})`,
   borderRadius: 2,
   color: `var(--color-primary-contrast, ${colors.primaryContrast})`,
   padding: 5,

--- a/libraries/ui-shared/DiscountBadge/style.js
+++ b/libraries/ui-shared/DiscountBadge/style.js
@@ -3,7 +3,6 @@ import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 
 const { colors } = themeConfig;
 const badge = {
-  // Before the custom properties the primary color was used for this class.
   background: `var(--color-primary, ${colors.secondary})`,
   borderRadius: 2,
   color: `var(--color-primary-contrast, ${colors.secondaryContrast})`,

--- a/libraries/ui-shared/DiscountBadge/style.js
+++ b/libraries/ui-shared/DiscountBadge/style.js
@@ -5,7 +5,7 @@ const { colors } = themeConfig;
 const badge = {
   background: `var(--color-primary, ${colors.secondary})`,
   borderRadius: 2,
-  color: `var(--color-primary-contrast, ${colors.secondaryContrast})`,
+  color: `var(--color-primary-contrast, ${colors.primaryContrast})`,
   padding: 5,
   width: '100%',
   fontWeight: 700,

--- a/libraries/ui-shared/DiscountBadge/style.js
+++ b/libraries/ui-shared/DiscountBadge/style.js
@@ -4,9 +4,9 @@ import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 const { colors } = themeConfig;
 const badge = {
   // Before the custom properties the primary color was used for this class.
-  background: `var(--color-secondary, ${colors.primary})`,
+  background: `var(--color-primary, ${colors.secondary})`,
   borderRadius: 2,
-  color: `var(--color-secondary-contrast, ${colors.primaryContrast})`,
+  color: `var(--color-primary-contrast, ${colors.secondaryContrast})`,
   padding: 5,
   width: '100%',
   fontWeight: 700,

--- a/libraries/ui-shared/Manufacturer/style.js
+++ b/libraries/ui-shared/Manufacturer/style.js
@@ -3,5 +3,5 @@ import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 
 export default css({
   // Before the custom properties the primary color was used for this class.
-  color: `var(--color-secondary, ${themeConfig.colors.primary})`,
+  color: `var(--color-primary, ${themeConfig.colors.secondary})`,
 }).toString();

--- a/libraries/ui-shared/Manufacturer/style.js
+++ b/libraries/ui-shared/Manufacturer/style.js
@@ -2,6 +2,5 @@ import { css } from 'glamor';
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 
 export default css({
-  // Before the custom properties the primary color was used for this class.
   color: `var(--color-primary, ${themeConfig.colors.secondary})`,
 }).toString();

--- a/libraries/ui-shared/Manufacturer/style.js
+++ b/libraries/ui-shared/Manufacturer/style.js
@@ -2,5 +2,5 @@ import { css } from 'glamor';
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 
 export default css({
-  color: `var(--color-primary, ${themeConfig.colors.secondary})`,
+  color: `var(--color-primary, ${themeConfig.colors.primary})`,
 }).toString();

--- a/libraries/ui-shared/RatingStars/style.js
+++ b/libraries/ui-shared/RatingStars/style.js
@@ -20,7 +20,7 @@ const emptyStars = css({
 const filledStars = css({
   position: 'absolute',
   // Before the custom properties the primary color was used for this class.
-  color: `var(--color-secondary, ${colors.primary})`,
+  color: `var(--color-primary, ${colors.secondary})`,
   top: 0,
 }).toString();
 

--- a/libraries/ui-shared/RatingStars/style.js
+++ b/libraries/ui-shared/RatingStars/style.js
@@ -19,7 +19,6 @@ const emptyStars = css({
 
 const filledStars = css({
   position: 'absolute',
-  // Before the custom properties the primary color was used for this class.
   color: `var(--color-primary, ${colors.secondary})`,
   top: 0,
 }).toString();

--- a/libraries/ui-shared/RatingStars/style.js
+++ b/libraries/ui-shared/RatingStars/style.js
@@ -19,7 +19,7 @@ const emptyStars = css({
 
 const filledStars = css({
   position: 'absolute',
-  color: `var(--color-primary, ${colors.secondary})`,
+  color: `var(--color-primary, ${colors.primary})`,
   top: 0,
 }).toString();
 

--- a/themes/theme-gmd/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
+++ b/themes/theme-gmd/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
@@ -20,7 +20,6 @@ export const inactive = css({
 });
 
 export const active = css(inactive, {
-  // Before the custom properties the accent color was used for this class.
   borderColor: `var(--color-primary, ${themeColors.secondary})`,
   color: `var(--color-primary, ${themeColors.secondary})`,
 });

--- a/themes/theme-gmd/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
+++ b/themes/theme-gmd/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
@@ -20,6 +20,6 @@ export const inactive = css({
 });
 
 export const active = css(inactive, {
-  borderColor: `var(--color-secondary, ${themeColors.primary})`,
-  color: `var(--color-secondary, ${themeColors.primary})`,
+  borderColor: `var(--color-secondary, ${themeColors.accent})`,
+  color: `var(--color-secondary, ${themeColors.accent})`,
 });

--- a/themes/theme-gmd/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
+++ b/themes/theme-gmd/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
@@ -21,6 +21,6 @@ export const inactive = css({
 
 export const active = css(inactive, {
   // Before the custom properties the accent color was used for this class.
-  borderColor: `var(--color-primary, ${themeColors.accent})`,
-  color: `var(--color-primary, ${themeColors.accent})`,
+  borderColor: `var(--color-primary, ${themeColors.secondary})`,
+  color: `var(--color-primary, ${themeColors.secondary})`,
 });

--- a/themes/theme-gmd/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
+++ b/themes/theme-gmd/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
@@ -20,6 +20,6 @@ export const inactive = css({
 });
 
 export const active = css(inactive, {
-  borderColor: `var(--color-primary, ${themeColors.secondary})`,
-  color: `var(--color-primary, ${themeColors.secondary})`,
+  borderColor: `var(--color-secondary, ${themeColors.primary})`,
+  color: `var(--color-secondary, ${themeColors.primary})`,
 });

--- a/themes/theme-ios11/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
+++ b/themes/theme-ios11/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
@@ -20,7 +20,6 @@ export const inactive = css({
 });
 
 export const active = css(inactive, {
-  // Before the custom properties the accent color was used for this class.
   borderColor: `var(--color-primary, ${themeColors.secondary})`,
   color: `var(--color-primary, ${themeColors.secondary})`,
 });

--- a/themes/theme-ios11/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
+++ b/themes/theme-ios11/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
@@ -20,6 +20,6 @@ export const inactive = css({
 });
 
 export const active = css(inactive, {
-  borderColor: `var(--color-secondary, ${themeColors.primary})`,
-  color: `var(--color-secondary, ${themeColors.primary})`,
+  borderColor: `var(--color-secondary, ${themeColors.accent})`,
+  color: `var(--color-secondary, ${themeColors.accent})`,
 });

--- a/themes/theme-ios11/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
+++ b/themes/theme-ios11/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
@@ -21,6 +21,6 @@ export const inactive = css({
 
 export const active = css(inactive, {
   // Before the custom properties the accent color was used for this class.
-  borderColor: `var(--color-primary, ${themeColors.accent})`,
-  color: `var(--color-primary, ${themeColors.accent})`,
+  borderColor: `var(--color-primary, ${themeColors.secondary})`,
+  color: `var(--color-primary, ${themeColors.secondary})`,
 });

--- a/themes/theme-ios11/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
+++ b/themes/theme-ios11/pages/Filter/components/Content/components/Selector/components/ValueButton/style.js
@@ -20,6 +20,6 @@ export const inactive = css({
 });
 
 export const active = css(inactive, {
-  borderColor: `var(--color-primary, ${themeColors.secondary})`,
-  color: `var(--color-primary, ${themeColors.secondary})`,
+  borderColor: `var(--color-secondary, ${themeColors.primary})`,
+  color: `var(--color-secondary, ${themeColors.primary})`,
 });


### PR DESCRIPTION
# Description

During the merge of PWA 6 and 7, we need to adjust the colours in order to match the original styles and to prevent undesired colour changes.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

