### PR TITLE
Added theme-config setting to disable automatic video responsiveness

### DIFF
--- a/libraries/common/collections/media-providers/MediaProvider.js
+++ b/libraries/common/collections/media-providers/MediaProvider.js
@@ -28,11 +28,17 @@ const consentMessageIcon = `
 class MediaProvider {
   /**
    * Constructor.
+   * @param {Object} options The provider options.
+   * @param {boolean} [options.responsify=true] Whether to responsify the video containers.
    */
-  constructor() {
+  constructor(options) {
     this.containers = new Map();
     this.isPending = false;
     this.remoteScriptUrl = null;
+
+    this.options = {
+      responsify: options?.responsify ?? true,
+    };
   }
 
   /**
@@ -59,6 +65,9 @@ class MediaProvider {
    * @returns {MediaProvider}
    */
   responsify(container) {
+    // Do not proceed when video responsify is disabled.
+    if (!this.options.responsify) return this;
+
     // Remove fixed dimensions from the container.
     container.removeAttribute('height');
     container.removeAttribute('width');

--- a/libraries/common/collections/media-providers/Vimeo.js
+++ b/libraries/common/collections/media-providers/Vimeo.js
@@ -9,9 +9,11 @@ const scriptUrl = 'https://player.vimeo.com/api/player.js';
 class VimeoMediaProvider extends MediaProvider {
   /**
    * Constructor.
+   * @param {Object} options The provider options.
+   * @param {boolean} [options.responsify=true] Whether to responsify the video containers.
    */
-  constructor() {
-    super();
+  constructor(options) {
+    super(options);
     // Need to check Vimeo.Player presence later
     this.isPending = true;
     this.remoteScriptUrl = scriptUrl;

--- a/libraries/common/subscriptions/app.js
+++ b/libraries/common/subscriptions/app.js
@@ -71,11 +71,12 @@ export default function app(subscribe) {
   subscribe(appWillStart$, ({
     dispatch, action, getState, events,
   }) => {
+    console.warn(appConfig?.responsifyVideos);
     embeddedMedia.addProvider(new Vimeo({
-      responsify: appConfig?.responsifyVideos?.Vimeo,
+      responsify: appConfig?.responsifyVideos?.vimeo,
     }));
     embeddedMedia.addProvider(new YouTube({
-      responsify: appConfig?.responsifyVideos?.youTubeVimeo,
+      responsify: appConfig?.responsifyVideos?.youTube,
     }));
 
     dispatch(registerLinkEvents(action.location));

--- a/libraries/common/subscriptions/app.js
+++ b/libraries/common/subscriptions/app.js
@@ -26,6 +26,7 @@ import {
   onDidReset,
   onUpdate,
 } from '@virtuous/conductor';
+import { appConfig } from '@shopgate/engage';
 import { UI_VISIBILITY_CHANGE } from '../constants/ui';
 import {
   appError, pipelineError, pwaDidAppear, pwaDidDisappear,
@@ -70,8 +71,12 @@ export default function app(subscribe) {
   subscribe(appWillStart$, ({
     dispatch, action, getState, events,
   }) => {
-    embeddedMedia.addProvider(new Vimeo());
-    embeddedMedia.addProvider(new YouTube());
+    embeddedMedia.addProvider(new Vimeo({
+      responsify: appConfig?.responsifyVideos?.Vimeo,
+    }));
+    embeddedMedia.addProvider(new YouTube({
+      responsify: appConfig?.responsifyVideos?.youTubeVimeo,
+    }));
 
     dispatch(registerLinkEvents(action.location));
 

--- a/libraries/common/subscriptions/app.js
+++ b/libraries/common/subscriptions/app.js
@@ -71,7 +71,6 @@ export default function app(subscribe) {
   subscribe(appWillStart$, ({
     dispatch, action, getState, events,
   }) => {
-    console.warn(appConfig?.responsifyVideos);
     embeddedMedia.addProvider(new Vimeo({
       responsify: appConfig?.responsifyVideos?.vimeo,
     }));

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -801,6 +801,18 @@
         "type": "json",
         "label": "Whether to use grouping separators, such as thousands separators."
       }
+    },
+    "responsifyVideos": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": {
+        "vimeo": true,
+        "youTube": true
+      },
+      "params": {
+        "type": "json",
+        "label": "By default videos we attempt to make videos inside HTML widgets responsive, so that they take the full screen width. This setting can be used to disable this behavior for specific video providers."
+      }
     }
   }
 }

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -811,7 +811,7 @@
       },
       "params": {
         "type": "json",
-        "label": "By default videos we attempt to make videos inside HTML widgets responsive, so that they take the full screen width. This setting can be used to disable this behavior for specific video providers."
+        "label": "By default we attempt to make videos inside HTML widgets responsive, so that they take the full screen width. This setting can be used to disable this behavior for specific video providers."
       }
     }
   }

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -811,6 +811,18 @@
         "type": "json",
         "label": "Whether to use grouping separators, such as thousands separators."
       }
+    },
+    "responsifyVideos": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": {
+        "vimeo": true,
+        "youTube": true
+      },
+      "params": {
+        "type": "json",
+        "label": "By default videos we attempt to make videos inside HTML widgets responsive, so that they take the full screen width. This setting can be used to disable this behavior for specific video providers."
+      }
     }
   }
 }

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -821,7 +821,7 @@
       },
       "params": {
         "type": "json",
-        "label": "By default videos we attempt to make videos inside HTML widgets responsive, so that they take the full screen width. This setting can be used to disable this behavior for specific video providers."
+        "label": "By default we attempt to make videos inside HTML widgets responsive, so that they take the full screen width. This setting can be used to disable this behavior for specific video providers."
       }
     }
   }


### PR DESCRIPTION
# Description

By default we try to make videos responsive that are included in HTML content that comes via API.

This pull request introduces a new setting `responsifyVideos` that allows to disable that behaviour for Vimeo / YouTube videos. It should be disabled when HTML code already contains the appropriate styling to display videos properly.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
