### PR TITLE
Show dialog for added coupon in cart

### DIFF
--- a/themes/theme-gmd/pages/Cart/components/CouponField/subscriptions.js
+++ b/themes/theme-gmd/pages/Cart/components/CouponField/subscriptions.js
@@ -1,4 +1,3 @@
-import { ToastProvider } from '@shopgate/engage/core';
 import { SUCCESS_ADD_COUPONS_TO_CART } from '@shopgate/pwa-common-commerce/cart/constants';
 import { couponsUpdated$ } from '@shopgate/pwa-common-commerce/cart/streams';
 import {
@@ -7,6 +6,7 @@ import {
   cartDidLeave$,
   productsUpdated$,
 } from '@shopgate/engage/cart';
+import showModal from '@shopgate/pwa-common/actions/modal/showModal';
 
 /**
  * Coupons subscription.
@@ -22,14 +22,15 @@ export default function coupon(subscribe) {
     productsUpdated$
   );
 
-  subscribe(successfullyAddedCouponsToCart$, ({ action, events }) => {
+  subscribe(successfullyAddedCouponsToCart$, ({ action, dispatch }) => {
     const { userInteracted } = action;
 
     if (!userInteracted) {
-      events.emit(ToastProvider.ADD, {
-        id: 'coupon.added',
-        message: 'cart.coupon_was_added',
-      });
+      dispatch(showModal({
+        dismiss: null,
+        confirm: 'modal.ok',
+        title: 'cart.coupon_was_added',
+      }));
     }
   });
 

--- a/themes/theme-gmd/pages/Cart/components/CouponField/subscriptions.js
+++ b/themes/theme-gmd/pages/Cart/components/CouponField/subscriptions.js
@@ -6,7 +6,7 @@ import {
   cartDidLeave$,
   productsUpdated$,
 } from '@shopgate/engage/cart';
-import showModal from '@shopgate/pwa-common/actions/modal/showModal';
+import { showModal } from '@shopgate/engage/core/actions';
 
 /**
  * Coupons subscription.

--- a/themes/theme-ios11/pages/Cart/components/CouponField/subscriptions.js
+++ b/themes/theme-ios11/pages/Cart/components/CouponField/subscriptions.js
@@ -1,4 +1,3 @@
-import { ToastProvider } from '@shopgate/engage/core';
 import { SUCCESS_ADD_COUPONS_TO_CART } from '@shopgate/pwa-common-commerce/cart/constants';
 import { couponsUpdated$ } from '@shopgate/pwa-common-commerce/cart/streams';
 import {
@@ -7,6 +6,7 @@ import {
   cartDidLeave$,
   productsUpdated$,
 } from '@shopgate/engage/cart';
+import showModal from '@shopgate/pwa-common/actions/modal/showModal';
 
 /**
  * Coupons subscription.
@@ -22,14 +22,15 @@ export default function coupon(subscribe) {
     productsUpdated$
   );
 
-  subscribe(successfullyAddedCouponsToCart$, ({ action, events }) => {
+  subscribe(successfullyAddedCouponsToCart$, ({ action, dispatch }) => {
     const { userInteracted } = action;
 
     if (!userInteracted) {
-      events.emit(ToastProvider.ADD, {
-        id: 'coupon.added',
-        message: 'cart.coupon_was_added',
-      });
+      dispatch(showModal({
+        dismiss: null,
+        confirm: 'modal.ok',
+        title: 'cart.coupon_was_added',
+      }));
     }
   });
 

--- a/themes/theme-ios11/pages/Cart/components/CouponField/subscriptions.js
+++ b/themes/theme-ios11/pages/Cart/components/CouponField/subscriptions.js
@@ -6,7 +6,7 @@ import {
   cartDidLeave$,
   productsUpdated$,
 } from '@shopgate/engage/cart';
-import showModal from '@shopgate/pwa-common/actions/modal/showModal';
+import { showModal } from '@shopgate/engage/core/actions';
 
 /**
  * Coupons subscription.


### PR DESCRIPTION
# Description

When a coupon was added to the cart, a dialog with a success message should be shown instead of a toast. It should only happen without user interaction, i.e. not in case the user added the coupon to the cart manually.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

