### PR TITLE
Fixed lazy loading of product images on iOS

### DIFF
--- a/libraries/common/components/Image/__snapshots__/Index.spec.jsx.snap
+++ b/libraries/common/components/Image/__snapshots__/Index.spec.jsx.snap
@@ -3,7 +3,6 @@
 exports[`<Image /> should render placeholders if forced to 1`] = `
 <Image
   alt={null}
-  animating={false}
   backgroundColor="#f2f2f2"
   className=""
   classNameImg=""
@@ -33,7 +32,6 @@ exports[`<Image /> should render placeholders if forced to 1`] = `
 exports[`<Image /> should render placeholders if src is null 1`] = `
 <Image
   alt={null}
-  animating={false}
   backgroundColor="#f2f2f2"
   className=""
   classNameImg=""

--- a/libraries/common/components/Image/style.js
+++ b/libraries/common/components/Image/style.js
@@ -27,18 +27,7 @@ const image = css({
   WebkitTouchCallout: 'none',
 }).toString();
 
-const imageAnimated = css({
-  opacity: 0,
-  transition: 'opacity 0.2s ease-in-out',
-}).toString();
-
-const imageVisible = css({
-  opacity: 1,
-}).toString();
-
 export default {
   container,
   image,
-  imageAnimated,
-  imageVisible,
 };


### PR DESCRIPTION
# Description

This pull request fixes lazy loading for product images on iOS. It removes a mechanism to detect if image files are already located inside the browser cache, since it doesn't work reliable on all browsers.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Goto a product list, open network tab in devtools and verify that additional images are requested while scrolling
