### PR TITLE
Bugfixes in merged codebase

### DIFF
--- a/libraries/common/components/Backdrop/index.jsx
+++ b/libraries/common/components/Backdrop/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Transition from 'react-inline-transition-group';
-import { toggleBodyScroll } from '@shopgate/engage/styles';
+import { toggleBodyScroll } from '@shopgate/engage/styles/helpers';
 import style from './style';
 
 /**

--- a/libraries/common/components/Input/components/DateInput.jsx
+++ b/libraries/common/components/Input/components/DateInput.jsx
@@ -11,7 +11,7 @@ import moment from 'moment';
 import CalendarIcon from '@shopgate/pwa-ui-shared/icons/CalendarIcon';
 import appConfig, { themeConfig } from '@shopgate/pwa-common/helpers/config';
 import Backdrop from '@shopgate/pwa-common/components/Backdrop';
-import { i18n } from '@shopgate/engage/core';
+import { i18n } from '@shopgate/engage/core/helpers';
 import SimpleInput from './SimpleInput';
 
 const { variables } = themeConfig;

--- a/libraries/common/components/SurroundPortals/index.jsx
+++ b/libraries/common/components/SurroundPortals/index.jsx
@@ -4,13 +4,18 @@ import Portal from '../Portal';
 import { AFTER, BEFORE } from '../../constants/Portals';
 
 /**
- * The Portal component.
- * @param {string} base portal (center) name
- * @param {Object} portalProps for portals
- * @param {Function} children children
- * @returns {JSX}
+ * The SurroundPortals component renders three Portal component. The main portal is wrapped around
+ * its children, the two additional portals are rendered before and after the main portal.
+ * The names of the additional portals are automatically created from the name of the main portal
+ * with a ".before" and ".after" suffix.
+ *
+ * @param {Object} props The component props
+ * @param {string} props.portalName Name for the main portal
+ * @param {Object} props.portalProps Props that are assigned to the portals
+ * @param {React.ReactNode} props.children Component children
+ * @returns {JSX.Element}
  */
-const SurroundPortals = ({ portalName, children, portalProps }) => (
+const SurroundPortals = ({ portalName, portalProps, children }) => (
   <Fragment>
     <Portal name={`${portalName}.${BEFORE}`} props={portalProps} />
     <Portal name={portalName} props={portalProps}>

--- a/libraries/common/subscriptions/router.js
+++ b/libraries/common/subscriptions/router.js
@@ -114,12 +114,12 @@ export default function routerSubscriptions(subscribe) {
         break;
     }
 
-    /**
-     * Further on we will only use the sanitized location except when link is external.
-     * In that case we want to preserve the original location.
-     */
-    const originalLocation = location;
-    location = handler.sanitizeLink(location);
+    // Remove trailing slashes from internal links, since they might break the routing mechanism.
+    // External links are treated as valid, since we don't know about the requirements at the
+    // 3rd party server (e.g. google maps links might require trailing slashes).
+    if (location && !handler.isExternalLink(location)) {
+      location = handler.sanitizeLink(location);
+    }
 
     // Stop further processing if the location is empty.
     if (!location) {
@@ -246,8 +246,8 @@ export default function routerSubscriptions(subscribe) {
 
     // If there is one of the known protocols in the url.
     if (location && handler.hasKnownProtocols(location)) {
-      if (handler.isExternalLink(originalLocation)) {
-        handler.openExternalLink(originalLocation, historyAction, state, routeState);
+      if (handler.isExternalLink(location)) {
+        handler.openExternalLink(location, historyAction, state, routeState);
       } else if (handler.isNativeLink(location)) {
         handler.openNativeLink(location);
       }

--- a/libraries/common/subscriptions/router.spec.js
+++ b/libraries/common/subscriptions/router.spec.js
@@ -515,6 +515,32 @@ describe('Router subscriptions', () => {
       );
     });
 
+    it('should handle external urls as expected when they are returned by a redirect handler', async () => {
+      const externalUrl = 'https://www.google.com/maps/dir/?api=1&destination=Gro';
+
+      /**
+       * @return {Promise}
+       */
+      const redirectHandler = () => Promise.resolve(externalUrl);
+
+      redirects.set('/register', redirectHandler);
+
+      const params = {
+        action: ACTION_PUSH,
+        pathname: '/register',
+      };
+
+      await callback(createCallbackPayload({ params }));
+      testExpectedCall(openExternalLinkSpy);
+
+      expect(openExternalLinkSpy).toHaveBeenCalledWith(
+        externalUrl,
+        params.action,
+        mockedRouterState,
+        undefined
+      );
+    });
+
     it('should handle native links like expected', async () => {
       /**
        * Replace the implementation of handler.openNative link temporarily. It reassigns

--- a/libraries/engage/cart/components/CartSummaryWide/CartSummaryWideCheckoutButton.jsx
+++ b/libraries/engage/cart/components/CartSummaryWide/CartSummaryWideCheckoutButton.jsx
@@ -28,7 +28,7 @@ const CartSummaryWideCheckoutButton = ({ isOrderable }:Props) => {
 
   return (
     <div className={container}>
-      <SurroundPortals portalName={CART_CHECKOUT_BUTTON} props={{ isActive }}>
+      <SurroundPortals portalName={CART_CHECKOUT_BUTTON} portalProps={{ isActive }}>
         <Link href={CHECKOUT_PATH} disabled={!isActive}>
           <RippleButton
             disabled={!isActive}

--- a/libraries/engage/cart/components/PaymentBar/PaymentBarCheckoutButton.jsx
+++ b/libraries/engage/cart/components/PaymentBar/PaymentBarCheckoutButton.jsx
@@ -24,7 +24,7 @@ function PaymentBarCheckoutButton({ isOrderable }: Props) {
   const isActive = useMemo(() => (isOrderable && !isLoading), [isLoading, isOrderable]);
 
   return (
-    <SurroundPortals portalName={CART_CHECKOUT_BUTTON} props={{ isActive }}>
+    <SurroundPortals portalName={CART_CHECKOUT_BUTTON} portalProps={{ isActive }}>
       <Link href={CHECKOUT_PATH} disabled={!isActive}>
         <RippleButton
           disabled={!isActive}

--- a/libraries/engage/cart/components/PaymentBar/PaymentBarReserveButton.jsx
+++ b/libraries/engage/cart/components/PaymentBar/PaymentBarReserveButton.jsx
@@ -36,7 +36,7 @@ function PaymentBarReserveButton({ historyReset }: Props) {
   }
 
   return (
-    <SurroundPortals portalName={CART_CHECKOUT_BUTTON} props={{ isActive: orderable }}>
+    <SurroundPortals portalName={CART_CHECKOUT_BUTTON} portalProps={{ isActive: orderable }}>
       <RippleButton
         onClick={handleClick}
         disabled={!orderable}

--- a/libraries/engage/core/helpers/errorBehavior.js
+++ b/libraries/engage/core/helpers/errorBehavior.js
@@ -1,7 +1,7 @@
 import { ToastProvider } from '@shopgate/pwa-common/providers';
 import { MODAL_PIPELINE_ERROR } from '@shopgate/pwa-common/constants/ModalTypes';
 import showModal from '@shopgate/pwa-common/actions/modal/showModal';
-import { logger, i18n } from '@shopgate/engage/core';
+import { logger, i18n } from '@shopgate/engage/core/helpers';
 
 /**
  * Creates an error message for a pipeline and a code

--- a/libraries/engage/core/helpers/featureFlag.js
+++ b/libraries/engage/core/helpers/featureFlag.js
@@ -1,5 +1,5 @@
 import { themeName, shopNumber } from '@shopgate/pwa-common/helpers/config';
-import { isDev } from '@shopgate/engage/core';
+import { isDev } from '@shopgate/engage/core/helpers';
 
 const STORE_KEY_PREFIX = `sgFeatureFlag_${shopNumber}_${themeName}__`;
 

--- a/libraries/engage/product/components/EffectivityDates/helpers.js
+++ b/libraries/engage/product/components/EffectivityDates/helpers.js
@@ -1,6 +1,7 @@
 import {
-  getThemeSettings, isBeta, isAfter, isBefore, addDuration,
-} from '@shopgate/engage/core';
+  isBeta, isAfter, isBefore, addDuration,
+} from '@shopgate/engage/core/helpers';
+import { getThemeSettings } from '@shopgate/engage/core/config';
 import { ALWAYS, NEVER } from './constants';
 
 /**

--- a/libraries/engage/product/helpers/index.js
+++ b/libraries/engage/product/helpers/index.js
@@ -1,8 +1,7 @@
 import configuration from '@shopgate/pwa-common/collections/Configuration';
 import { DEFAULT_PRODUCTS_FETCH_PARAMS } from '@shopgate/pwa-common/constants/Configuration';
-import {
-  getFullImageSource, getThemeSettings, isBeta, loadImage,
-} from '@shopgate/engage/core';
+import { getFullImageSource, isBeta, loadImage } from '@shopgate/engage/core/helpers';
+import { getThemeSettings } from '@shopgate/engage/core/config';
 import { buildShowScheduledParams } from '../components/EffectivityDates/helpers';
 
 export * from '@shopgate/pwa-common-commerce/product/helpers';

--- a/libraries/engage/product/helpers/redirects.js
+++ b/libraries/engage/product/helpers/redirects.js
@@ -1,6 +1,6 @@
-import {
-  isBeta, redirects, getThemeSettings, isAfter,
-} from '@shopgate/engage/core';
+import { isBeta, isAfter } from '@shopgate/engage/core/helpers';
+import { redirects } from '@shopgate/engage/core/collections';
+import { getThemeSettings } from '@shopgate/engage/core/config';
 import { ITEM_PATTERN } from '@shopgate/pwa-common-commerce/product/constants';
 import { makeGetProductEffectivityDates } from '../selectors/product';
 

--- a/libraries/engage/styles/helpers/setPageBackgroundColor.js
+++ b/libraries/engage/styles/helpers/setPageBackgroundColor.js
@@ -1,5 +1,5 @@
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
-import { hasWebBridge } from '@shopgate/engage/core';
+import { hasWebBridge } from '@shopgate/engage/core/helpers';
 import { setCSSCustomProp } from './cssCustomProperties';
 
 const { colors: { light: defaultBackgroundColor } } = themeConfig;

--- a/libraries/engage/styles/helpers/toggleBodyScroll.js
+++ b/libraries/engage/styles/helpers/toggleBodyScroll.js
@@ -1,5 +1,5 @@
 import MobileDetect from 'mobile-detect';
-import { logger } from '@shopgate/engage/core';
+import { logger } from '@shopgate/engage/core/helpers';
 
 const md = new MobileDetect(navigator.userAgent);
 

--- a/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
@@ -275,6 +275,10 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
                               resolutions={
                                 Array [
                                   Object {
+                                    "height": 1024,
+                                    "width": 1024,
+                                  },
+                                  Object {
                                     "height": 2048,
                                     "width": 2048,
                                   },
@@ -306,6 +310,10 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
                               classNameImg="css-4kgshc"
                               resolutions={
                                 Array [
+                                  Object {
+                                    "height": 1024,
+                                    "width": 1024,
+                                  },
                                   Object {
                                     "height": 2048,
                                     "width": 2048,
@@ -611,6 +619,10 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
                               resolutions={
                                 Array [
                                   Object {
+                                    "height": 1024,
+                                    "width": 1024,
+                                  },
+                                  Object {
                                     "height": 2048,
                                     "width": 2048,
                                   },
@@ -642,6 +654,10 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
                               classNameImg="css-4kgshc"
                               resolutions={
                                 Array [
+                                  Object {
+                                    "height": 1024,
+                                    "width": 1024,
+                                  },
                                   Object {
                                     "height": 2048,
                                     "width": 2048,

--- a/themes/theme-ios11/pages/More/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/pages/More/__snapshots__/index.spec.jsx.snap
@@ -121,17 +121,9 @@ exports[`<More /> should render as expected when the user is logged in 1`] = `
               <LoggedIn
                 logout={[Function]}
               >
-                <Portal
-                  name="nav-menu.my-account.before"
-                  props={
-                    Object {
-                      "Item": [Function],
-                    }
-                  }
-                />
-                <Portal
-                  name="nav-menu.my-account"
-                  props={
+                <SurroundPortals
+                  portalName="nav-menu.my-account"
+                  portalProps={
                     Object {
                       "Item": [Function],
                     }
@@ -185,182 +177,9 @@ exports[`<More /> should render as expected when the user is logged in 1`] = `
                           }
                         }
                       >
-                        <MoreMenuItem
-                          className={null}
-                          href="/account/profile"
-                          label="navigation.profile"
-                          onClick={null}
-                          testId="accountButton"
-                        >
-                          <Connect(Link)
-                            className="css-1hj8a57"
-                            href="/account/profile"
-                          >
-                            <Link
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-1hj8a57"
-                              disabled={false}
-                              historyPush={[Function]}
-                              historyReplace={[Function]}
-                              href="/account/profile"
-                              replace={false}
-                              role="link"
-                              state={Object {}}
-                              tabIndex={null}
-                              tag="div"
-                              target={null}
-                            >
-                              <div
-                                aria-hidden={null}
-                                aria-label={null}
-                                className="css-9auwkz css-1hj8a57 common__link"
-                                data-test-id="link: /account/profile"
-                                href={null}
-                                onClick={[Function]}
-                                role="link"
-                                tabIndex={null}
-                              >
-                                <Translate
-                                  acceptPlainTextWithPlaceholders={false}
-                                  className={null}
-                                  params={Object {}}
-                                  role={null}
-                                  string="navigation.profile"
-                                  transform={null}
-                                >
-                                  <span
-                                    className={null}
-                                    role={null}
-                                  >
-                                    navigation.profile
-                                  </span>
-                                </Translate>
-                              </div>
-                            </Link>
-                          </Connect(Link)>
-                        </MoreMenuItem>
-                        <MoreMenuItem
-                          className={null}
-                          href="/account/orders"
-                          label="navigation.order_history"
-                          onClick={null}
-                          testId="accountButton"
-                        >
-                          <Connect(Link)
-                            className="css-1hj8a57"
-                            href="/account/orders"
-                          >
-                            <Link
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-1hj8a57"
-                              disabled={false}
-                              historyPush={[Function]}
-                              historyReplace={[Function]}
-                              href="/account/orders"
-                              replace={false}
-                              role="link"
-                              state={Object {}}
-                              tabIndex={null}
-                              tag="div"
-                              target={null}
-                            >
-                              <div
-                                aria-hidden={null}
-                                aria-label={null}
-                                className="css-9auwkz css-1hj8a57 common__link"
-                                data-test-id="link: /account/orders"
-                                href={null}
-                                onClick={[Function]}
-                                role="link"
-                                tabIndex={null}
-                              >
-                                <Translate
-                                  acceptPlainTextWithPlaceholders={false}
-                                  className={null}
-                                  params={Object {}}
-                                  role={null}
-                                  string="navigation.order_history"
-                                  transform={null}
-                                >
-                                  <span
-                                    className={null}
-                                    role={null}
-                                  >
-                                    navigation.order_history
-                                  </span>
-                                </Translate>
-                              </div>
-                            </Link>
-                          </Connect(Link)>
-                        </MoreMenuItem>
-                        <MoreMenuItem
-                          className={null}
-                          href="/account/wish-list"
-                          label="navigation.favorites"
-                          onClick={null}
-                          testId="accountButton"
-                        >
-                          <Connect(Link)
-                            className="css-1hj8a57"
-                            href="/account/wish-list"
-                          >
-                            <Link
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-1hj8a57"
-                              disabled={false}
-                              historyPush={[Function]}
-                              historyReplace={[Function]}
-                              href="/account/wish-list"
-                              replace={false}
-                              role="link"
-                              state={Object {}}
-                              tabIndex={null}
-                              tag="div"
-                              target={null}
-                            >
-                              <div
-                                aria-hidden={null}
-                                aria-label={null}
-                                className="css-9auwkz css-1hj8a57 common__link"
-                                data-test-id="link: /account/wish-list"
-                                href={null}
-                                onClick={[Function]}
-                                role="link"
-                                tabIndex={null}
-                              >
-                                <Translate
-                                  acceptPlainTextWithPlaceholders={false}
-                                  className={null}
-                                  params={Object {}}
-                                  role={null}
-                                  string="navigation.favorites"
-                                  transform={null}
-                                >
-                                  <span
-                                    className={null}
-                                    role={null}
-                                  >
-                                    navigation.favorites
-                                  </span>
-                                </Translate>
-                              </div>
-                            </Link>
-                          </Connect(Link)>
-                        </MoreMenuItem>
-                        <Portal
-                          name="nav-menu.logout.before"
-                          props={
-                            Object {
-                              "Item": [Function],
-                            }
-                          }
-                        />
-                        <Portal
-                          name="nav-menu.logout"
-                          props={
+                        <SurroundPortals
+                          portalName="nav-menu.logout"
+                          portalProps={
                             Object {
                               "Item": [Function],
                             }
@@ -379,44 +198,18 @@ exports[`<More /> should render as expected when the user is logged in 1`] = `
                               onClick={[Function]}
                               type="button"
                             >
-                              <Translate
-                                acceptPlainTextWithPlaceholders={false}
-                                className={null}
-                                params={Object {}}
-                                role={null}
+                              <Text
                                 string="navigation.logout"
-                                transform={null}
                               >
-                                <span
-                                  className={null}
-                                  role={null}
-                                >
-                                  navigation.logout
-                                </span>
-                              </Translate>
+                                navigation.logout
+                              </Text>
                             </button>
                           </MoreMenuItem>
-                        </Portal>
-                        <Portal
-                          name="nav-menu.logout.after"
-                          props={
-                            Object {
-                              "Item": [Function],
-                            }
-                          }
-                        />
+                        </SurroundPortals>
                       </div>
                     </Section>
                   </div>
-                </Portal>
-                <Portal
-                  name="nav-menu.my-account.after"
-                  props={
-                    Object {
-                      "Item": [Function],
-                    }
-                  }
-                />
+                </SurroundPortals>
               </LoggedIn>
             </Portal>
             <Portal
@@ -532,53 +325,16 @@ exports[`<More /> should render as expected when the user is logged in 1`] = `
                         onClick={null}
                         testId={null}
                       >
-                        <Connect(Link)
+                        <Link
                           className="css-1hj8a57"
                           href="/page/shipping"
                         >
-                          <Link
-                            aria-hidden={null}
-                            aria-label={null}
-                            className="css-1hj8a57"
-                            disabled={false}
-                            historyPush={[Function]}
-                            historyReplace={[Function]}
-                            href="/page/shipping"
-                            replace={false}
-                            role="link"
-                            state={Object {}}
-                            tabIndex={null}
-                            tag="div"
-                            target={null}
+                          <Text
+                            string="navigation.shipping"
                           >
-                            <div
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-9auwkz css-1hj8a57 common__link"
-                              data-test-id="link: /page/shipping"
-                              href={null}
-                              onClick={[Function]}
-                              role="link"
-                              tabIndex={null}
-                            >
-                              <Translate
-                                acceptPlainTextWithPlaceholders={false}
-                                className={null}
-                                params={Object {}}
-                                role={null}
-                                string="navigation.shipping"
-                                transform={null}
-                              >
-                                <span
-                                  className={null}
-                                  role={null}
-                                >
-                                  navigation.shipping
-                                </span>
-                              </Translate>
-                            </div>
-                          </Link>
-                        </Connect(Link)>
+                            navigation.shipping
+                          </Text>
+                        </Link>
                       </MoreMenuItem>
                     </Portal>
                     <Portal
@@ -620,53 +376,16 @@ exports[`<More /> should render as expected when the user is logged in 1`] = `
                         onClick={null}
                         testId={null}
                       >
-                        <Connect(Link)
+                        <Link
                           className="css-1hj8a57"
                           href="/page/payment"
                         >
-                          <Link
-                            aria-hidden={null}
-                            aria-label={null}
-                            className="css-1hj8a57"
-                            disabled={false}
-                            historyPush={[Function]}
-                            historyReplace={[Function]}
-                            href="/page/payment"
-                            replace={false}
-                            role="link"
-                            state={Object {}}
-                            tabIndex={null}
-                            tag="div"
-                            target={null}
+                          <Text
+                            string="navigation.payment"
                           >
-                            <div
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-9auwkz css-1hj8a57 common__link"
-                              data-test-id="link: /page/payment"
-                              href={null}
-                              onClick={[Function]}
-                              role="link"
-                              tabIndex={null}
-                            >
-                              <Translate
-                                acceptPlainTextWithPlaceholders={false}
-                                className={null}
-                                params={Object {}}
-                                role={null}
-                                string="navigation.payment"
-                                transform={null}
-                              >
-                                <span
-                                  className={null}
-                                  role={null}
-                                >
-                                  navigation.payment
-                                </span>
-                              </Translate>
-                            </div>
-                          </Link>
-                        </Connect(Link)>
+                            navigation.payment
+                          </Text>
+                        </Link>
                       </MoreMenuItem>
                     </Portal>
                     <Portal
@@ -708,53 +427,16 @@ exports[`<More /> should render as expected when the user is logged in 1`] = `
                         onClick={null}
                         testId={null}
                       >
-                        <Connect(Link)
+                        <Link
                           className="css-1hj8a57"
                           href="/page/terms"
                         >
-                          <Link
-                            aria-hidden={null}
-                            aria-label={null}
-                            className="css-1hj8a57"
-                            disabled={false}
-                            historyPush={[Function]}
-                            historyReplace={[Function]}
-                            href="/page/terms"
-                            replace={false}
-                            role="link"
-                            state={Object {}}
-                            tabIndex={null}
-                            tag="div"
-                            target={null}
+                          <Text
+                            string="navigation.terms"
                           >
-                            <div
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-9auwkz css-1hj8a57 common__link"
-                              data-test-id="link: /page/terms"
-                              href={null}
-                              onClick={[Function]}
-                              role="link"
-                              tabIndex={null}
-                            >
-                              <Translate
-                                acceptPlainTextWithPlaceholders={false}
-                                className={null}
-                                params={Object {}}
-                                role={null}
-                                string="navigation.terms"
-                                transform={null}
-                              >
-                                <span
-                                  className={null}
-                                  role={null}
-                                >
-                                  navigation.terms
-                                </span>
-                              </Translate>
-                            </div>
-                          </Link>
-                        </Connect(Link)>
+                            navigation.terms
+                          </Text>
+                        </Link>
                       </MoreMenuItem>
                     </Portal>
                     <Portal
@@ -796,53 +478,16 @@ exports[`<More /> should render as expected when the user is logged in 1`] = `
                         onClick={null}
                         testId={null}
                       >
-                        <Connect(Link)
+                        <Link
                           className="css-1hj8a57"
                           href="/page/privacy"
                         >
-                          <Link
-                            aria-hidden={null}
-                            aria-label={null}
-                            className="css-1hj8a57"
-                            disabled={false}
-                            historyPush={[Function]}
-                            historyReplace={[Function]}
-                            href="/page/privacy"
-                            replace={false}
-                            role="link"
-                            state={Object {}}
-                            tabIndex={null}
-                            tag="div"
-                            target={null}
+                          <Text
+                            string="navigation.privacy"
                           >
-                            <div
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-9auwkz css-1hj8a57 common__link"
-                              data-test-id="link: /page/privacy"
-                              href={null}
-                              onClick={[Function]}
-                              role="link"
-                              tabIndex={null}
-                            >
-                              <Translate
-                                acceptPlainTextWithPlaceholders={false}
-                                className={null}
-                                params={Object {}}
-                                role={null}
-                                string="navigation.privacy"
-                                transform={null}
-                              >
-                                <span
-                                  className={null}
-                                  role={null}
-                                >
-                                  navigation.privacy
-                                </span>
-                              </Translate>
-                            </div>
-                          </Link>
-                        </Connect(Link)>
+                            navigation.privacy
+                          </Text>
+                        </Link>
                       </MoreMenuItem>
                     </Portal>
                     <Portal
@@ -906,53 +551,16 @@ exports[`<More /> should render as expected when the user is logged in 1`] = `
                         onClick={null}
                         testId={null}
                       >
-                        <Connect(Link)
+                        <Link
                           className="css-1hj8a57"
                           href="/page/imprint"
                         >
-                          <Link
-                            aria-hidden={null}
-                            aria-label={null}
-                            className="css-1hj8a57"
-                            disabled={false}
-                            historyPush={[Function]}
-                            historyReplace={[Function]}
-                            href="/page/imprint"
-                            replace={false}
-                            role="link"
-                            state={Object {}}
-                            tabIndex={null}
-                            tag="div"
-                            target={null}
+                          <Text
+                            string="navigation.about"
                           >
-                            <div
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-9auwkz css-1hj8a57 common__link"
-                              data-test-id="link: /page/imprint"
-                              href={null}
-                              onClick={[Function]}
-                              role="link"
-                              tabIndex={null}
-                            >
-                              <Translate
-                                acceptPlainTextWithPlaceholders={false}
-                                className={null}
-                                params={Object {}}
-                                role={null}
-                                string="navigation.about"
-                                transform={null}
-                              >
-                                <span
-                                  className={null}
-                                  role={null}
-                                >
-                                  navigation.about
-                                </span>
-                              </Translate>
-                            </div>
-                          </Link>
-                        </Connect(Link)>
+                            navigation.about
+                          </Text>
+                        </Link>
                       </MoreMenuItem>
                     </Portal>
                     <Portal
@@ -1270,53 +878,16 @@ exports[`<More /> should render as expected when the user is not logged in 1`] =
                         onClick={null}
                         testId={null}
                       >
-                        <Connect(Link)
+                        <Link
                           className="css-1hj8a57"
                           href="/page/shipping"
                         >
-                          <Link
-                            aria-hidden={null}
-                            aria-label={null}
-                            className="css-1hj8a57"
-                            disabled={false}
-                            historyPush={[Function]}
-                            historyReplace={[Function]}
-                            href="/page/shipping"
-                            replace={false}
-                            role="link"
-                            state={Object {}}
-                            tabIndex={null}
-                            tag="div"
-                            target={null}
+                          <Text
+                            string="navigation.shipping"
                           >
-                            <div
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-9auwkz css-1hj8a57 common__link"
-                              data-test-id="link: /page/shipping"
-                              href={null}
-                              onClick={[Function]}
-                              role="link"
-                              tabIndex={null}
-                            >
-                              <Translate
-                                acceptPlainTextWithPlaceholders={false}
-                                className={null}
-                                params={Object {}}
-                                role={null}
-                                string="navigation.shipping"
-                                transform={null}
-                              >
-                                <span
-                                  className={null}
-                                  role={null}
-                                >
-                                  navigation.shipping
-                                </span>
-                              </Translate>
-                            </div>
-                          </Link>
-                        </Connect(Link)>
+                            navigation.shipping
+                          </Text>
+                        </Link>
                       </MoreMenuItem>
                     </Portal>
                     <Portal
@@ -1358,53 +929,16 @@ exports[`<More /> should render as expected when the user is not logged in 1`] =
                         onClick={null}
                         testId={null}
                       >
-                        <Connect(Link)
+                        <Link
                           className="css-1hj8a57"
                           href="/page/payment"
                         >
-                          <Link
-                            aria-hidden={null}
-                            aria-label={null}
-                            className="css-1hj8a57"
-                            disabled={false}
-                            historyPush={[Function]}
-                            historyReplace={[Function]}
-                            href="/page/payment"
-                            replace={false}
-                            role="link"
-                            state={Object {}}
-                            tabIndex={null}
-                            tag="div"
-                            target={null}
+                          <Text
+                            string="navigation.payment"
                           >
-                            <div
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-9auwkz css-1hj8a57 common__link"
-                              data-test-id="link: /page/payment"
-                              href={null}
-                              onClick={[Function]}
-                              role="link"
-                              tabIndex={null}
-                            >
-                              <Translate
-                                acceptPlainTextWithPlaceholders={false}
-                                className={null}
-                                params={Object {}}
-                                role={null}
-                                string="navigation.payment"
-                                transform={null}
-                              >
-                                <span
-                                  className={null}
-                                  role={null}
-                                >
-                                  navigation.payment
-                                </span>
-                              </Translate>
-                            </div>
-                          </Link>
-                        </Connect(Link)>
+                            navigation.payment
+                          </Text>
+                        </Link>
                       </MoreMenuItem>
                     </Portal>
                     <Portal
@@ -1446,53 +980,16 @@ exports[`<More /> should render as expected when the user is not logged in 1`] =
                         onClick={null}
                         testId={null}
                       >
-                        <Connect(Link)
+                        <Link
                           className="css-1hj8a57"
                           href="/page/terms"
                         >
-                          <Link
-                            aria-hidden={null}
-                            aria-label={null}
-                            className="css-1hj8a57"
-                            disabled={false}
-                            historyPush={[Function]}
-                            historyReplace={[Function]}
-                            href="/page/terms"
-                            replace={false}
-                            role="link"
-                            state={Object {}}
-                            tabIndex={null}
-                            tag="div"
-                            target={null}
+                          <Text
+                            string="navigation.terms"
                           >
-                            <div
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-9auwkz css-1hj8a57 common__link"
-                              data-test-id="link: /page/terms"
-                              href={null}
-                              onClick={[Function]}
-                              role="link"
-                              tabIndex={null}
-                            >
-                              <Translate
-                                acceptPlainTextWithPlaceholders={false}
-                                className={null}
-                                params={Object {}}
-                                role={null}
-                                string="navigation.terms"
-                                transform={null}
-                              >
-                                <span
-                                  className={null}
-                                  role={null}
-                                >
-                                  navigation.terms
-                                </span>
-                              </Translate>
-                            </div>
-                          </Link>
-                        </Connect(Link)>
+                            navigation.terms
+                          </Text>
+                        </Link>
                       </MoreMenuItem>
                     </Portal>
                     <Portal
@@ -1534,53 +1031,16 @@ exports[`<More /> should render as expected when the user is not logged in 1`] =
                         onClick={null}
                         testId={null}
                       >
-                        <Connect(Link)
+                        <Link
                           className="css-1hj8a57"
                           href="/page/privacy"
                         >
-                          <Link
-                            aria-hidden={null}
-                            aria-label={null}
-                            className="css-1hj8a57"
-                            disabled={false}
-                            historyPush={[Function]}
-                            historyReplace={[Function]}
-                            href="/page/privacy"
-                            replace={false}
-                            role="link"
-                            state={Object {}}
-                            tabIndex={null}
-                            tag="div"
-                            target={null}
+                          <Text
+                            string="navigation.privacy"
                           >
-                            <div
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-9auwkz css-1hj8a57 common__link"
-                              data-test-id="link: /page/privacy"
-                              href={null}
-                              onClick={[Function]}
-                              role="link"
-                              tabIndex={null}
-                            >
-                              <Translate
-                                acceptPlainTextWithPlaceholders={false}
-                                className={null}
-                                params={Object {}}
-                                role={null}
-                                string="navigation.privacy"
-                                transform={null}
-                              >
-                                <span
-                                  className={null}
-                                  role={null}
-                                >
-                                  navigation.privacy
-                                </span>
-                              </Translate>
-                            </div>
-                          </Link>
-                        </Connect(Link)>
+                            navigation.privacy
+                          </Text>
+                        </Link>
                       </MoreMenuItem>
                     </Portal>
                     <Portal
@@ -1644,53 +1104,16 @@ exports[`<More /> should render as expected when the user is not logged in 1`] =
                         onClick={null}
                         testId={null}
                       >
-                        <Connect(Link)
+                        <Link
                           className="css-1hj8a57"
                           href="/page/imprint"
                         >
-                          <Link
-                            aria-hidden={null}
-                            aria-label={null}
-                            className="css-1hj8a57"
-                            disabled={false}
-                            historyPush={[Function]}
-                            historyReplace={[Function]}
-                            href="/page/imprint"
-                            replace={false}
-                            role="link"
-                            state={Object {}}
-                            tabIndex={null}
-                            tag="div"
-                            target={null}
+                          <Text
+                            string="navigation.about"
                           >
-                            <div
-                              aria-hidden={null}
-                              aria-label={null}
-                              className="css-9auwkz css-1hj8a57 common__link"
-                              data-test-id="link: /page/imprint"
-                              href={null}
-                              onClick={[Function]}
-                              role="link"
-                              tabIndex={null}
-                            >
-                              <Translate
-                                acceptPlainTextWithPlaceholders={false}
-                                className={null}
-                                params={Object {}}
-                                role={null}
-                                string="navigation.about"
-                                transform={null}
-                              >
-                                <span
-                                  className={null}
-                                  role={null}
-                                >
-                                  navigation.about
-                                </span>
-                              </Translate>
-                            </div>
-                          </Link>
-                        </Connect(Link)>
+                            navigation.about
+                          </Text>
+                        </Link>
                       </MoreMenuItem>
                     </Portal>
                     <Portal

--- a/themes/theme-ios11/pages/More/components/Item/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/pages/More/components/Item/__snapshots__/index.spec.jsx.snap
@@ -14,21 +14,11 @@ exports[`<Item /> should render as a button when no href, but a click handler is
     onClick={[Function]}
     type="button"
   >
-    <Translate
-      acceptPlainTextWithPlaceholders={false}
-      className={null}
-      params={Object {}}
-      role={null}
+    <Text
       string="Item Label"
-      transform={null}
     >
-      <span
-        className={null}
-        role={null}
-      >
-        Item Label
-      </span>
-    </Translate>
+      Item Label
+    </Text>
   </button>
 </MoreMenuItem>
 `;
@@ -45,23 +35,11 @@ exports[`<Item /> should render as a link when an href is passed to the props 1`
     className="css-1hj8a57"
     href="/some/link"
   >
-    <div>
-      <Translate
-        acceptPlainTextWithPlaceholders={false}
-        className={null}
-        params={Object {}}
-        role={null}
-        string="Item Label"
-        transform={null}
-      >
-        <span
-          className={null}
-          role={null}
-        >
-          Item Label
-        </span>
-      </Translate>
-    </div>
+    <Text
+      string="Item Label"
+    >
+      Item Label
+    </Text>
   </Link>
 </MoreMenuItem>
 `;

--- a/themes/theme-ios11/pages/More/components/Item/index.jsx
+++ b/themes/theme-ios11/pages/More/components/Item/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Link from '@shopgate/pwa-common/components/Link';
-import I18n from '@shopgate/pwa-common/components/I18n';
+import { Link, I18n } from '@shopgate/engage/components';
 import styles from './style';
 
 /**

--- a/themes/theme-ios11/pages/More/components/Item/index.spec.jsx
+++ b/themes/theme-ios11/pages/More/components/Item/index.spec.jsx
@@ -2,22 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import Item from './index';
 
-jest.mock('@shopgate/pwa-common/components/Link', () => {
-  /* eslint-disable react/prop-types */
-  /**
-   * Mocked LinkComponent.
-   * @param {Object} props Component props.
-   * @return {JSX}
-   */
-  const Link = ({ children }) => (
-    <div>
-      {children}
-    </div>
-  );
-
-  /* eslint-enable react/prop-types */
-  return Link;
-});
+jest.mock('@shopgate/engage/components');
 
 const label = 'Item Label';
 
@@ -38,6 +23,6 @@ describe('<Item />', () => {
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('Link').exists()).toBe(true);
     expect(wrapper.find('Link').prop('href')).toBe(href);
-    expect(wrapper.text()).toBe(label);
+    expect(wrapper.find('Text').prop('string')).toBe(label);
   });
 });

--- a/themes/theme-ios11/pages/More/components/Quicklinks/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/pages/More/components/Quicklinks/__snapshots__/index.spec.jsx.snap
@@ -128,23 +128,11 @@ exports[`<Quicklinks /> should render quicklinks 1`] = `
                   className="css-1hj8a57"
                   href="/some/url"
                 >
-                  <div>
-                    <Translate
-                      acceptPlainTextWithPlaceholders={false}
-                      className={null}
-                      params={Object {}}
-                      role={null}
-                      string="Some Label"
-                      transform={null}
-                    >
-                      <span
-                        className={null}
-                        role={null}
-                      >
-                        Some Label
-                      </span>
-                    </Translate>
-                  </div>
+                  <Text
+                    string="Some Label"
+                  >
+                    Some Label
+                  </Text>
                 </Link>
               </MoreMenuItem>
               <MoreMenuItem
@@ -159,23 +147,11 @@ exports[`<Quicklinks /> should render quicklinks 1`] = `
                   className="css-1hj8a57"
                   href="/another/url"
                 >
-                  <div>
-                    <Translate
-                      acceptPlainTextWithPlaceholders={false}
-                      className={null}
-                      params={Object {}}
-                      role={null}
-                      string="Another Label"
-                      transform={null}
-                    >
-                      <span
-                        className={null}
-                        role={null}
-                      >
-                        Another Label
-                      </span>
-                    </Translate>
-                  </div>
+                  <Text
+                    string="Another Label"
+                  >
+                    Another Label
+                  </Text>
                 </Link>
               </MoreMenuItem>
             </SurroundPortals>

--- a/themes/theme-ios11/pages/More/components/Quicklinks/index.spec.jsx
+++ b/themes/theme-ios11/pages/More/components/Quicklinks/index.spec.jsx
@@ -11,17 +11,6 @@ jest.mock('@shopgate/engage/back-in-stock/selectors', () => ({
   getIsBackInStockEnabled: jest.fn(() => false),
 }));
 jest.mock('@shopgate/engage/components');
-jest.mock('@shopgate/pwa-common/components/Link', () => {
-  /* eslint-disable react/prop-types, require-jsdoc */
-  const Link = ({ children }) => (
-    <div>
-      {children}
-    </div>
-  );
-
-  /* eslint-enable react/prop-types, require-jsdoc */
-  return Link;
-});
 
 let mockedQuicklinks;
 jest.mock('@shopgate/pwa-common/selectors/menu', () => ({
@@ -52,7 +41,7 @@ describe('<Quicklinks />', () => {
     const links = wrapper.find('Link');
     quicklinks.forEach((entry, index) => {
       const link = links.at(index);
-      expect(link.text()).toBe(entry.label);
+      expect(link.find('Text').prop('string')).toBe(entry.label);
       expect(link.prop('href')).toBe(entry.url);
     });
   });

--- a/themes/theme-ios11/pages/More/components/Section/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/pages/More/components/Section/__snapshots__/index.spec.jsx.snap
@@ -63,23 +63,11 @@ exports[`<Section /> should render with a headline and items 1`] = `
         className="css-1hj8a57"
         href="/link/one"
       >
-        <div>
-          <Translate
-            acceptPlainTextWithPlaceholders={false}
-            className={null}
-            params={Object {}}
-            role={null}
-            string="Item One"
-            transform={null}
-          >
-            <span
-              className={null}
-              role={null}
-            >
-              Item One
-            </span>
-          </Translate>
-        </div>
+        <Text
+          string="Item One"
+        >
+          Item One
+        </Text>
       </Link>
     </MoreMenuItem>
     <MoreMenuItem
@@ -93,23 +81,11 @@ exports[`<Section /> should render with a headline and items 1`] = `
         className="css-1hj8a57"
         href="/link/two"
       >
-        <div>
-          <Translate
-            acceptPlainTextWithPlaceholders={false}
-            className={null}
-            params={Object {}}
-            role={null}
-            string="Item Two"
-            transform={null}
-          >
-            <span
-              className={null}
-              role={null}
-            >
-              Item Two
-            </span>
-          </Translate>
-        </div>
+        <Text
+          string="Item Two"
+        >
+          Item Two
+        </Text>
       </Link>
     </MoreMenuItem>
   </div>
@@ -147,23 +123,11 @@ exports[`<Section /> should render without a headline but items 1`] = `
         className="css-1hj8a57"
         href="/link/one"
       >
-        <div>
-          <Translate
-            acceptPlainTextWithPlaceholders={false}
-            className={null}
-            params={Object {}}
-            role={null}
-            string="Item One"
-            transform={null}
-          >
-            <span
-              className={null}
-              role={null}
-            >
-              Item One
-            </span>
-          </Translate>
-        </div>
+        <Text
+          string="Item One"
+        >
+          Item One
+        </Text>
       </Link>
     </MoreMenuItem>
     <MoreMenuItem
@@ -177,23 +141,11 @@ exports[`<Section /> should render without a headline but items 1`] = `
         className="css-1hj8a57"
         href="/link/two"
       >
-        <div>
-          <Translate
-            acceptPlainTextWithPlaceholders={false}
-            className={null}
-            params={Object {}}
-            role={null}
-            string="Item Two"
-            transform={null}
-          >
-            <span
-              className={null}
-              role={null}
-            >
-              Item Two
-            </span>
-          </Translate>
-        </div>
+        <Text
+          string="Item Two"
+        >
+          Item Two
+        </Text>
       </Link>
     </MoreMenuItem>
   </div>

--- a/themes/theme-ios11/pages/More/components/Section/index.spec.jsx
+++ b/themes/theme-ios11/pages/More/components/Section/index.spec.jsx
@@ -4,17 +4,7 @@ import Item from '../Item';
 import Section from './index';
 import styles from '../../style';
 
-jest.mock('@shopgate/pwa-common/components/Link', () => {
-  /* eslint-disable react/prop-types, require-jsdoc */
-  const Link = ({ children }) => (
-    <div>
-      {children}
-    </div>
-  );
-
-  /* eslint-enable react/prop-types require-jsdoc */
-  return Link;
-});
+jest.mock('@shopgate/engage/components');
 
 describe('<Section />', () => {
   it('should render with a headline and items', () => {

--- a/themes/theme-ios11/pages/More/components/UserMenu/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/pages/More/components/UserMenu/__snapshots__/index.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<UserMenu /> should render as expected when the user is logged in 1`] = `
+exports[`<UserMenu /> should render additional links when logged in and new services are enabled 1`] = `
 <Provider
   store={
     Object {
@@ -15,7 +15,7 @@ exports[`<UserMenu /> should render as expected when the user is logged in 1`] =
   <UserMenu
     entries={null}
     isLoggedIn={true}
-    logout={[MockFunction]}
+    logout={[Function]}
     user={null}
   >
     <Portal
@@ -23,9 +23,9 @@ exports[`<UserMenu /> should render as expected when the user is logged in 1`] =
       props={
         Object {
           "entries": null,
-          "handleLogout": [MockFunction],
+          "handleLogout": [Function],
           "isLoggedIn": true,
-          "logout": [MockFunction],
+          "logout": [Function],
           "user": null,
         }
       }
@@ -35,27 +35,19 @@ exports[`<UserMenu /> should render as expected when the user is logged in 1`] =
       props={
         Object {
           "entries": null,
-          "handleLogout": [MockFunction],
+          "handleLogout": [Function],
           "isLoggedIn": true,
-          "logout": [MockFunction],
+          "logout": [Function],
           "user": null,
         }
       }
     >
       <LoggedIn
-        logout={[MockFunction]}
+        logout={[Function]}
       >
-        <Portal
-          name="nav-menu.my-account.before"
-          props={
-            Object {
-              "Item": [Function],
-            }
-          }
-        />
-        <Portal
-          name="nav-menu.my-account"
-          props={
+        <SurroundPortals
+          portalName="nav-menu.my-account"
+          portalProps={
             Object {
               "Item": [Function],
             }
@@ -120,21 +112,11 @@ exports[`<UserMenu /> should render as expected when the user is logged in 1`] =
                     className="css-1hj8a57"
                     href="/account/profile"
                   >
-                    <Translate
-                      acceptPlainTextWithPlaceholders={false}
-                      className={null}
-                      params={Object {}}
-                      role={null}
+                    <Text
                       string="navigation.profile"
-                      transform={null}
                     >
-                      <span
-                        className={null}
-                        role={null}
-                      >
-                        navigation.profile
-                      </span>
-                    </Translate>
+                      navigation.profile
+                    </Text>
                   </Link>
                 </MoreMenuItem>
                 <MoreMenuItem
@@ -148,21 +130,11 @@ exports[`<UserMenu /> should render as expected when the user is logged in 1`] =
                     className="css-1hj8a57"
                     href="/account/orders"
                   >
-                    <Translate
-                      acceptPlainTextWithPlaceholders={false}
-                      className={null}
-                      params={Object {}}
-                      role={null}
+                    <Text
                       string="navigation.order_history"
-                      transform={null}
                     >
-                      <span
-                        className={null}
-                        role={null}
-                      >
-                        navigation.order_history
-                      </span>
-                    </Translate>
+                      navigation.order_history
+                    </Text>
                   </Link>
                 </MoreMenuItem>
                 <MoreMenuItem
@@ -176,34 +148,168 @@ exports[`<UserMenu /> should render as expected when the user is logged in 1`] =
                     className="css-1hj8a57"
                     href="/account/wish-list"
                   >
-                    <Translate
-                      acceptPlainTextWithPlaceholders={false}
-                      className={null}
-                      params={Object {}}
-                      role={null}
+                    <Text
                       string="navigation.favorites"
-                      transform={null}
                     >
-                      <span
-                        className={null}
-                        role={null}
-                      >
-                        navigation.favorites
-                      </span>
-                    </Translate>
+                      navigation.favorites
+                    </Text>
                   </Link>
                 </MoreMenuItem>
-                <Portal
-                  name="nav-menu.logout.before"
-                  props={
+                <SurroundPortals
+                  portalName="nav-menu.logout"
+                  portalProps={
                     Object {
                       "Item": [Function],
                     }
                   }
-                />
-                <Portal
-                  name="nav-menu.logout"
-                  props={
+                >
+                  <MoreMenuItem
+                    className={null}
+                    href={null}
+                    label="navigation.logout"
+                    onClick={[Function]}
+                    testId="logoutButton"
+                  >
+                    <button
+                      className="css-1hj8a57"
+                      data-test-id="logoutButton"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <Text
+                        string="navigation.logout"
+                      >
+                        navigation.logout
+                      </Text>
+                    </button>
+                  </MoreMenuItem>
+                </SurroundPortals>
+              </div>
+            </Section>
+          </div>
+        </SurroundPortals>
+      </LoggedIn>
+    </Portal>
+    <Portal
+      name="user-menu.container.after"
+      props={
+        Object {
+          "entries": null,
+          "handleLogout": [Function],
+          "isLoggedIn": true,
+          "logout": [Function],
+          "user": null,
+        }
+      }
+    />
+  </UserMenu>
+</Provider>
+`;
+
+exports[`<UserMenu /> should render as expected when the user is logged in 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <UserMenu
+    entries={null}
+    isLoggedIn={true}
+    logout={[MockFunction]}
+    user={null}
+  >
+    <Portal
+      name="user-menu.container.before"
+      props={
+        Object {
+          "entries": null,
+          "handleLogout": [MockFunction],
+          "isLoggedIn": true,
+          "logout": [MockFunction],
+          "user": null,
+        }
+      }
+    />
+    <Portal
+      name="user-menu.container"
+      props={
+        Object {
+          "entries": null,
+          "handleLogout": [MockFunction],
+          "isLoggedIn": true,
+          "logout": [MockFunction],
+          "user": null,
+        }
+      }
+    >
+      <LoggedIn
+        logout={[MockFunction]}
+      >
+        <SurroundPortals
+          portalName="nav-menu.my-account"
+          portalProps={
+            Object {
+              "Item": [Function],
+            }
+          }
+        >
+          <div
+            data-test-id="userMenu"
+          >
+            <Section
+              title="navigation.your_account"
+            >
+              <Headline
+                style={
+                  Object {
+                    "margin": "24px 20px 16px",
+                  }
+                }
+                tag="h2"
+                text="navigation.your_account"
+              >
+                <h2
+                  className="css-18cwfw7 headline theme__headline"
+                  data-test-id="Headline"
+                  style={
+                    Object {
+                      "margin": "24px 20px 16px",
+                    }
+                  }
+                >
+                  <Translate
+                    acceptPlainTextWithPlaceholders={false}
+                    className={null}
+                    params={Object {}}
+                    role={null}
+                    string="navigation.your_account"
+                    transform={null}
+                  >
+                    <span
+                      className={null}
+                      role={null}
+                    >
+                      navigation.your_account
+                    </span>
+                  </Translate>
+                </h2>
+              </Headline>
+              <div
+                className={
+                  Object {
+                    "data-css-13ch7sr": "",
+                  }
+                }
+              >
+                <SurroundPortals
+                  portalName="nav-menu.logout"
+                  portalProps={
                     Object {
                       "Item": [Function],
                     }
@@ -222,44 +328,18 @@ exports[`<UserMenu /> should render as expected when the user is logged in 1`] =
                       onClick={[MockFunction]}
                       type="button"
                     >
-                      <Translate
-                        acceptPlainTextWithPlaceholders={false}
-                        className={null}
-                        params={Object {}}
-                        role={null}
+                      <Text
                         string="navigation.logout"
-                        transform={null}
                       >
-                        <span
-                          className={null}
-                          role={null}
-                        >
-                          navigation.logout
-                        </span>
-                      </Translate>
+                        navigation.logout
+                      </Text>
                     </button>
                   </MoreMenuItem>
-                </Portal>
-                <Portal
-                  name="nav-menu.logout.after"
-                  props={
-                    Object {
-                      "Item": [Function],
-                    }
-                  }
-                />
+                </SurroundPortals>
               </div>
             </Section>
           </div>
-        </Portal>
-        <Portal
-          name="nav-menu.my-account.after"
-          props={
-            Object {
-              "Item": [Function],
-            }
-          }
-        />
+        </SurroundPortals>
       </LoggedIn>
     </Portal>
     <Portal

--- a/themes/theme-ios11/pages/More/components/UserMenu/components/LoggedIn/index.jsx
+++ b/themes/theme-ios11/pages/More/components/UserMenu/components/LoggedIn/index.jsx
@@ -1,7 +1,8 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import Portal from '@shopgate/pwa-common/components/Portal';
-import * as commonPortals from '@shopgate/pwa-common/constants/Portals';
+import { hasNewServices } from '@shopgate/engage/core/helpers';
+import { NAV_MENU_MY_ACCOUNT, NAV_MENU_LOGOUT } from '@shopgate/engage/core/constants';
+import { SurroundPortals } from '@shopgate/engage/components';
 import { ORDERS_PATH, WISH_LIST_PATH, PROFILE_PATH } from '@shopgate/engage/account/constants';
 import Section from '../../../Section';
 import Item from '../../../Item';
@@ -14,40 +15,38 @@ import Item from '../../../Item';
 const LoggedIn = ({ logout }) => {
   const props = { Item };
   return (
-    <Fragment>
-      <Portal name={commonPortals.NAV_MENU_MY_ACCOUNT_BEFORE} props={props} />
-      <Portal name={commonPortals.NAV_MENU_MY_ACCOUNT} props={props}>
-        <div data-test-id="userMenu">
-          <Section title="navigation.your_account">
-            <Item
-              href={PROFILE_PATH}
-              label="navigation.profile"
-              testId="accountButton"
-            />
-            <Item
-              href={ORDERS_PATH}
-              label="navigation.order_history"
-              testId="accountButton"
-            />
-            <Item
-              href={WISH_LIST_PATH}
-              label="navigation.favorites"
-              testId="accountButton"
-            />
-            <Portal name={commonPortals.NAV_MENU_LOGOUT_BEFORE} props={props} />
-            <Portal name={commonPortals.NAV_MENU_LOGOUT} props={props}>
+    <SurroundPortals portalName={NAV_MENU_MY_ACCOUNT} portalProps={props}>
+      <div data-test-id="userMenu">
+        <Section title="navigation.your_account">
+          {hasNewServices() && (
+            <>
               <Item
-                onClick={logout}
-                label="navigation.logout"
-                testId="logoutButton"
+                href={PROFILE_PATH}
+                label="navigation.profile"
+                testId="accountButton"
               />
-            </Portal>
-            <Portal name={commonPortals.NAV_MENU_LOGOUT_AFTER} props={props} />
-          </Section>
-        </div>
-      </Portal>
-      <Portal name={commonPortals.NAV_MENU_MY_ACCOUNT_AFTER} props={props} />
-    </Fragment>
+              <Item
+                href={ORDERS_PATH}
+                label="navigation.order_history"
+                testId="accountButton"
+              />
+              <Item
+                href={WISH_LIST_PATH}
+                label="navigation.favorites"
+                testId="accountButton"
+              />
+            </>
+          )}
+          <SurroundPortals portalName={NAV_MENU_LOGOUT} portalProps={props}>
+            <Item
+              onClick={logout}
+              label="navigation.logout"
+              testId="logoutButton"
+            />
+          </SurroundPortals>
+        </Section>
+      </div>
+    </SurroundPortals>
   );
 };
 

--- a/themes/theme-ios11/pages/More/components/UserMenu/components/LoggedIn/index.jsx
+++ b/themes/theme-ios11/pages/More/components/UserMenu/components/LoggedIn/index.jsx
@@ -9,7 +9,7 @@ import Item from '../../../Item';
 
 /**
  * @param {Object} props The component props.
- * @param {Object} context The consumed context.
+ * @param {Function} props.logout Callback invoked when users press the "logout" button
  * @returns {JSX}
  */
 const LoggedIn = ({ logout }) => {

--- a/themes/theme-ios11/pages/More/components/UserMenu/index.spec.jsx
+++ b/themes/theme-ios11/pages/More/components/UserMenu/index.spec.jsx
@@ -4,6 +4,8 @@ import { Provider } from 'react-redux';
 import { createMockStore } from '@shopgate/pwa-common/store';
 import { isUserLoginDisabled } from '@shopgate/pwa-common/selectors/user';
 import mockRenderOptions from '@shopgate/pwa-common/helpers/mocks/mockRenderOptions';
+import { hasNewServices } from '@shopgate/engage/core/helpers';
+import { ORDERS_PATH, WISH_LIST_PATH, PROFILE_PATH } from '@shopgate/engage/account/constants';
 import UserMenu from './index';
 
 jest.mock('@shopgate/engage/components');
@@ -12,8 +14,9 @@ jest.mock('@shopgate/pwa-common/selectors/user', () => ({
   isUserLoginDisabled: jest.fn().mockReturnValue(false),
 }));
 
-jest.mock('@shopgate/pwa-common/components/Link', () => function Link({ children }) { return children; });
-jest.mock('@shopgate/pwa-ui-shared/Sheet', () => null);
+jest.mock('@shopgate/engage/core/helpers/environment', () => ({
+  hasNewServices: jest.fn().mockReturnValue(false),
+}));
 
 const store = createMockStore();
 
@@ -30,6 +33,10 @@ describe('<UserMenu />', () => {
     expect(wrapper.find('MoreMenuItem').last().text()).toBe('navigation.logout');
     wrapper.find('MoreMenuItem').last().simulate('click');
     expect(logoutHandler).toHaveBeenCalledTimes(1);
+
+    expect(wrapper.exists({ href: PROFILE_PATH })).toBe(false);
+    expect(wrapper.exists({ href: WISH_LIST_PATH })).toBe(false);
+    expect(wrapper.exists({ href: ORDERS_PATH })).toBe(false);
   });
 
   it('should render as expected when the user is logged out and the buttons are enabled', () => {
@@ -58,5 +65,19 @@ describe('<UserMenu />', () => {
     const links = wrapper.find('Link');
     expect(links.at(0).prop('disabled')).toBe(true);
     expect(links.at(1).prop('disabled')).toBe(true);
+  });
+
+  it('should render additional links when logged in and new services are enabled', () => {
+    hasNewServices.mockReturnValueOnce(true);
+
+    const wrapper = mount((
+      <Provider store={store}>
+        <UserMenu isLoggedIn logout={() => {}} />
+      </Provider>), mockRenderOptions);
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.exists({ href: PROFILE_PATH })).toBe(true);
+    expect(wrapper.exists({ href: WISH_LIST_PATH })).toBe(true);
+    expect(wrapper.exists({ href: ORDERS_PATH })).toBe(true);
   });
 });

--- a/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
@@ -275,6 +275,10 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
                               resolutions={
                                 Array [
                                   Object {
+                                    "height": 1024,
+                                    "width": 1024,
+                                  },
+                                  Object {
                                     "height": 2048,
                                     "width": 2048,
                                   },
@@ -306,6 +310,10 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
                               classNameImg="css-4kgshc"
                               resolutions={
                                 Array [
+                                  Object {
+                                    "height": 1024,
+                                    "width": 1024,
+                                  },
                                   Object {
                                     "height": 2048,
                                     "width": 2048,
@@ -611,6 +619,10 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
                               resolutions={
                                 Array [
                                   Object {
+                                    "height": 1024,
+                                    "width": 1024,
+                                  },
+                                  Object {
                                     "height": 2048,
                                     "width": 2048,
                                   },
@@ -642,6 +654,10 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
                               classNameImg="css-4kgshc"
                               resolutions={
                                 Array [
+                                  Object {
+                                    "height": 1024,
+                                    "width": 1024,
+                                  },
                                   Object {
                                     "height": 2048,
                                     "width": 2048,


### PR DESCRIPTION
# Description
This pull requests is about to implement bugfixes for the merged PWA6 and PWA7 codebases that where found during testing.

- removed links in `more` page of the the iOS theme that are only supposed to be visible for logged in users for shops that are deployed on the new services (account, order history, wishlist on account page)
- fixed "redirects" to external urls e.g. from `/register` to webshop url

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
