### PR TITLE
Prevented duplicate execution of opt-in tracking events

### DIFF
--- a/libraries/engage/push-opt-in/components/PushOptInModal/index.jsx
+++ b/libraries/engage/push-opt-in/components/PushOptInModal/index.jsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
+import throttle from 'lodash/throttle';
 import classNames from 'classnames';
 import {
   Grid, I18n, Button, Modal,
@@ -53,6 +54,17 @@ const PushOptInModal = ({
     }
   }, [modalImageSVG, modalImageURL]);
 
+  // Button event handlers are throttled to prevent multiple clicks
+  const handleAllowPushOptIn = useCallback(
+    throttle(allowPushOptIn, 1000, { leading: true, trailing: false }),
+    []
+  );
+
+  const handleDenyPushOptIn = useCallback(
+    throttle(denyPushOptIn, 1000, { leading: true, trailing: false }),
+    []
+  );
+
   if (!isPushOptInModalVisible) {
     return null;
   }
@@ -84,10 +96,10 @@ const PushOptInModal = ({
             string={modalMessage || 'pushOptInModal.message'}
             id="pushOptInDialogMessage"
           />
-          <Button onClick={allowPushOptIn} type="primary" className={classNames(styles.button, 'push-opt-in-modal__button-allow')}>
+          <Button onClick={handleAllowPushOptIn} type="primary" className={classNames(styles.button, 'push-opt-in-modal__button-allow')}>
             <I18n.Text string={modalButtonAllow || 'pushOptInModal.buttonAllow'} />
           </Button>
-          <Button onClick={denyPushOptIn} type="plain" className={classNames(styles.button, 'push-opt-in-modal__button-deny')}>
+          <Button onClick={handleDenyPushOptIn} type="plain" className={classNames(styles.button, 'push-opt-in-modal__button-deny')}>
             <I18n.Text string={modalButtonDeny || 'pushOptInModal.buttonDeny'} className={styles.buttonText} />
           </Button>
         </Grid.Item>

--- a/libraries/engage/tracking/components/CookieConsentModal/index.jsx
+++ b/libraries/engage/tracking/components/CookieConsentModal/index.jsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
+import throttle from 'lodash/throttle';
 import {
   Grid, I18n, Button, Modal, Link, ConditionalWrapper,
 } from '@shopgate/engage/components';
@@ -59,6 +60,22 @@ const CookieConsentModal = ({
     }
   }, [modalImageSVG, modalImageURL]);
 
+  // Button event handlers are throttled to prevent multiple clicks
+  const handleAcceptAllCookies = useCallback(
+    throttle(acceptAllCookies, 1000, { leading: true, trailing: false }),
+    []
+  );
+
+  const handleAcceptRequiredCookies = useCallback(
+    throttle(acceptRequiredCookies, 1000, { leading: true, trailing: false }),
+    []
+  );
+
+  const handleOpenPrivacySettings = useCallback(
+    throttle(openPrivacySettings, 1000, { leading: true, trailing: false }),
+    []
+  );
+
   if (!isCookieConsentModalVisible) {
     return null;
   }
@@ -108,7 +125,7 @@ const CookieConsentModal = ({
 
           <Grid.Item component="div" className={styles.buttonWrapper}>
             <Button
-              onClick={acceptAllCookies}
+              onClick={handleAcceptAllCookies}
               type="primary"
               className={classNames(styles.button, 'cookie-consent-modal__button-accept-all')}
             >
@@ -116,7 +133,7 @@ const CookieConsentModal = ({
             </Button>
             {showRequiredCookiesButton ? (
               <Button
-                onClick={acceptRequiredCookies}
+                onClick={handleAcceptRequiredCookies}
                 type="simple"
                 className={classNames(styles.button, 'cookie-consent-modal__button-accept-required')}
               >
@@ -124,7 +141,7 @@ const CookieConsentModal = ({
               </Button>
             ) : null}
             <Button
-              onClick={openPrivacySettings}
+              onClick={handleOpenPrivacySettings}
               type="simple"
               className={classNames(styles.button, 'cookie-consent-modal__button-open-settings')}
             >


### PR DESCRIPTION
# Description
This pull request resolves an issue where, in rare scenarios, push opt-in and tracking opt-in events were executed twice.

The root cause of this issue was identified as users double-tapping buttons inside the opt-in modals, leading to the double tracking of the `softOptInSelected` and `hardOptInShown` events.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
The most easy way to reproduce the issue is to open a shop with soft push opt-in inside the Android app. When the push opt-in modal comes visible, open the developer tools and double tap on the "Enable Notifications" button.
Without this fix the events noted inside the descriptions are dispatched twice.