### PR TITLE
Fix a11y for product image badges

### DIFF
--- a/libraries/common/components/Image/ImageInner.jsx
+++ b/libraries/common/components/Image/ImageInner.jsx
@@ -35,6 +35,7 @@ const ImageInner = forwardRef(({
     onLoad={onLoad}
     onError={onError}
     style={style}
+    aria-hidden
   />
 ));
 

--- a/libraries/common/components/Image/ImageInner.jsx
+++ b/libraries/common/components/Image/ImageInner.jsx
@@ -30,12 +30,11 @@ const ImageInner = forwardRef(({
     )}
     alt={alt}
     aria-label={alt}
-    role="presentation"
+    aria-hidden={!alt}
     data-test-id="image"
     onLoad={onLoad}
     onError={onError}
     style={style}
-    aria-hidden
   />
 ));
 

--- a/libraries/engage/product/components/ProductBadges/index.jsx
+++ b/libraries/engage/product/components/ProductBadges/index.jsx
@@ -26,7 +26,7 @@ const styles = {
 /**
  * The ProductBadges component
  * @param {Object} props The component props
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 const ProductBadges = ({
   children, location, productId, portalProps, className,

--- a/libraries/engage/product/components/ProductCard/index.jsx
+++ b/libraries/engage/product/components/ProductCard/index.jsx
@@ -38,7 +38,7 @@ const location = 'productCard';
  * @param {boolean} props.hideRating Whether the rating should be hidden.
  * @param {boolean} props.hideName Whether the name should be hidden.
  * @param {number} props.titleRows The max number of rows for the product title.
- * @return {JSX}
+ * @return {JSX.Element}
  */
 function ProductCard(props) {
   const {
@@ -63,7 +63,7 @@ function ProductCard(props) {
   return (
     <Link
       className="engage__product-card"
-      tagName="a"
+      tag="a"
       href={getProductRoute(product.id)}
       itemProp="item"
       itemScope

--- a/libraries/engage/product/components/ProductDiscountBadge/index.jsx
+++ b/libraries/engage/product/components/ProductDiscountBadge/index.jsx
@@ -11,7 +11,7 @@ import connect from './connector';
 
 /**
  * ProductDiscountBadge
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const ProductDiscountBadge = ({ productId, discount }) => {
   const {
@@ -31,10 +31,7 @@ const ProductDiscountBadge = ({ productId, discount }) => {
       }}
     >
       { pdp.show && discount ? (
-        <div
-          className={`${styles.container} ${css(pdp.style)} theme__product__product-discount`}
-          aria-hidden
-        >
+        <div className={`${styles.container} ${css(pdp.style)} theme__product__product-discount`}>
           <SurroundPortals portalName={PRODUCT_DISCOUNT} portalProps={{ productId, discount }}>
             <DiscountBadge className={styles.badge} text={`-${discount}%`} />
           </SurroundPortals>

--- a/libraries/engage/product/components/ProductImage/index.jsx
+++ b/libraries/engage/product/components/ProductImage/index.jsx
@@ -186,7 +186,7 @@ class ProductImage extends Component {
             className={showInnerShadow ? styles.innerShadow : ''}
             backgroundColor={noBackground ? 'transparent' : colors.light}
             onError={this.imageLoadingFailed}
-            aria-hidden
+            aria-hidden={!this.props.alt}
           />
         </div>
       </SurroundPortals>

--- a/libraries/engage/product/components/ProductImage/index.jsx
+++ b/libraries/engage/product/components/ProductImage/index.jsx
@@ -154,7 +154,6 @@ class ProductImage extends Component {
               [styles.innerShadow]: showInnerShadow,
               [className]: !!className,
             })}
-            aria-hidden
           >
             { placeholderSrc ? (
               <ProductImagePlaceholder
@@ -163,11 +162,10 @@ class ProductImage extends Component {
                 noBackground={noBackground}
               />
             ) : (
-              <div className={styles.placeholderContent} data-test-id="placeHolder">
+              <div aria-hidden className={styles.placeholderContent} data-test-id="placeHolder">
                 <PlaceholderIcon className={styles.placeholder} />
               </div>
             )}
-
           </div>
         </SurroundPortals>
       );
@@ -182,12 +180,13 @@ class ProductImage extends Component {
           resolutions: this.props.resolutions,
         }}
       >
-        <div aria-hidden className={`${className} engage__product__product-image`}>
+        <div className={`${className} engage__product__product-image`}>
           <Image
             {...this.props}
             className={showInnerShadow ? styles.innerShadow : ''}
             backgroundColor={noBackground ? 'transparent' : colors.light}
             onError={this.imageLoadingFailed}
+            aria-hidden
           />
         </div>
       </SurroundPortals>

--- a/libraries/ui-shared/DiscountBadge/index.jsx
+++ b/libraries/ui-shared/DiscountBadge/index.jsx
@@ -21,6 +21,7 @@ const DiscountBadge = ({
     data-test-id={text}
     className="ui-shared__discount-badge"
     aria-label={`${i18n.text('cart.discount')}: ${text}`}
+    tabIndex={-1}
   >
     <I18n.Text
       className={`${styles[display]} ${className}`}

--- a/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemDiscount/index.jsx
+++ b/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemDiscount/index.jsx
@@ -23,7 +23,7 @@ class ItemDiscount extends PureComponent {
   };
 
   /**
-   * @returns {JSX}
+   * @returns {JSX.Element}
    */
   render() {
     const { productId, discount } = this.props;
@@ -34,7 +34,7 @@ class ItemDiscount extends PureComponent {
     }
 
     return (
-      <div className={`${styles} theme__product-grid__item__item-discount`} aria-hidden>
+      <div className={`${styles} theme__product-grid__item__item-discount`}>
         <Portal name={PRODUCT_ITEM_DISCOUNT_BEFORE} props={props} />
         <Portal name={PRODUCT_ITEM_DISCOUNT} props={props}>
           <DiscountBadge text={`-${discount}%`} />

--- a/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemImage/index.jsx
+++ b/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemImage/index.jsx
@@ -42,7 +42,6 @@ class ItemImage extends PureComponent {
             src={imageUrl}
             resolutions={gridResolutions}
             itemProp="image"
-            aria-hidden
           />
         </Portal>
         <Portal name={PRODUCT_ITEM_IMAGE_AFTER} props={props} />

--- a/themes/theme-gmd/components/ProductGrid/components/Item/index.jsx
+++ b/themes/theme-gmd/components/ProductGrid/components/Item/index.jsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { isBeta } from '@shopgate/engage/core';
 import { getProductRoute, FeaturedMedia, ProductBadges } from '@shopgate/engage/product';
-import Link from '@shopgate/pwa-common/components/Link';
+import { Link } from '@shopgate/engage/components';
 import ItemImage from './components/ItemImage';
 import ItemDiscount from './components/ItemDiscount';
 import ItemFavoritesButton from './components/ItemFavoritesButton';
@@ -21,7 +21,6 @@ const Item = ({ product, display }) => (
       href={getProductRoute(product.id)}
       state={{ title: product.name }}
       className={itemImage}
-      aria-hidden
     >
       {isBeta() && product.featuredMedia
         ? <FeaturedMedia

--- a/themes/theme-gmd/components/ProductGrid/components/Item/index.jsx
+++ b/themes/theme-gmd/components/ProductGrid/components/Item/index.jsx
@@ -18,6 +18,7 @@ const Item = ({ product, display }) => (
   <div className={`${styles} theme__product-grid__item`}>
     <Link
       tag="a"
+      role="none"
       href={getProductRoute(product.id)}
       state={{ title: product.name }}
       className={itemImage}

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -134,7 +134,7 @@ class ProductImageSlider extends Component {
 
   /**
    * Renders the product image slider component.
-   * @returns {JSX}
+   * @returns {JSX.Element}
    */
   render() {
     const {
@@ -150,6 +150,7 @@ class ProductImageSlider extends Component {
           indicators
           onSlideChange={this.handleSlideChange}
           className={className}
+          aria-hidden={ariaHidden}
         >
           {images.map(image => (
             <Swiper.Item key={`${productId}-${image}`}>
@@ -182,6 +183,7 @@ class ProductImageSlider extends Component {
           resolutions={pdpResolutions}
           noBackground
           alt={product ? product.name : ''}
+          aria-hidden={ariaHidden}
         />
       );
       if (!src) {
@@ -200,9 +202,7 @@ class ProductImageSlider extends Component {
         data-test-id={`product: ${product ? product.name : ''}`}
         onClick={onClick}
         onKeyDown={onClick}
-        role="button"
-        tabIndex="0"
-        aria-hidden={ariaHidden}
+        role="presentation"
         style={wrapperStyles}
         ref={this.mediaRef}
       >
@@ -214,7 +214,7 @@ class ProductImageSlider extends Component {
 
 /**
  * @param {Object} props The component props.
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const Wrapper = props => (
   <SurroundPortals portalName={PRODUCT_IMAGE} portalProps={props}>

--- a/themes/theme-gmd/themeApi/ProductCard/components/Badge/index.jsx
+++ b/themes/theme-gmd/themeApi/ProductCard/components/Badge/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Portal } from '@shopgate/pwa-common/components';
+import { Portal } from '@shopgate/engage/components';
 import DiscountBadge from '@shopgate/pwa-ui-shared/DiscountBadge';
 import {
   PRODUCT_ITEM_DISCOUNT,
@@ -10,7 +10,7 @@ import {
 import styles from './style';
 
 /**
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 function ProductCardBadge({ productId, style, value }) {
   const props = { productId };

--- a/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemDiscount/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemDiscount/index.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Portal from '@shopgate/pwa-common/components/Portal';
+import { Portal } from '@shopgate/engage/components';
 import {
   PRODUCT_ITEM_DISCOUNT,
   PRODUCT_ITEM_DISCOUNT_AFTER,
@@ -23,7 +23,7 @@ class ItemDiscount extends PureComponent {
   };
 
   /**
-   * @returns {JSX}
+   * @returns {JSX.Element}
    */
   render() {
     const { productId, discount } = this.props;
@@ -34,7 +34,7 @@ class ItemDiscount extends PureComponent {
     }
 
     return (
-      <div className={`${styles} theme__product-grid__item__item-discount`} aria-hidden>
+      <div className={`${styles} theme__product-grid__item__item-discount`}>
         <Portal name={PRODUCT_ITEM_DISCOUNT_BEFORE} props={props} />
         <Portal name={PRODUCT_ITEM_DISCOUNT} props={props}>
           <DiscountBadge text={`-${discount}%`} />

--- a/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemImage/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemImage/index.jsx
@@ -41,7 +41,6 @@ class ItemImage extends PureComponent {
             src={imageUrl}
             resolutions={gridResolutions}
             itemProp="image"
-            aria-hidden
           />
         </Portal>
         <Portal name={PRODUCT_ITEM_IMAGE_AFTER} props={props} />

--- a/themes/theme-ios11/components/ProductGrid/components/Item/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/components/Item/index.jsx
@@ -44,7 +44,7 @@ const Item = ({ product, display }) => (
     </ProductBadges>
     <div className={itemDetails}>
       <Link
-        tagName="a"
+        tag="a"
         role="button"
         href={getProductRoute(product.id)}
         state={{ title: product.name }}

--- a/themes/theme-ios11/components/ProductGrid/components/Item/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/components/Item/index.jsx
@@ -19,10 +19,10 @@ import styles, { itemDetails } from './style';
 const Item = ({ product, display }) => (
   <div className={`${styles} theme__product-grid__item`}>
     <Link
-      tagName="a"
+      tag="a"
+      role="none"
       href={getProductRoute(product.id)}
       state={{ title: product.name }}
-      aria-hidden
     >
       {isBeta() && product.featuredMedia
         ? <FeaturedMedia

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -131,7 +131,7 @@ class ProductImageSlider extends Component {
 
   /**
    * Renders the product image slider component.
-   * @returns {JSX}
+   * @returns {JSX.Element}
    */
   render() {
     const {
@@ -147,6 +147,7 @@ class ProductImageSlider extends Component {
           indicators
           onSlideChange={this.handleSlideChange}
           className={className}
+          aria-hidden={ariaHidden}
         >
           {images.map(image => (
             <Swiper.Item key={`${productId}-${image}`}>
@@ -179,6 +180,7 @@ class ProductImageSlider extends Component {
           resolutions={pdpResolutions}
           noBackground
           alt={product ? product.name : ''}
+          aria-hidden={ariaHidden}
         />
       );
       if (!src) {
@@ -197,9 +199,7 @@ class ProductImageSlider extends Component {
         data-test-id={`product: ${product ? product.name : ''}`}
         onClick={onClick}
         onKeyDown={onClick}
-        role="button"
-        tabIndex="0"
-        aria-hidden={ariaHidden}
+        role="presentation"
         style={wrapperStyles}
         ref={this.mediaRef}
       >
@@ -211,7 +211,7 @@ class ProductImageSlider extends Component {
 
 /**
  * @param {Object} props The component props.
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const Wrapper = props => (
   <SurroundPortals portalName={PRODUCT_IMAGE} portalProps={props}>

--- a/themes/theme-ios11/themeApi/ProductCard/components/Badge/index.jsx
+++ b/themes/theme-ios11/themeApi/ProductCard/components/Badge/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Portal } from '@shopgate/pwa-common/components';
+import { Portal } from '@shopgate/engage/components';
 import DiscountBadge from '@shopgate/pwa-ui-shared/DiscountBadge';
 import {
   PRODUCT_ITEM_DISCOUNT,
@@ -10,7 +10,7 @@ import {
 import styles from './style';
 
 /**
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 function ProductCardBadge({ productId, style, value }) {
   const props = { productId };


### PR DESCRIPTION
# Description

We needed to adjust the product image slider to make the product badge accessible for screen reader.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

The central pneumatic air compressor in the HFT Dev1 shop has a product badge you can test.
