### PR TITLE
Add HTTPS URL support in QR code scanner

### DIFF
--- a/libraries/commerce/scanner/actions/handleQrCode.js
+++ b/libraries/commerce/scanner/actions/handleQrCode.js
@@ -1,9 +1,11 @@
-import { historyPop, historyReplace } from '@shopgate/pwa-common/actions/router';
-import { fetchPageConfig } from '@shopgate/pwa-common/actions/page';
-import { getPageConfigById } from '@shopgate/pwa-common/selectors/page';
-import { mutable } from '@shopgate/pwa-common/helpers/redux';
-import { fetchProductsById, getProductById } from '@shopgate/pwa-common-commerce/product';
-import { fetchCategory, getCategory } from '@shopgate/pwa-common-commerce/category';
+import { historyPop, historyReplace, historyPush } from '@shopgate/engage/core/actions';
+import { fetchPageConfig } from '@shopgate/engage/page/actions';
+import { getPageConfigById } from '@shopgate/engage/page/selectors';
+import { fetchProductsById } from '@shopgate/engage/product';
+import { getProductById } from '@shopgate/engage/product/selectors/product';
+import { fetchCategory } from '@shopgate/engage/category/actions';
+import { getCategory } from '@shopgate/engage/category/selectors';
+import { isHTTPS, mutable } from '@shopgate/engage/core/helpers';
 import successHandleScanner from '../action-creators/successHandleScanner';
 import {
   QR_CODE_TYPE_CATEGORY,
@@ -99,7 +101,20 @@ const handleQrCode = ({ scope, format, payload }) => async (dispatch, getState) 
         }));
       }
       break;
-    default: notFound();
+    default: {
+      if (isHTTPS(payload)) {
+        dispatch(successHandleScanner(scope, format, payload));
+        // Open external link in in-app browser
+        dispatch(historyPush({
+          pathname: payload,
+        }));
+        // Remove the scanner screen from the history
+        dispatch(historyPop());
+      } else {
+        notFound();
+      }
+      break;
+    }
   }
   return null;
 };

--- a/libraries/common/helpers/data/index.js
+++ b/libraries/common/helpers/data/index.js
@@ -43,6 +43,13 @@ export const isExternal = url =>
   url.includes('http://') || url.includes('https://') || url.includes('//');
 
 /**
+ * Checks whether the url is an HTTPS url.
+ * @param {string} url The url to open.
+ * @return {boolean}
+ */
+export const isHTTPS = (url = '') => url.startsWith('https://');
+
+/**
  * Returns the actual url to the image, by adding url parameters with the dimensions for img-cdn
  * @param {string} src Source to the image.
  * @param {Object} dimension Dimension of the requested image.


### PR DESCRIPTION
# Description

Till now the scanner feature only supported qr-codes with special links that e.g. opened products or performed a search.

This pull request extends the qr-code scanner and adds support for website urls. Since the default In-App-Browser only supports HTTPs urls, qr-codes with HTTP urls will still result in "Not Found" errors.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Create a QR code with an url and scan it with the app.

If you want to simulate the process inside a desktop browser in dev environment, you can invoke the following function call inside the console (scanner route needs to be open)
```js
SGEvent.__call('scannerDidScan', [{ format: 'QR_CODE', code: 'https://www.google.com' }])
```
