### PR TITLE
Add setHeaders method to HttpRequest for custom header support

### DIFF
--- a/libraries/core/classes/HttpRequest/index.js
+++ b/libraries/core/classes/HttpRequest/index.js
@@ -24,6 +24,7 @@ class HttpRequest extends Request {
 
     this.payload = null;
     this.contentType = null;
+    this.headers = null;
 
     this.createSerial(this.url);
     this.createEventCallbackName('httpResponse');
@@ -46,6 +47,16 @@ class HttpRequest extends Request {
    */
   setContentType(type) {
     this.contentType = type;
+    return this;
+  }
+
+  /**
+   * Sets the headers for the HttpRequest
+   * @param {{ [headerName: string]: string }} headers
+   * @returns {HttpRequest}
+   */
+  setHeaders(headers) {
+    this.headers = headers;
     return this;
   }
 
@@ -97,6 +108,14 @@ class HttpRequest extends Request {
     }
 
     return contentType;
+  }
+
+  getHeaders() {
+    if (!this.headers) {
+      return {};
+    }
+
+    return this.headers;
   }
 
   /**
@@ -166,7 +185,9 @@ class HttpRequest extends Request {
         timeout: this.timeout,
         followRedirects: this.followRedirects,
         body: this.getRequestBody(),
+        // the iOS Cloud Flight app will use this over any content type passed in the headers and breaks if it's not set:
         contentType: this.contentType ? this.contentType : this.getContentType(),
+        headers: this.getHeaders(),
       };
 
       /**

--- a/libraries/core/classes/HttpRequest/index.js
+++ b/libraries/core/classes/HttpRequest/index.js
@@ -43,6 +43,7 @@ class HttpRequest extends Request {
   /**
    * Sets the contentType for the HttpRequest
    * @param {string} type The contentType for request
+   * @deprecated Not supported anymore by app version >= 11.0.0
    * @returns {HttpRequest}
    */
   setContentType(type) {
@@ -51,11 +52,20 @@ class HttpRequest extends Request {
   }
 
   /**
-   * Sets the headers for the HttpRequest
-   * @param {{ [headerName: string]: string }} headers
-   * @returns {HttpRequest}
+   * @typedef {Object.<string, string>} HeaderMap
+   */
+
+  /**
+   * Sets the headers for the HttpRequest.
+   * @param {HeaderMap} headers - An object mapping header names to values.
+   * @returns {HttpRequest} The current HttpRequest instance (for chaining).
    */
   setHeaders(headers) {
+    if (typeof headers !== 'object') {
+      logger.error('HttpRequest: setHeaders expects an object as parameter');
+      return this;
+    }
+
     this.headers = headers;
     return this;
   }
@@ -110,6 +120,10 @@ class HttpRequest extends Request {
     return contentType;
   }
 
+  /**
+   * Determines the headers for the request
+   * @returns {Object} The headers
+   */
   getHeaders() {
     if (!this.headers) {
       return {};
@@ -185,7 +199,8 @@ class HttpRequest extends Request {
         timeout: this.timeout,
         followRedirects: this.followRedirects,
         body: this.getRequestBody(),
-        // the iOS Cloud Flight app will use this over any content type passed in the headers and breaks if it's not set:
+        // the iOS Cloud Flight app will use this over any content type passed in
+        // the headers and breaks if it's not set:
         contentType: this.contentType ? this.contentType : this.getContentType(),
         headers: this.getHeaders(),
       };

--- a/libraries/webcheckout/actions/logout.js
+++ b/libraries/webcheckout/actions/logout.js
@@ -6,9 +6,14 @@ import successShopifyLogout from '../action-creators/successShopifyLogout';
 import { getLogoutUrl, getLogoutSuccessUrl } from '../selectors';
 
 /**
+ * @typedef {Object} LogoutOptions
+ * @property {Object.<string, string>} [headers] - Optional request headers.
+ */
+
+/**
  * Log out the current user.
- * @param {{ headers: { [headerName: string]: string } }} options
- * @return {Function} A redux thunk.
+ * @param {LogoutOptions} [options] - Optional options containing request headers.
+ * @returns {Function} A Redux thunk.
  */
 const webCheckoutLogout = (options = {}) => (dispatch) => {
   const logoutUrl = getLogoutUrl();
@@ -20,9 +25,9 @@ const webCheckoutLogout = (options = {}) => (dispatch) => {
 
   dispatch(requestShopifyLogout());
 
-  const request = new HttpRequest(logoutUrl)
+  const request = new HttpRequest(logoutUrl);
 
-  if (options.headers) request.setHeaders(options.headers)
+  if (options.headers) request.setHeaders(options.headers);
 
   request.dispatch()
     .then((response) => {

--- a/libraries/webcheckout/actions/logout.js
+++ b/libraries/webcheckout/actions/logout.js
@@ -20,6 +20,7 @@ const webCheckoutLogout = () => (dispatch) => {
   dispatch(requestShopifyLogout());
 
   new HttpRequest(logoutUrl)
+    .setHeaders({ accept: 'text/html' })
     .dispatch()
     .then((response) => {
       const {

--- a/libraries/webcheckout/actions/logout.js
+++ b/libraries/webcheckout/actions/logout.js
@@ -7,9 +7,10 @@ import { getLogoutUrl, getLogoutSuccessUrl } from '../selectors';
 
 /**
  * Log out the current user.
+ * @param {{ headers: { [headerName: string]: string } }} options
  * @return {Function} A redux thunk.
  */
-const webCheckoutLogout = () => (dispatch) => {
+const webCheckoutLogout = (options = {}) => (dispatch) => {
   const logoutUrl = getLogoutUrl();
 
   if (!logoutUrl) {
@@ -19,9 +20,11 @@ const webCheckoutLogout = () => (dispatch) => {
 
   dispatch(requestShopifyLogout());
 
-  new HttpRequest(logoutUrl)
-    .setHeaders({ accept: 'text/html' })
-    .dispatch()
+  const request = new HttpRequest(logoutUrl)
+
+  if (options.headers) request.setHeaders(options.headers)
+
+  request.dispatch()
     .then((response) => {
       const {
         headers: { location } = {},


### PR DESCRIPTION
# Description

This pull request adds a new `setHeaders` method to the `HttpRequest` class, enabling custom HTTP headers to be set for outgoing requests. This provides greater flexibility when configuring requests.

Notes
- Custom headers are supported starting with app version 11.0.0.
- The method accepts an object where each key-value pair represents a header name and its corresponding value.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
