### PR TITLE
Fixed usages of legacy cart item context

### DIFF
--- a/libraries/engage/cart/components/CartItem/CartItemProductProvider.jsx
+++ b/libraries/engage/cart/components/CartItem/CartItemProductProvider.jsx
@@ -8,6 +8,7 @@ import { CART_INPUT_AUTO_SCROLL_DELAY } from '../../cart.constants';
 import Context from './CartItemProductProvider.context';
 import connect from './CartItemProductProvider.connector';
 import { type OwnProps, type StateProps, type DispatchProps } from './CartItemProductProvider.types';
+import CartItemProductProviderLegacy from './CartItemProductProviderLegacy';
 
 const { variables } = themeConfig;
 
@@ -148,7 +149,9 @@ const CartItemProductProvider = ({
 
   return (
     <Context.Provider value={value}>
-      {children}
+      <CartItemProductProviderLegacy>
+        {children}
+      </CartItemProductProviderLegacy>
     </Context.Provider>
   );
 };

--- a/libraries/engage/cart/components/CartItem/CartItemProductProviderLegacy.jsx
+++ b/libraries/engage/cart/components/CartItem/CartItemProductProviderLegacy.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CART_ITEM_TYPE_PRODUCT } from '@shopgate/engage/cart';
+import { useCartItemProduct } from './CartItem.hooks';
+
+/**
+ * Provides legacy context for CartItemProduct component and its children.
+ * Within PWA7 the context was refactored to the new context API. To keep compatibility with
+ * older extensions, this provider is used to provide the legacy context.
+ *
+ * Should be removed when PWA 7 is deployed to all of the shops and affected extensions can be
+ * updated without the need to support older PWA versions.
+ */
+class LegacyProvider extends React.Component {
+  /**
+   * @param {Object} props The component props.
+   */
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      cartItemId: props.cartItemId,
+      product: props.product,
+    };
+  }
+
+  /**
+   * @param {Object} nextProps Next props
+   * @param {*} prevState  Prev state
+   * @returns {Object|null}
+   */
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (
+      nextProps.cartItemId !== prevState.cartItemId ||
+      nextProps.product !== prevState.product
+    ) {
+      return {
+        cartItemId: nextProps.cartItemId,
+        product: nextProps.product,
+      };
+    }
+    return null;
+  }
+
+  /**
+   * @returns {Object}
+   */
+  getChildContext() {
+    return {
+      type: CART_ITEM_TYPE_PRODUCT,
+      cartItemId: this.state.cartItemId,
+      product: this.state.product,
+    };
+  }
+
+  /**
+   * @returns {JSX.Element}
+   */
+  render() {
+    return this.props.children;
+  }
+}
+
+LegacyProvider.propTypes = {
+  cartItemId: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  product: PropTypes.shape().isRequired,
+};
+
+LegacyProvider.childContextTypes = {
+  type: PropTypes.string,
+  cartItemId: PropTypes.string,
+  product: PropTypes.shape(),
+};
+
+/**
+ * Bridges the CartItemProductContext value to the legacy CartItemProduct context.
+ * @param {Object} props The component props.
+ * @returns {JSX.Element}
+ */
+const CartItemProductProviderLegacy = ({ children }) => {
+  const { cartItemId, product } = useCartItemProduct();
+
+  return (
+    <LegacyProvider cartItemId={cartItemId} product={product}>
+      {children}
+    </LegacyProvider>
+  );
+};
+
+CartItemProductProviderLegacy.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default CartItemProductProviderLegacy;


### PR DESCRIPTION
# Description
During the development of PWA 7 the context that wraps cart items was refactored to the new React context API. Since there are extensions that rely on the previously used legacy context, this pull requests introduces a bridge component that maps the new context values to the legacy context.

Its intended to be an interim solution till PWA 7 has a higher usage and extensions can be refactored to the new context without the risk to break backwards compatibility.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

