### PR TITLE
Added mechanism to modify external image urls

### DIFF
--- a/libraries/common/constants/Configuration.js
+++ b/libraries/common/constants/Configuration.js
@@ -24,11 +24,11 @@ export const IS_CONNECT_EXTENSION_ATTACHED = 'IS_CONNECT_EXTENSION_ATTACHED';
  * @example
  * configuration.set(
  *  CONFIGURATION_COLLECTION_CREATE_EXTERNAL_IMAGE_URL,
- *  (src, { width } = {}) => {
- *    if (!src || !src.startsWith('https://mycdn.com')) {
+ *  (baseUrl, { width } = {}) => {
+ *    if (!baseUrl || !baseUrl.startsWith('https://mycdn.com')) {
  *      return null;
  *    }
- *    return `${src}?width=${width}`;
+ *    return `${baseUrl}?width=${width}`;
  *   }
  * );
  */

--- a/libraries/common/constants/Configuration.js
+++ b/libraries/common/constants/Configuration.js
@@ -5,3 +5,32 @@ export const TAB_BAR_PATTERNS_BLACK_LIST = 'TAB_BAR_PATTERNS_BLACK_LIST';
 export const CONFIGURATION_COLLECTION_KEY_BASE_URL = 'CONFIGURATION_COLLECTION_KEY_BASE_URL';
 export const PIPELINES = 'PIPELINES';
 export const IS_CONNECT_EXTENSION_ATTACHED = 'IS_CONNECT_EXTENSION_ATTACHED';
+
+/**
+ * This configuration collection key can be used to register a helper function to modify external
+ * image urls that are not delivered via the Shopgate CDN. The handler allows to add additional
+ * parameters to the image url to e.g. set resolution, format or quality.
+ *
+ * The handler function receives the source url and an object containing the options for the image.
+ * @param {string} src - The plain source URL of the image.
+ * @param {Object} options - An object containing parameters for the image.
+ * @param {number} options.width - The desired width of the image in pixels.
+ * @param {number} options.height - The desired height of the image in pixels.
+ * @param {string} options.fillColor - A hex color code to use as the background fill color.
+ * @param {number} options.quality - The quality of the image (e.g., for compression) as percentage.
+ * @param {string} options.format - The desired image format (e.g., 'jpeg', 'png').
+ * @returns {string|null|undefined} - The modified image URL.
+ *
+ * @example
+ * configuration.set(
+ *  CONFIGURATION_COLLECTION_CREATE_EXTERNAL_IMAGE_URL,
+ *  (src, { width } = {}) => {
+ *    if (!src || !src.startsWith('https://mycdn.com')) {
+ *      return null;
+ *    }
+ *    return `${src}?width=${width}`;
+ *   }
+ * );
+ */
+export const CONFIGURATION_COLLECTION_CREATE_EXTERNAL_IMAGE_URL =
+  'CONFIGURATION_COLLECTION_CREATE_EXTERNAL_IMAGE_URL';

--- a/libraries/engage/core/helpers/getFullImageSource.js
+++ b/libraries/engage/core/helpers/getFullImageSource.js
@@ -1,3 +1,5 @@
+import { CONFIGURATION_COLLECTION_CREATE_EXTERNAL_IMAGE_URL } from '@shopgate/engage/core/constants';
+import { configuration } from '@shopgate/engage/core/collections';
 import { getProductImageSettings } from '../../product/helpers';
 import { getImageFormat } from './getImageFormat';
 
@@ -65,6 +67,27 @@ export const getFullImageSource = (src, { width, height } = {}) => {
       zd: 'resize',
       fillc: 'FFFFFF',
     });
+  }
+
+  // Check if an extension registered an external image url handler within the config collection.
+  const createUrlFn = configuration.get(CONFIGURATION_COLLECTION_CREATE_EXTERNAL_IMAGE_URL);
+
+  if (typeof createUrlFn === 'function') {
+    const { fillColor, quality } = getProductImageSettings();
+    const format = getImageFormat();
+
+    // Invoke the handler with all relevant parameters.
+    const externalUrl = createUrlFn(src, {
+      width,
+      height,
+      fillColor,
+      quality,
+      format,
+    });
+
+    if (!!externalUrl && typeof externalUrl === 'string') {
+      return externalUrl;
+    }
   }
 
   return src;


### PR DESCRIPTION
# Description
Images within the PWA are typically delivered via the Shopgate CDN, with URLs containing multiple parameters to optimize them for specific use cases. For example:
- Images in a product list use a smaller resolution.
- Images on a product details page use a higher resolution.

However, there are scenarios where the default Shopgate image base URLs might be replaced by URLs from external CDNs through pipeline steps. To provide extension developers with the ability to create optimized images for various use cases, this pull request introduces a new feature enabling the registration of handler functions to extend external CDN image base URLs dynamically.

The feature is implemented via the `configuration` collection and can be used as follows:

```js
import { configuration } from '@shopgate/engage/core/collections';
import { CONFIGURATION_COLLECTION_CREATE_EXTERNAL_IMAGE_URL } from '@shopgate/engage/core/constants';

// Register the handler inside the configuration collection.
configuration.set(
  CONFIGURATION_COLLECTION_CREATE_EXTERNAL_IMAGE_URL,
  (baseUrl, { width, height, fillColor, quality, format } = {}) => {
    if (!baseUrl || !baseUrl.startsWith('https://mycdn.com')) {
      // Return nullish value if the URL is not supported - image will be displayed from the original URL.
      return null;
    }
    // Return the new URL with the desired parameters.
    return `${baseUrl}?width=${width}`;
  }
);
```

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
