### PR TITLE
Re-added accidentally removed property to CartItem context

### DIFF
--- a/libraries/engage/cart/components/CartItem/CartItemProductProvider.jsx
+++ b/libraries/engage/cart/components/CartItem/CartItemProductProvider.jsx
@@ -102,6 +102,7 @@ const CartItemProductProvider = ({
       toggleEditMode,
       editMode,
       isEditable,
+      cartItemId: id,
       cartItem: {
         id,
         product,


### PR DESCRIPTION
# Description

During development of PWA 7 the `cartItemId` property of the CartItem context was accidentally removed inside a refactoring.  As a result some extensions that rely on it break.

This pull request adds the missing property again.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Cart item context in PWA 6 - implemented via legacy context [see here](https://github.com/shopgate/pwa/blob/releases/v6.23.1/themes/theme-gmd/pages/Cart/components/Item/components/Product/index.jsx#L68) | [usage](https://github.com/shopgate/pwa/blob/releases/v6.23.1/themes/theme-gmd/pages/Cart/components/Item/components/Product/components/Layout/components/Title/index.jsx#L25)

Cart item context in PWA 7 [see here](https://github.com/shopgate/pwa/blob/v7.20.2/libraries/engage/cart/components/CartItem/CartItemProductProvider.jsx#L93) | [usage](https://github.com/shopgate/pwa/blob/v7.20.2/libraries/engage/cart/components/CartItem/CartItemProductTitle.jsx#L78))
