### PR TITLE
Fixed a YouTube iFrame Issue on recent iOS versions

### DIFF
--- a/libraries/common/collections/EmbeddedMedia.js
+++ b/libraries/common/collections/EmbeddedMedia.js
@@ -73,6 +73,19 @@ class EmbeddedMedia {
   }
 
   /**
+   * Applies optimizations to embedded media iframes within the given container.
+   * Common enhancements include adding responsive wrappers and appropriate
+   * sandbox attributes to improve security and layout behavior.
+   *
+   * @param {Document} document - The DOM document containing iframes to optimize.
+   */
+  applyIframeOptimizations(document) {
+    this.providers.forEach((provider) => {
+      provider.applyIframeOptimizations(document);
+    });
+  }
+
+  /**
    * Stops all playing media within the DOM containers.
    */
   stop() {

--- a/libraries/common/collections/media-providers/MediaProvider.js
+++ b/libraries/common/collections/media-providers/MediaProvider.js
@@ -60,6 +60,18 @@ class MediaProvider {
   }
 
   /**
+   * Applies optimizations to embedded media iframes within the given container.
+   * Common enhancements include adding responsive wrappers and appropriate
+   * sandbox attributes to improve security and layout behavior.
+   *
+   * @param {Document} document - The DOM document containing iframes to optimize.
+   * @returns {MediaProvider}
+   */
+  applyIframeOptimizations() {
+    return this;
+  }
+
+  /**
    * Optimizes video container to make it responsive.
    * @param {Element} container A DOM container.
    * @returns {MediaProvider}

--- a/libraries/common/collections/media-providers/Vimeo.js
+++ b/libraries/common/collections/media-providers/Vimeo.js
@@ -73,15 +73,36 @@ class VimeoMediaProvider extends MediaProvider {
 
     const players = [];
 
-    iframes.forEach((iframe, index) => {
-      // Block clicks on Vimeo icon
-      iframes[index].sandbox = 'allow-forms allow-scripts allow-pointer-lock allow-same-origin allow-top-navigation';
-
-      this.responsify(iframe);
+    iframes.forEach((iframe) => {
       players.push(new window.Vimeo.Player(iframe));
     });
 
     this.containers.set(container, players);
+
+    return this;
+  }
+
+  /**
+   * Applies optimizations to embedded media iframes within the given container.
+   * Common enhancements include adding responsive wrappers and appropriate
+   * sandbox attributes to improve security and layout behavior.
+   *
+   * @param {Document} document - The DOM document containing iframes to optimize.
+   * @returns {YouTubeMediaProvider}
+   */
+  applyIframeOptimizations(document) {
+    const iframes = this.getMediaContainers(document);
+
+    if (!iframes.length) {
+      return this;
+    }
+
+    iframes.forEach((iframe, index) => {
+      // Block clicks on Vimeo icon
+      iframes[index].setAttribute('sandbox', 'allow-forms allow-scripts allow-pointer-lock allow-same-origin allow-top-navigation');
+
+      this.responsify(iframe);
+    });
 
     return this;
   }
@@ -92,10 +113,22 @@ class VimeoMediaProvider extends MediaProvider {
    * @returns {VimeoMediaProvider}
    */
   stop() {
-    this.containers.forEach((players) => {
-      players.forEach((player) => {
-        player.pause();
-      });
+    // Select all iframes in the document. Actually this should be done via the iframes
+    // registered in this.containers, but that doesn't seem to work reliably anymore.
+    // Since we had to find a quick fix for CURB-5033 we now select all iframes in the document
+    // via the media container selector and then stop the videos.
+    const iframes = this.getMediaContainers(document);
+
+    iframes.forEach((iframe) => {
+      try {
+        const player = new window.Vimeo.Player(iframe);
+
+        player.pause().catch(() => {
+          // Ignore errors
+        });
+      } catch (e) {
+        // Ignore errors
+      }
     });
 
     return this;

--- a/libraries/common/collections/media-providers/YouTube.js
+++ b/libraries/common/collections/media-providers/YouTube.js
@@ -30,14 +30,34 @@ class YouTubeMediaProvider extends MediaProvider {
       return this;
     }
 
+    this.containers.set(container, iframes);
+
+    return this;
+  }
+
+  /**
+   * Applies optimizations to embedded media iframes within the given container.
+   * Common enhancements include adding responsive wrappers and appropriate
+   * sandbox attributes to improve security and layout behavior.
+   *
+   * @param {Document} document - The DOM document containing iframes to optimize.
+   * @returns {YouTubeMediaProvider}
+   */
+  applyIframeOptimizations(document) {
+    const iframes = this.getMediaContainers(document);
+
+    if (!iframes.length) {
+      return this;
+    }
+
     // Update the video urls to enable stopping videos via the event API.
     iframes.forEach((iframe, index) => {
       // Block clicks on YouTube icon
-      iframes[index].sandbox = 'allow-forms allow-scripts allow-pointer-lock allow-same-origin allow-top-navigation';
+      iframes[index].setAttribute('sandbox', 'allow-forms allow-scripts allow-pointer-lock allow-same-origin allow-top-navigation');
 
       this.responsify(iframe);
 
-      const { src } = iframe;
+      const src = iframe.getAttribute('src');
 
       const [url, query] = src.split('?');
       const urlParams = new URLSearchParams(query);
@@ -47,10 +67,8 @@ class YouTubeMediaProvider extends MediaProvider {
       // Enable controls to avoid the iframe not being resumable because of controls=0 param on ios.
       urlParams.set('controls', 1);
 
-      iframes[index].src = `${url}?${urlParams.toString()}`;
+      iframes[index].setAttribute('src', `${url}?${urlParams.toString()}`);
     });
-
-    this.containers.set(container, iframes);
 
     return this;
   }
@@ -61,12 +79,23 @@ class YouTubeMediaProvider extends MediaProvider {
    * @returns {YouTubeMediaProvider}
    */
   stop() {
-    this.containers.forEach((iframes) => {
-      iframes.forEach((iframe) => {
-        if (iframe.contentWindow && iframe.contentWindow.postMessage) {
-          iframe.contentWindow.postMessage('{"event":"command","func":"stopVideo","args":""}', '*');
-        }
-      });
+    // Select all iframes in the document. Actually this should be done via the iframes
+    // registered in this.containers, but that doesn't seem to work reliably anymore.
+    // Since we had to find a quick fix for CURB-5033 we now select all iframes in the document
+    // via the media container selector and then stop the videos.
+    const iframes = this.getMediaContainers(document);
+
+    iframes.forEach((iframe) => {
+      if (typeof iframe?.contentWindow?.postMessage === 'function') {
+        iframe.contentWindow.postMessage(
+          JSON.stringify({
+            event: 'command',
+            func: 'stopVideo',
+            args: [],
+          }),
+          '*'
+        );
+      }
     });
 
     return this;

--- a/libraries/common/helpers/html/parseHTML.js
+++ b/libraries/common/helpers/html/parseHTML.js
@@ -43,6 +43,8 @@ const parseHTML = (html, decode, settings, processStyles = false, cookieConsentS
     // Run cookie consent logic from embedded media to remove markup that's not supposed to run
     // when consent is not accepted.
     embeddedMedia.handleCookieConsent(dom, cookieConsent);
+    // Optimize embedded media iframe markup before it's injected into the DOM.
+    embeddedMedia.applyIframeOptimizations(dom);
 
     // How many onloads have been processed.
     let onloads = 0;


### PR DESCRIPTION
# Description
This PR addresses a critical issue affecting YouTube iFrames on recent iOS versions (notably iOS 18.4.0). When product descriptions included embedded YouTube videos, the entire app view could be unexpectedly replaced by the iFrame content, making it impossible to navigate back or restore the app to a usable state.

## Root Cause
The issue appears to be caused by recent changes — possibly a bug — in Safari’s WebView behavior. Previously, we applied optimizations to iFrames after they were inserted into the DOM, such as updating the src, adding sandbox attributes, and making the iFrame responsive. On newer iOS versions, modifying the src of an iFrame after it’s in the DOM can trigger the fullscreen behavior that breaks app navigation.

## Solution
This PR updates the logic so that all iFrame optimizations are applied before the HTML content is inserted into the DOM. This avoids problematic runtime modifications and ensures more stable behavior across platforms.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Since YouTube iFrames are currently removed from product descriptions, you need to be a little bit creative. The most easy way to inject iFrames into product descriptions is to manipulate the product description selector (see https://github.com/shopgate/pwa/blob/master/libraries/commerce/product/selectors/product.js#L617).

Just replace `return entry.description` with something like:
```js
return `<iframe width="560" height="315" src="https://www.youtube.com/embed/WrBw9zO4z58?si=b0jAkJv6pwINPsyk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>${entry.description}`;
```
To test YouTube iframes in HTML widgets, you can manipulate the widget and replace the HTML [here](https://github.com/shopgate/pwa/blob/master/themes/theme-ios11/widgets/Html/index.jsx#L17) with

```js
const html = '&lt;iframe width=&quot;560&quot; height=&quot;315&quot; src=&quot;https://www.youtube.com/embed/WrBw9zO4z58?si=b0jAkJv6pwINPsyk&quot; title=&quot;YouTube video player&quot; frameborder=&quot;0&quot; allow=&quot;accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share&quot; referrerpolicy=&quot;strict-origin-when-cross-origin&quot; allowfullscreen&gt;&lt;/iframe&gt;';

```