### PR TITLE
Fixed issue in native checkout caused by update of react-redux

### DIFF
--- a/libraries/engage/checkout/paymentMethods/index.jsx
+++ b/libraries/engage/checkout/paymentMethods/index.jsx
@@ -6,7 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { connect } from 'react-redux';
+import { connect, useStore } from 'react-redux';
 import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
@@ -156,6 +156,8 @@ const PaymentMethodProvider = ({
     },
   }), [setButtonLocked]);
 
+  const store = useStore();
+
   // Ignore for ROPIS.
   if (!needsPayment) {
     return null;
@@ -182,7 +184,16 @@ const PaymentMethodProvider = ({
         </div>
         {paymentImpl ? (
           <Provider
+            /**
+             * 2025-01-10: Not 100% sure why a context is being passed here. It seems to work
+             * without it, but since the payment component implementation has a high complexity,
+             * but isn't really used right now in production shops, i kept it for now.
+             * To enable compatibility with react-redux > 7, the "store" prop was added so that
+             * Redux connected child components can still access the store.
+             * Should be revisited when the "native checkout" gets relevance.
+             */
             context={Context}
+            store={store}
             data={paymentData}
             activePaymentMeta={activePaymentMeta}
           >

--- a/libraries/engage/package.json
+++ b/libraries/engage/package.json
@@ -22,7 +22,7 @@
     "@shopgate/pwa-ui-ios": "7.21.2",
     "@shopgate/pwa-ui-material": "7.21.2",
     "@shopgate/pwa-ui-shared": "7.21.2",
-    "@stripe/react-stripe-js": "^1.1.2",
+    "@stripe/react-stripe-js": "^1.16.5",
     "@stripe/stripe-js": "^1.3.1",
     "@virtuous/conductor": "~2.5.0",
     "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,10 +2103,10 @@
   dependencies:
     event-target-shim "^5.0.1"
 
-"@stripe/react-stripe-js@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@stripe/react-stripe-js/-/react-stripe-js-1.1.2.tgz#a7f5ef5b4d7dc7fa723501b706644414cfe6dcba"
-  integrity sha512-07hu8RJXwWKGbvdvd1yt1cYvGtDB8jFX+q10f7FQuItUt9rlSo0am3WIx845iMHANiYgxyRb1PS201Yle9xxPQ==
+"@stripe/react-stripe-js@^1.16.5":
+  version "1.16.5"
+  resolved "https://registry.yarnpkg.com/@stripe/react-stripe-js/-/react-stripe-js-1.16.5.tgz#51cf862b50ca91ae6193c77a5bec889e81047f10"
+  integrity sha512-lVPW3IfwdacyS22pP+nBB6/GNFRRhT/4jfgAK6T2guQmtzPwJV1DogiGGaBNhiKtSY18+yS8KlHSu+PvZNclvQ==
   dependencies:
     prop-types "^15.7.2"
 


### PR DESCRIPTION
# Description
This pull request fixes an issue that was introduced with the update of `react-redux` package to a recent version. Due to the changes how react-redux handles the store now (new React context API) the providers of payment components (e.g. `StripeProvider`) where not able to access the Redux store anymore.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
- connect to a shop that uses the new services
- put a product with BOPIS fulfillment method into the cart and goto checkout
- select credit card as payment method
- add test credit card data (your name, expiration date in the future, number 4242 4242 4242 4242)
- complete checkout

Without the changes from this PR there should be a React error in the console and the PWA app should be broken (white screen). With the changes everything should work as expected and checkout should be possible again.