### PR TITLE
Fixed liveshopping widget visibility and styling

### DIFF
--- a/themes/theme-gmd/widgets/Liveshopping/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/widgets/Liveshopping/__snapshots__/spec.jsx.snap
@@ -6,7 +6,7 @@ exports[`<LiveshoppingWidget /> should render the widget with a slider for multi
 <div
   className={
     Object {
-      "data-css-9a70pf": "",
+      "data-css-1rjsvq5": "",
     }
   }
   data-test-id="liveShoppingWidget"
@@ -38,6 +38,7 @@ exports[`<LiveshoppingWidget /> should render the widget with a slider for multi
           productId="1234"
         >
           <LiveshoppingItem
+            hasPagination={true}
             productId="1234"
           />
         </ProductListEntryProvider>
@@ -50,6 +51,7 @@ exports[`<LiveshoppingWidget /> should render the widget with a slider for multi
           productId="1235"
         >
           <LiveshoppingItem
+            hasPagination={true}
             productId="1235"
           />
         </ProductListEntryProvider>
@@ -63,7 +65,7 @@ exports[`<LiveshoppingWidget /> should render the widget with no slider for one 
 <div
   className={
     Object {
-      "data-css-9a70pf": "",
+      "data-css-1rjsvq5": "",
     }
   }
   data-test-id="liveShoppingWidget"
@@ -78,6 +80,7 @@ exports[`<LiveshoppingWidget /> should render the widget with no slider for one 
       productId="1234"
     >
       <LiveshoppingItem
+        hasPagination={false}
         productId="1234"
       />
     </ProductListEntryProvider>

--- a/themes/theme-gmd/widgets/Liveshopping/components/Item/index.jsx
+++ b/themes/theme-gmd/widgets/Liveshopping/components/Item/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Theme } from '@shopgate/pwa-common/context';
 import CountdownTimer from '@shopgate/pwa-common/components/CountdownTimer';
 import Link from '@shopgate/pwa-common/components/Link';
@@ -14,9 +15,13 @@ import styles from './style';
  * The LiveShoppingItem component.
  * @param {Object} props The component props.
  * @param {string} props.productId The product id.
- * @returns {JSX}
+ * @param {boolean} [props.hasPagination=false] Whether surrounding swiper has pagination.
+ * @returns {JSX.Element}
  */
-function LiveshoppingItem({ productId }) {
+function LiveshoppingItem({
+  productId,
+  hasPagination,
+}) {
   return (
     <Theme>
       {({ ProductCard }) => (
@@ -34,7 +39,11 @@ function LiveshoppingItem({ productId }) {
             const { ListImage: gridResolutions } = getProductImageSettings();
 
             return (
-              <Link href={url} state={{ title: name }}>
+              <Link
+                href={url}
+                state={{ title: name }}
+                className={classNames({ [styles.linkPagination]: hasPagination })}
+              >
                 <Grid>
                   <Grid.Item className={styles.image}>
                     <ProductImage
@@ -43,7 +52,10 @@ function LiveshoppingItem({ productId }) {
                       alt={name}
                     />
                   </Grid.Item>
-                  <Grid.Item className={styles.infoPane}>
+                  <Grid.Item className={classNames(styles.infoPane, {
+                    [styles.infoPanePagination]: hasPagination,
+                  })}
+                  >
                     <div data-test-id={name}>
                       <ProductBadges
                         location="liveshopping"
@@ -73,6 +85,11 @@ function LiveshoppingItem({ productId }) {
 
 LiveshoppingItem.propTypes = {
   productId: PropTypes.string.isRequired,
+  hasPagination: PropTypes.bool,
+};
+
+LiveshoppingItem.defaultProps = {
+  hasPagination: false,
 };
 
 export default LiveshoppingItem;

--- a/themes/theme-gmd/widgets/Liveshopping/components/Item/style.js
+++ b/themes/theme-gmd/widgets/Liveshopping/components/Item/style.js
@@ -20,6 +20,10 @@ const infoPane = css({
   justifyContent: 'space-between',
 }).toString();
 
+const infoPanePagination = css({
+  paddingBottom: 0,
+}).toString();
+
 const priceGrid = css({
   alignItems: 'flex-end',
   justifyContent: 'space-between',
@@ -40,6 +44,10 @@ const price = css({
 const card = {
   margin: '5px 15px 10px',
 };
+
+const linkPagination = css({
+  paddingBottom: 28,
+}).toString();
 
 const title = {
   marginBottom: variables.gap.small * 0.5,
@@ -66,10 +74,12 @@ const badgesPortal = css({
 export default {
   image,
   infoPane,
+  infoPanePagination,
   priceGrid,
   priceStriked,
   price,
   card,
+  linkPagination,
   title,
   timer,
   badgesPortal,

--- a/themes/theme-gmd/widgets/Liveshopping/connector.js
+++ b/themes/theme-gmd/widgets/Liveshopping/connector.js
@@ -1,5 +1,7 @@
 import { connect } from 'react-redux';
-import getLiveshoppingProducts from '@shopgate/pwa-common-commerce/product/actions/getLiveshoppingProducts';
+import {
+  fetchLiveshoppingProducts,
+} from '@shopgate/engage/product';
 import { selectProductIds } from './selectors';
 
 /**
@@ -12,7 +14,7 @@ const mapStateToProps = (state, props) => ({
 });
 
 const mapDispatchToProps = {
-  fetchProducts: getLiveshoppingProducts,
+  fetchProducts: fetchLiveshoppingProducts,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/themes/theme-gmd/widgets/Liveshopping/index.jsx
+++ b/themes/theme-gmd/widgets/Liveshopping/index.jsx
@@ -48,7 +48,7 @@ export class LiveshoppingWidget extends Component {
             {products.map(id => (
               <Swiper.Item key={id}>
                 <ProductListEntryProvider productId={id}>
-                  <Item productId={id} />
+                  <Item productId={id} hasPagination />
                 </ProductListEntryProvider>
               </Swiper.Item>
             ))}

--- a/themes/theme-gmd/widgets/Liveshopping/selectors.js
+++ b/themes/theme-gmd/widgets/Liveshopping/selectors.js
@@ -11,7 +11,6 @@ import {
 
 /**
  * Retrieves the result hash.
- * @param {string} defaultSortOrder The default sort order
  * @returns {string} The result hash.
  */
 const getResultHash = () => generateResultHash({

--- a/themes/theme-gmd/widgets/Liveshopping/selectors.js
+++ b/themes/theme-gmd/widgets/Liveshopping/selectors.js
@@ -1,20 +1,22 @@
 import { createSelector } from 'reselect';
-import { generateResultHash } from '@shopgate/pwa-common/helpers/redux';
-import { getProductState } from '@shopgate/pwa-common-commerce/product/selectors/product';
-import * as pipelines from '@shopgate/pwa-common-commerce/product/constants/Pipelines';
-import { makeGetDefaultSortOrder } from '@shopgate/engage/filter';
+import {
+  generateResultHash,
+} from '@shopgate/engage/core/helpers';
+import {
+  getProductState,
+} from '@shopgate/engage/product/selectors/product';
+import {
+  SHOPGATE_CATALOG_GET_LIVESHOPPING_PRODUCTS,
+} from '@shopgate/engage/product/constants';
 
 /**
  * Retrieves the result hash.
  * @param {string} defaultSortOrder The default sort order
  * @returns {string} The result hash.
  */
-const getResultHash = defaultSortOrder => generateResultHash({
-  pipeline: pipelines.SHOPGATE_CATALOG_GET_LIVESHOPPING_PRODUCTS,
-  sort: defaultSortOrder,
-}, true, false);
-
-const getDefaultSortOrder = makeGetDefaultSortOrder();
+const getResultHash = () => generateResultHash({
+  pipeline: SHOPGATE_CATALOG_GET_LIVESHOPPING_PRODUCTS,
+}, false, false);
 
 /**
  * Retrieves the result by hash.
@@ -24,9 +26,8 @@ const getDefaultSortOrder = makeGetDefaultSortOrder();
  */
 const getResultByHash = createSelector(
   getProductState,
-  getDefaultSortOrder,
-  (productState, defaultSortOrder) => {
-    const hash = getResultHash(defaultSortOrder);
+  (productState) => {
+    const hash = getResultHash();
     return productState.resultsByHash[hash];
   }
 );

--- a/themes/theme-gmd/widgets/Liveshopping/style.js
+++ b/themes/theme-gmd/widgets/Liveshopping/style.js
@@ -2,6 +2,7 @@ import { css } from 'glamor';
 
 const wrapper = css({
   padding: '16px 0px 0px',
+  '--swiper-pagination-bottom': '20px',
 });
 
 export default {

--- a/themes/theme-ios11/widgets/Liveshopping/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/widgets/Liveshopping/__snapshots__/spec.jsx.snap
@@ -6,9 +6,10 @@ exports[`<LiveshoppingWidget /> should render the widget with a slider for multi
 <div
   className={
     Object {
-      "data-css-9a70pf": "",
+      "data-css-1rjsvq5": "",
     }
   }
+  data-test-id="liveShoppingWidget"
 >
   <ProductListTypeProvider
     meta={null}
@@ -37,6 +38,7 @@ exports[`<LiveshoppingWidget /> should render the widget with a slider for multi
           productId="1234"
         >
           <LiveshoppingItem
+            hasPagination={true}
             productId="1234"
           />
         </ProductListEntryProvider>
@@ -49,6 +51,7 @@ exports[`<LiveshoppingWidget /> should render the widget with a slider for multi
           productId="1235"
         >
           <LiveshoppingItem
+            hasPagination={true}
             productId="1235"
           />
         </ProductListEntryProvider>
@@ -62,7 +65,7 @@ exports[`<LiveshoppingWidget /> should render the widget with no slider for one 
 <div
   className={
     Object {
-      "data-css-9a70pf": "",
+      "data-css-1rjsvq5": "",
     }
   }
   data-test-id="liveShoppingWidget"
@@ -77,6 +80,7 @@ exports[`<LiveshoppingWidget /> should render the widget with no slider for one 
       productId="1234"
     >
       <LiveshoppingItem
+        hasPagination={false}
         productId="1234"
       />
     </ProductListEntryProvider>

--- a/themes/theme-ios11/widgets/Liveshopping/components/Item/index.jsx
+++ b/themes/theme-ios11/widgets/Liveshopping/components/Item/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Theme } from '@shopgate/pwa-common/context';
 import CountdownTimer from '@shopgate/pwa-common/components/CountdownTimer';
 import Link from '@shopgate/pwa-common/components/Link';
@@ -14,9 +15,13 @@ import styles from './style';
  * The LiveShoppingItem component.
  * @param {Object} props The component props.
  * @param {string} props.productId The product id.
- * @returns {JSX}
+ * @param {boolean} [props.hasPagination=false] Whether surrounding swiper has pagination.
+ * @returns {JSX.Element}
  */
-function LiveshoppingItem({ productId }) {
+function LiveshoppingItem({
+  productId,
+  hasPagination,
+}) {
   return (
     <Theme>
       {({ ProductCard }) => (
@@ -34,7 +39,11 @@ function LiveshoppingItem({ productId }) {
             const { ListImage: gridResolutions } = getProductImageSettings();
 
             return (
-              <Link href={url} state={{ title: name }}>
+              <Link
+                href={url}
+                state={{ title: name }}
+                className={classNames({ [styles.linkPagination]: hasPagination })}
+              >
                 <Grid>
                   <Grid.Item className={styles.image}>
                     <ProductImage
@@ -43,7 +52,10 @@ function LiveshoppingItem({ productId }) {
                       alt={name}
                     />
                   </Grid.Item>
-                  <Grid.Item className={styles.infoPane}>
+                  <Grid.Item className={classNames(styles.infoPane, {
+                    [styles.infoPanePagination]: hasPagination,
+                  })}
+                  >
                     <div data-test-id={name}>
                       <ProductBadges
                         location="liveshopping"
@@ -73,6 +85,11 @@ function LiveshoppingItem({ productId }) {
 
 LiveshoppingItem.propTypes = {
   productId: PropTypes.string.isRequired,
+  hasPagination: PropTypes.bool,
+};
+
+LiveshoppingItem.defaultProps = {
+  hasPagination: false,
 };
 
 export default LiveshoppingItem;

--- a/themes/theme-ios11/widgets/Liveshopping/components/Item/style.js
+++ b/themes/theme-ios11/widgets/Liveshopping/components/Item/style.js
@@ -20,6 +20,10 @@ const infoPane = css({
   justifyContent: 'space-between',
 }).toString();
 
+const infoPanePagination = css({
+  paddingBottom: 0,
+}).toString();
+
 const priceGrid = css({
   alignItems: 'flex-end',
   justifyContent: 'space-between',
@@ -40,6 +44,10 @@ const price = css({
 const card = {
   margin: '5px 15px 10px',
 };
+
+const linkPagination = css({
+  paddingBottom: 28,
+}).toString();
 
 const title = {
   marginBottom: variables.gap.small * 0.5,
@@ -66,10 +74,12 @@ const badgesPortal = css({
 export default {
   image,
   infoPane,
+  infoPanePagination,
   priceGrid,
   priceStriked,
   price,
   card,
+  linkPagination,
   title,
   timer,
   badgesPortal,

--- a/themes/theme-ios11/widgets/Liveshopping/connector.js
+++ b/themes/theme-ios11/widgets/Liveshopping/connector.js
@@ -1,5 +1,7 @@
 import { connect } from 'react-redux';
-import getLiveshoppingProducts from '@shopgate/pwa-common-commerce/product/actions/getLiveshoppingProducts';
+import {
+  fetchLiveshoppingProducts,
+} from '@shopgate/engage/product';
 import { selectProductIds } from './selectors';
 
 /**
@@ -12,7 +14,7 @@ const mapStateToProps = (state, props) => ({
 });
 
 const mapDispatchToProps = {
-  fetchProducts: getLiveshoppingProducts,
+  fetchProducts: fetchLiveshoppingProducts,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps);

--- a/themes/theme-ios11/widgets/Liveshopping/index.jsx
+++ b/themes/theme-ios11/widgets/Liveshopping/index.jsx
@@ -42,13 +42,13 @@ export class LiveshoppingWidget extends Component {
     }
 
     return (
-      <div className={styles.wrapper}>
+      <div className={styles.wrapper} data-test-id="liveShoppingWidget">
         <ProductListTypeProvider type="liveshopping" subType="widgets">
           <Swiper indicators loop={products.length > 1}>
             {products.map(id => (
               <Swiper.Item key={id}>
                 <ProductListEntryProvider productId={id}>
-                  <Item productId={id} />
+                  <Item productId={id} hasPagination />
                 </ProductListEntryProvider>
               </Swiper.Item>
             ))}

--- a/themes/theme-ios11/widgets/Liveshopping/selectors.js
+++ b/themes/theme-ios11/widgets/Liveshopping/selectors.js
@@ -11,7 +11,6 @@ import {
 
 /**
  * Retrieves the result hash.
- * @param {string} defaultSortOrder The default sort order
  * @returns {string} The result hash.
  */
 const getResultHash = () => generateResultHash({

--- a/themes/theme-ios11/widgets/Liveshopping/selectors.js
+++ b/themes/theme-ios11/widgets/Liveshopping/selectors.js
@@ -1,20 +1,22 @@
 import { createSelector } from 'reselect';
-import { generateResultHash } from '@shopgate/pwa-common/helpers/redux';
-import { getProductState } from '@shopgate/pwa-common-commerce/product/selectors/product';
-import * as pipelines from '@shopgate/pwa-common-commerce/product/constants/Pipelines';
-import { makeGetDefaultSortOrder } from '@shopgate/engage/filter';
+import {
+  generateResultHash,
+} from '@shopgate/engage/core/helpers';
+import {
+  getProductState,
+} from '@shopgate/engage/product/selectors/product';
+import {
+  SHOPGATE_CATALOG_GET_LIVESHOPPING_PRODUCTS,
+} from '@shopgate/engage/product/constants';
 
 /**
  * Retrieves the result hash.
  * @param {string} defaultSortOrder The default sort order
  * @returns {string} The result hash.
  */
-const getResultHash = defaultSortOrder => generateResultHash({
-  pipeline: pipelines.SHOPGATE_CATALOG_GET_LIVESHOPPING_PRODUCTS,
-  sort: defaultSortOrder,
-}, true, false);
-
-const getDefaultSortOrder = makeGetDefaultSortOrder();
+const getResultHash = () => generateResultHash({
+  pipeline: SHOPGATE_CATALOG_GET_LIVESHOPPING_PRODUCTS,
+}, false, false);
 
 /**
  * Retrieves the result by hash.
@@ -24,9 +26,8 @@ const getDefaultSortOrder = makeGetDefaultSortOrder();
  */
 const getResultByHash = createSelector(
   getProductState,
-  getDefaultSortOrder,
-  (productState, defaultSortOrder) => {
-    const hash = getResultHash(defaultSortOrder);
+  (productState) => {
+    const hash = getResultHash();
     return productState.resultsByHash[hash];
   }
 );

--- a/themes/theme-ios11/widgets/Liveshopping/style.js
+++ b/themes/theme-ios11/widgets/Liveshopping/style.js
@@ -2,13 +2,9 @@ import { css } from 'glamor';
 
 const wrapper = css({
   padding: '16px 0px 0px',
+  '--swiper-pagination-bottom': '20px',
 });
 
-const indicators = css({
-  textAlign: 'center',
-}).toString();
-
 export default {
-  indicators,
   wrapper,
 };


### PR DESCRIPTION
# Description

This pull request fixes an issue with the visibility of liveshopping widgets. 

The issue was caused by a bugfix in the `generateResultHash` helper when the `includeSort` option was set to `false`. Before the bugfix there where situations where the sort parameter was added to the hash even when it was not supposed to.

The fix caused that now products of the liveshopping widgets where put to Redux without the sort parameter, but the corresponding selector was configured to search for a hash WITH sort parameter.

The code changes of this pull request remove the sort parameter from the product selector, since the `shopgate.catalog.getLiveshoppingProducts.v1` should deliver the products in the correct order.

Besides the visibility issue the pull request also improves styling of the widget when it shows multiple slides.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

- Configure a "Deal of the Day" widget in merchant admin
- Verify that it's visible in PWA