### PR TITLE
Fixed an issue when YouTube or Video logos where tapped inside iframes

### DIFF
--- a/libraries/common/collections/media-providers/Vimeo.js
+++ b/libraries/common/collections/media-providers/Vimeo.js
@@ -71,7 +71,10 @@ class VimeoMediaProvider extends MediaProvider {
 
     const players = [];
 
-    iframes.forEach((iframe) => {
+    iframes.forEach((iframe, index) => {
+      // Block clicks on Vimeo icon
+      iframes[index].sandbox = 'allow-forms allow-scripts allow-pointer-lock allow-same-origin allow-top-navigation';
+
       this.responsify(iframe);
       players.push(new window.Vimeo.Player(iframe));
     });

--- a/libraries/common/collections/media-providers/YouTube.js
+++ b/libraries/common/collections/media-providers/YouTube.js
@@ -32,6 +32,9 @@ class YouTubeMediaProvider extends MediaProvider {
 
     // Update the video urls to enable stopping videos via the event API.
     iframes.forEach((iframe, index) => {
+      // Block clicks on YouTube icon
+      iframes[index].sandbox = 'allow-forms allow-scripts allow-pointer-lock allow-same-origin allow-top-navigation';
+
       this.responsify(iframe);
 
       const { src } = iframe;


### PR DESCRIPTION
# Description
This pull request fixes an issue where taps on YouTube or Vimeo logos inside a player iframe opened the In-App Browser without navigation bar and controls. This behaviour is prevented by restricting iframe permissions via the `sandbox` attribute.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Add a YouTube or Vimeo embedded code to the description of a product, or CMS page HTML widget. When the changes of this PR are active, clicks on YouTube or Vimeo icon inside the iframes don't work anymore inside the browser and the apps.
