### PR TITLE
Adjust toast message for added favorites

### DIFF
--- a/libraries/commerce/favorites/actions/toggleFavorites.js
+++ b/libraries/commerce/favorites/actions/toggleFavorites.js
@@ -32,7 +32,7 @@ export const addFavorite = mutable((
   listId,
   quantity,
   notes,
-  showToast = true
+  showToast = false
 ) => (dispatch, getState) => {
   const defaultList = getFavoritesDefaultList(getState());
   dispatch(addProductToFavorites(productId, listId || defaultList.id, quantity, notes, showToast));
@@ -84,7 +84,7 @@ export const toggleFavorite = mutable((productId, listId, withRelatives = false)
     const wishlistItemQuantityEnabled = getWishlistItemQuantityEnabled(state);
     const loadWishlistOnAppStartEnabled = getLoadWishlistOnAppStartEnabled(state);
     if (wishlistItemQuantityEnabled || !loadWishlistOnAppStartEnabled) {
-      dispatch(addFavorite(productId, listId));
+      dispatch(addFavorite(productId, listId, null, null, true));
     } else {
       const isOnList = makeIsProductOnSpecificFavoriteList(
         () => productId,


### PR DESCRIPTION
# Description

When adding an article to the favorites list, we don't want to show a toast message to confirm this action unless the feature to load the wishlist on app start is activated. When the user removes an item from the favorites, we do show the toast message with the option to undo this action.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

