### PR TITLE
Removed the webpack-dev-server error overlay

### DIFF
--- a/utils/webpack/webpack.config.js
+++ b/utils/webpack/webpack.config.js
@@ -221,6 +221,10 @@ const config = {
     static: {
       directory: path.resolve(themePath, PUBLIC_FOLDER),
     },
+    client: {
+      // Deactivate full-screen error overlay in dev server
+      overlay: false,
+    },
     host: '0.0.0.0',
     port: process.env.optionsPort,
     historyApiFallback: true,


### PR DESCRIPTION
# Description

With the recently updated `webpack-dev-server` version a new behaviour was introduced. In case of JS errors, a full screen overlay is shown to display the error.

Since this overlay can't be closed on iOS devices with notch, we treat this as a bug and decided to deactivate this feature.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
