### PR TITLE
Add Support for Updating Navigation Bar Color on Android 15 Edge-to-Edge displays

### DIFF
--- a/libraries/engage/core/helpers/androidNavigationBar.js
+++ b/libraries/engage/core/helpers/androidNavigationBar.js
@@ -1,0 +1,37 @@
+import { AndroidNavigationBar } from '@shopgate/native-modules';
+import { logger, appSupportsAndroidEdgeToEdge } from '@shopgate/engage/core/helpers';
+
+/**
+ * @typedef {Object} UpdateAndroidNavigationBarOptions
+ * @property {string} [color] Color for the navigation bar.
+ * Accepts hex, hex with alpha, rgb(), or rgba().
+ */
+
+let lastOptions = null;
+
+/**
+ * Updates the Android navigation bar style based on the provided visual options.
+ * Typically used to match app UI to system navigation bar for a more native look and feel.
+ *
+ * @param {UpdateAndroidNavigationBarOptions} [options={}] Visual customization options for
+ * the nav bar.
+ */
+export const updateAndroidNavigationBarColor = (options = {}) => {
+  // Only necessary for Android devices with edge-to-edge screens
+  if (!appSupportsAndroidEdgeToEdge()) {
+    return;
+  }
+
+  const { color } = options;
+
+  const needsUpdate = !lastOptions || options.color !== lastOptions.color;
+
+  if (needsUpdate) {
+    try {
+      AndroidNavigationBar.setColor({ color });
+      lastOptions = { ...options };
+    } catch (e) {
+      logger.error('Error updating Android navigation bar color', e);
+    }
+  }
+};

--- a/libraries/engage/core/helpers/appFeatures.js
+++ b/libraries/engage/core/helpers/appFeatures.js
@@ -7,6 +7,7 @@ import {
   hasSGJavaScriptBridge,
   hasWebBridge,
   hasNewServices,
+  isAndroidOs,
 } from '@shopgate/engage/core/helpers';
 
 /**
@@ -65,9 +66,14 @@ export const appSupportsCookieConsent = () => {
  * @returns {boolean}
  */
 export const appSupportsAndroidEdgeToEdge = () => {
-  if (hasWebBridge() || !hasSGJavaScriptBridge()) {
-    // Deactivated in browser mode and development for now
+  if (hasWebBridge()) {
+    // Deactivated in browser mode
     return false;
+  }
+
+  if (!hasSGJavaScriptBridge() && isAndroidOs) {
+    // Active in dev environment with Android user agent
+    return true;
   }
 
   return isFeatureFlagEnabled('StatusBar', APP_FEATURE_ANDROID_EDGE_TO_EDGE);

--- a/libraries/engage/core/helpers/index.js
+++ b/libraries/engage/core/helpers/index.js
@@ -17,6 +17,7 @@ export { getFullImageSource } from './getFullImageSource';
 export { getImageFormat } from './getImageFormat';
 export { i18n, getWeekDaysOrder } from './i18n';
 export { updateLegacyNavigationBar } from './updateLegacyNavigationBar';
+export { updateAndroidNavigationBarColor } from './androidNavigationBar';
 export { default as nl2br } from './nl2br';
 export * from './string';
 export { isIOSTheme } from './isIOSTheme';

--- a/libraries/engage/core/initialization/index.js
+++ b/libraries/engage/core/initialization/index.js
@@ -136,9 +136,11 @@ export const initialize = async (locales, reducers, subscribers) => {
   moment.locale(process.env.LOCALE);
 
   if (isDev) {
+    // Inject an object to the window that can be used to check if the PWA is running in dev mode
     window.SGConnectDev = {
-      // Indicates the the current dev app is running in a browser - not in the app
+      // Indicates the the current dev app is running in a browser - not in the real app
       isDevBrowser: !hasWebBridge() && !hasSGJavaScriptBridge(),
+      // Indicates that the PWA is running in a dev environment
       isDev,
     };
   }

--- a/libraries/engage/core/initialization/index.js
+++ b/libraries/engage/core/initialization/index.js
@@ -11,7 +11,12 @@ import fetchClientInformation from '@shopgate/pwa-common/actions/client/fetchCli
 import appConfig from '@shopgate/pwa-common/helpers/config';
 import { appInitialization, configuration } from '@shopgate/engage/core/collections';
 import { CONFIGURATION_COLLECTION_KEY_BASE_URL } from '@shopgate/engage/core/constants';
-import { getAppBaseUrl } from '@shopgate/engage/core/helpers';
+import {
+  getAppBaseUrl,
+  isDev,
+  hasSGJavaScriptBridge,
+  hasWebBridge,
+} from '@shopgate/engage/core/helpers';
 import {
   receiveShopSettings,
   receiveMerchantSettings,
@@ -129,6 +134,14 @@ const fetchSettings = store => new Promise((resolve, reject) => {
  */
 export const initialize = async (locales, reducers, subscribers) => {
   moment.locale(process.env.LOCALE);
+
+  if (isDev) {
+    window.SGConnectDev = {
+      // Indicates the the current dev app is running in a browser - not in the app
+      isDevBrowser: !hasWebBridge() && !hasSGJavaScriptBridge(),
+      isDev,
+    };
+  }
 
   i18n.init({
     locales,

--- a/libraries/engage/core/subscriptions/app.js
+++ b/libraries/engage/core/subscriptions/app.js
@@ -1,9 +1,16 @@
 import { appWillStart$ } from '@shopgate/engage/core/streams';
 import { configuration } from '@shopgate/engage/core/collections';
-import { hasNewServices } from '@shopgate/engage/core/helpers';
+import {
+  hasNewServices,
+  appSupportsAndroidEdgeToEdge,
+  updateAndroidNavigationBarColor,
+} from '@shopgate/engage/core/helpers';
 import { CONFIGURATION_COLLECTION_KEY_BASE_URL } from '@shopgate/engage/core/constants';
+import { appConfig } from '@shopgate/engage';
 import { reloadApp$ } from '../streams';
 import { reloadApp } from '../action-creators';
+
+const { androidNavigationBarDefaultColor } = appConfig;
 
 /**
  * App subscriptions
@@ -17,6 +24,11 @@ export default function app(subscribe) {
     window.reloadSGApp = () => {
       dispatch(reloadApp());
     };
+
+    if (appSupportsAndroidEdgeToEdge() && androidNavigationBarDefaultColor) {
+      // Set the navigation bar color for android devices with edge-to-edge screens
+      updateAndroidNavigationBarColor({ color: androidNavigationBarDefaultColor });
+    }
   });
 
   subscribe(reloadApp$, () => {

--- a/libraries/engage/package.json
+++ b/libraries/engage/package.json
@@ -15,7 +15,7 @@
     "connect"
   ],
   "dependencies": {
-    "@shopgate/native-modules": "^1.0.0-beta.22",
+    "@shopgate/native-modules": "1.0.0-beta.25",
     "@shopgate/pwa-common": "7.26.0",
     "@shopgate/pwa-common-commerce": "7.26.0",
     "@shopgate/pwa-core": "7.26.0",

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -817,7 +817,7 @@
     "androidNavigationBarDefaultColor": {
       "type": "admin",
       "destination": "frontend",
-      "default": "#ffffff",
+      "default": null,
       "params": {
         "type": "text" ,
         "label": "Default color of the navigation bar on Android >= 15",

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -813,6 +813,16 @@
         "type": "json",
         "label": "By default we attempt to make videos inside HTML widgets responsive, so that they take the full screen width. This setting can be used to disable this behavior for specific video providers."
       }
+    },
+    "androidNavigationBarDefaultColor": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": "#ffffff",
+      "params": {
+        "type": "text" ,
+        "label": "Default color of the navigation bar on Android >= 15",
+        "description": "On Android >= 15 the navigation bar overlays the app. This settings defines the default color of the navigation bar if not set on demand by the PWA."
+      }
     }
   }
 }

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -825,6 +825,16 @@
         "type": "json",
         "label": "By default we attempt to make videos inside HTML widgets responsive, so that they take the full screen width. This setting can be used to disable this behavior for specific video providers."
       }
+    },
+    "androidNavigationBarDefaultColor": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": "#fafafa",
+      "params": {
+        "type": "text" ,
+        "label": "Default color of the navigation bar on Android >= 15",
+        "description": "On Android >= 15 the navigation bar overlays the app. This settings defines the default color of the navigation bar if not set on demand by the PWA."
+      }
     }
   }
 }

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -829,7 +829,7 @@
     "androidNavigationBarDefaultColor": {
       "type": "admin",
       "destination": "frontend",
-      "default": "#fafafa",
+      "default": null,
       "params": {
         "type": "text" ,
         "label": "Default color of the navigation bar on Android >= 15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,10 +2111,10 @@
     "@sentry/types" "6.0.1"
     tslib "^1.9.3"
 
-"@shopgate/native-modules@^1.0.0-beta.22":
-  version "1.0.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@shopgate/native-modules/-/native-modules-1.0.0-beta.22.tgz#b3495d56378881580dc4dfb153ff98d28e15ecde"
-  integrity sha512-kzOMov0tM/yLNmoRmvCjc3BbXv7AcT9To/HaHDZrmB3IZKKoF+m9hBk9uJCP2KUegfjxQmakQ1DGFFVBooyWjw==
+"@shopgate/native-modules@1.0.0-beta.25":
+  version "1.0.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@shopgate/native-modules/-/native-modules-1.0.0-beta.25.tgz#8d3abe75b65811fe4db2a72083e0c58dac51c717"
+  integrity sha512-GMWtIXzzMGLikyLDazaVScGRMf/vORlpU5w8AONwT3jPy9lXpB+BkJ0XKuUirltWjhA/UyCRPeVfvCZUx/IUaQ==
   dependencies:
     event-target-shim "^5.0.1"
 


### PR DESCRIPTION
# Description
This pull request introduces support for customizing the navigation bar on Android 15 devices with edge-to-edge displays.

## What’s New
- **New helper**: `updateAndroidNavigationBarColor` — allows dynamically updating the navigation bar color on Android 15+ devices (can be imported via `@shopgate/engage/core/helpers`).
- **Configurable default color**: The default navigation bar color can now be set via `extension-config` (default null).

## Why
Android 15 introduces changes to how the navigation bar is rendered, especially on edge-to-edge devices. This update ensures that apps can maintain consistent UI theming by explicitly setting the navigation bar color when needed.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
- Run `yarn` to update node modules with the latest version of `@shopgate/native-modules` package
- Start frontend SDK and connect with an **Android 15** device or a simulator with an app version that implements the necessary features
- Test different navigation bar colors by changing the `androidNavigationBarDefaultColor` theme config (hex, hex alpha, rgb, rgba)
