### PR TITLE
Fix accessibility for iOS theme on android device

### DIFF
--- a/libraries/engage/product/components/ProductCard/index.jsx
+++ b/libraries/engage/product/components/ProductCard/index.jsx
@@ -68,6 +68,7 @@ function ProductCard(props) {
       itemProp="item"
       itemScope
       itemType="http://schema.org/Product"
+      tabIndex={0}
     >
       {isBeta() && product.featuredMedia
         ? <FeaturedMedia

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -150,7 +150,6 @@ class ProductImageSlider extends Component {
           indicators
           onSlideChange={this.handleSlideChange}
           className={className}
-          aria-label={product ? product.name : ''}
         >
           {images.map(image => (
             <Swiper.Item key={`${productId}-${image}`}>

--- a/themes/theme-gmd/widgets/ProductSlider/index.jsx
+++ b/themes/theme-gmd/widgets/ProductSlider/index.jsx
@@ -153,8 +153,6 @@ class ProductSlider extends PureComponent {
               <Swiper.Item
                 key={product.id}
                 aria-live="off"
-                tabIndex={0}
-                aria-label={product.name}
               >
                 <ProductListEntryProvider productId={product.id}>
                   <Card className={styles.card}>

--- a/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemDetails/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemDetails/index.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   MapPriceHint,
@@ -7,32 +7,55 @@ import {
   Swatches,
   AVAILABILITY_STATE_OK,
   AVAILABILITY_STATE_ALERT,
+  getProductRoute,
 } from '@shopgate/engage/product';
 import { hasNewServices as checkHasNewServices, i18n } from '@shopgate/engage/core/helpers';
-
-import {
-  Availability,
-} from '@shopgate/engage/components';
-
+import { Availability, Link } from '@shopgate/engage/components';
 import { StockInfoLists } from '@shopgate/engage/locations/components';
+import { historyPush } from '@shopgate/pwa-common/actions/router';
+import { useDispatch } from 'react-redux';
 import ItemName from '../ItemName';
 import ItemPrice from '../ItemPrice';
 import * as styles from './style';
 
 /**
+ * The Product Grid Item Detail component.
+ * @param {Object} props The component props.
+ * @param {Object} props.product The product.
+ * @param {Object} props.display The display object.
  * @returns {JSX.Element}
  */
 const ItemDetails = ({ product, display }) => {
   const { id: productId, name = null, stock = null } = product;
+  const dispatch = useDispatch();
 
   const hasNewServices = useMemo(() => checkHasNewServices(), []);
+
+  // click events necessary for a11y navigation on Android
+  const handleClick = useCallback(() => {
+    dispatch(historyPush({
+      pathname: getProductRoute(productId),
+    }));
+  }, [dispatch, productId]);
+
+  const handleKeyDown = useCallback((event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      handleClick();
+    }
+  }, [handleClick]);
 
   if (display && !display.name && !display.price && !display.reviews) {
     return null;
   }
 
   return (
-    <div className={`${styles.details} theme__product-grid__item__item-details`} tabIndex={-1} role="button">
+    <Link
+      className={`${styles.details} theme__product-grid__item__item-details`}
+      role="button"
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      href={getProductRoute(productId)}
+    >
       {/*
         This feature is currently in BETA testing.
         It should only be used for approved BETA Client Projects
@@ -71,7 +94,7 @@ const ItemDetails = ({ product, display }) => {
       )}
 
       <ItemPrice product={product} display={display} />
-    </div>
+    </Link>
   );
 };
 

--- a/themes/theme-ios11/components/ProductGrid/components/Item/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/components/Item/index.jsx
@@ -12,6 +12,8 @@ import styles, { itemDetails } from './style';
 /**
  * The Product Grid Item component.
  * @param {Object} props The component props.
+ * @param {Object} props.product The product.
+ * @param {Object} props.display The display object.
  * @return {JSX.Element}
  */
 const Item = ({ product, display }) => (
@@ -43,6 +45,7 @@ const Item = ({ product, display }) => (
     <div className={itemDetails}>
       <Link
         tagName="a"
+        role="button"
         href={getProductRoute(product.id)}
         state={{ title: product.name }}
       >

--- a/themes/theme-ios11/pages/More/components/Item/index.jsx
+++ b/themes/theme-ios11/pages/More/components/Item/index.jsx
@@ -4,7 +4,7 @@ import { Link, I18n } from '@shopgate/engage/components';
 import styles from './style';
 
 /**
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 function MoreMenuItem({
   href, label, onClick, testId, className,
@@ -18,7 +18,7 @@ function MoreMenuItem({
   }
 
   return (
-    <Link className={className || styles} href={href}>
+    <Link className={className || styles} href={href} role="button">
       <I18n.Text string={label} />
     </Link>
   );

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -147,7 +147,6 @@ class ProductImageSlider extends Component {
           indicators
           onSlideChange={this.handleSlideChange}
           className={className}
-          aria-label={product ? product.name : ''}
         >
           {images.map(image => (
             <Swiper.Item key={`${productId}-${image}`}>

--- a/themes/theme-ios11/widgets/ProductSlider/index.jsx
+++ b/themes/theme-ios11/widgets/ProductSlider/index.jsx
@@ -35,7 +35,7 @@ const createSliderItem = (product, { showName, showPrice, showReviews }) => {
   }
 
   return (
-    <Swiper.Item key={key} aria-live="off" tabIndex={0} aria-label={product.name}>
+    <Swiper.Item key={key} aria-live="off">
       <ProductListEntryProvider productId={product.id}>
         <Card className={styles.card}>
           <ProductCard

--- a/themes/theme-ios11/widgets/ProductSlider/index.jsx
+++ b/themes/theme-ios11/widgets/ProductSlider/index.jsx
@@ -35,7 +35,7 @@ const createSliderItem = (product, { showName, showPrice, showReviews }) => {
   }
 
   return (
-    <Swiper.Item key={key} aria-live="off">
+    <Swiper.Item key={key} aria-live="off" tabIndex={0} aria-label={product.name}>
       <ProductListEntryProvider productId={product.id}>
         <Card className={styles.card}>
           <ProductCard


### PR DESCRIPTION
# Description

When using the iOS theme on an Android device, it is not possible to focus the products in the product slider, nor the product in the product grid in the category lists, nor the links in the more menu. This PR fixes these issues.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

