### PR TITLE
Add possibility to add ScrollHeader styling from external

### DIFF
--- a/libraries/engage/components/ScrollHeader/index.jsx
+++ b/libraries/engage/components/ScrollHeader/index.jsx
@@ -12,7 +12,11 @@ import {
  * @returns {JSX}
  */
 function ScrollHeader({
-  className, children, hideOnScroll, scrollOffset,
+  className,
+  children,
+  hideOnScroll,
+  scrollOffset,
+  classes,
 }) {
   const [shouldHideHeader, setShouldHideHeader] = useState(false);
 
@@ -27,10 +31,15 @@ function ScrollHeader({
     },
   });
 
+  const scrolledInStyle = classes?.scrolledIn ? classes.scrolledIn : scrolledIn;
+  const scrolledOutStyle = classes?.scrolledOut ? classes.scrolledOut : scrolledOut;
+  const transitionStyle = classes?.transition ? classes.transition : transition;
+  const rootStyle = classes?.root ? classes.root : root;
+
   return (
-    <div className={classNames(root, transition, className, {
-      [scrolledIn]: !shouldHideHeader,
-      [scrolledOut]: shouldHideHeader,
+    <div className={classNames(rootStyle, transitionStyle, className, {
+      [scrolledInStyle]: !shouldHideHeader,
+      [scrolledOutStyle]: shouldHideHeader,
     })}
     >
       {children}
@@ -40,6 +49,12 @@ function ScrollHeader({
 
 ScrollHeader.propTypes = {
   children: PropTypes.node.isRequired,
+  classes: PropTypes.shape({
+    root: PropTypes.string,
+    scrolledIn: PropTypes.string,
+    scrolledOut: PropTypes.string,
+    transition: PropTypes.string,
+  }),
   className: PropTypes.string,
   hideOnScroll: PropTypes.bool,
   scrollOffset: PropTypes.number,
@@ -49,6 +64,7 @@ ScrollHeader.defaultProps = {
   className: null,
   hideOnScroll: true,
   scrollOffset: 100,
+  classes: {},
 };
 
 export default ScrollHeader;

--- a/libraries/engage/components/ScrollHeader/index.jsx
+++ b/libraries/engage/components/ScrollHeader/index.jsx
@@ -6,6 +6,7 @@ import {
   root, scrolledIn, scrolledOut, transition,
 } from './style';
 
+/* eslint-disable react/prop-types */
 /**
  * A container component that hides its content on scroll down and shows it on scroll up.
  *
@@ -27,8 +28,8 @@ import {
 function ScrollHeaderBase({
   className,
   children,
-  hideOnScroll,
-  scrollOffset,
+  hideOnScroll = true,
+  scrollOffset = 100,
   onChange,
   classes,
 }, ref) {
@@ -66,11 +67,16 @@ function ScrollHeaderBase({
   );
 }
 
-ScrollHeaderBase.propTypes = {
+/* eslint-enable react/prop-types */
+
+const ScrollHeader = forwardRef(ScrollHeaderBase);
+ScrollHeader.displayName = 'ScrollHeader';
+
+ScrollHeader.propTypes = {
   children: PropTypes.node.isRequired,
   classes: PropTypes.shape({
-    scrolledIn: PropTypes.object,
-    scrolledOut: PropTypes.object,
+    scrolledIn: PropTypes.string,
+    scrolledOut: PropTypes.string,
   }),
   className: PropTypes.string,
   hideOnScroll: PropTypes.bool,
@@ -78,15 +84,12 @@ ScrollHeaderBase.propTypes = {
   scrollOffset: PropTypes.number,
 };
 
-ScrollHeaderBase.defaultProps = {
+ScrollHeader.defaultProps = {
   className: null,
   hideOnScroll: true,
   scrollOffset: 100,
   classes: {},
   onChange: null,
 };
-
-const ScrollHeader = forwardRef(ScrollHeaderBase);
-ScrollHeader.displayName = 'ScrollHeader';
 
 export default ScrollHeader;

--- a/libraries/engage/components/ScrollHeader/index.jsx
+++ b/libraries/engage/components/ScrollHeader/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, forwardRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useScrollDirectionChange } from '@shopgate/engage/core/hooks';
@@ -7,17 +7,31 @@ import {
 } from './style';
 
 /**
- * Scroll Header component
- * @param {Object} props props
- * @returns {JSX}
+ * A container component that hides its content on scroll down and shows it on scroll up.
+ *
+ * @param {Object} props The component props.
+ * @param {boolean}  [props.hideOnScroll] Toggle hide-on-scroll (default: true).
+ * @param {number} [props.scrollOffset] Pixels to scroll before toggling (default: 100).
+ * @param {Function} [props.onChange] Callback function that is called when the header changes
+ * @param {string} [props.className] Extra CSS classes on the root element.
+ * @param {Object} [props.classes] Override internal class names.
+ * @param {string} [props.classes.scrolledIn] Override class for the scrolled-in state
+ * (content is hidden).
+ * @param {string} [props.classes.scrolledOut] Override class for the scrolled-out state
+ * (content is visible).
+ * visibility. Contains a boolean indicating whether the header is visible.
+ * @param {React.ReactNode} props.children  Content of the header.
+ * @param {React.Ref<HTMLDivElement>} ref   Forwarded ref to the header `<div>`.
+ * @returns {JSX.Element}
  */
-function ScrollHeader({
+function ScrollHeaderBase({
   className,
   children,
   hideOnScroll,
   scrollOffset,
+  onChange,
   classes,
-}) {
+}, ref) {
   const [shouldHideHeader, setShouldHideHeader] = useState(false);
 
   useScrollDirectionChange({
@@ -31,18 +45,28 @@ function ScrollHeader({
     },
   });
 
+  useEffect(() => {
+    if (typeof onChange !== 'function') {
+      return;
+    }
+
+    onChange(!shouldHideHeader);
+  }, [onChange, shouldHideHeader]);
+
   return (
-    <div className={classNames(root, transition, className, {
-      [classNames(scrolledIn, classes.scrolledIn)]: !shouldHideHeader,
-      [classNames(scrolledOut, classes.scrolledOut)]: shouldHideHeader,
-    })}
+    <div
+      ref={ref}
+      className={classNames(root, transition, className, {
+        [classNames(scrolledIn, classes?.scrolledIn)]: !shouldHideHeader,
+        [classNames(scrolledOut, classes?.scrolledOut)]: shouldHideHeader,
+      })}
     >
       {children}
     </div>
   );
 }
 
-ScrollHeader.propTypes = {
+ScrollHeaderBase.propTypes = {
   children: PropTypes.node.isRequired,
   classes: PropTypes.shape({
     scrolledIn: PropTypes.object,
@@ -50,14 +74,19 @@ ScrollHeader.propTypes = {
   }),
   className: PropTypes.string,
   hideOnScroll: PropTypes.bool,
+  onChange: PropTypes.func,
   scrollOffset: PropTypes.number,
 };
 
-ScrollHeader.defaultProps = {
+ScrollHeaderBase.defaultProps = {
   className: null,
   hideOnScroll: true,
   scrollOffset: 100,
   classes: {},
+  onChange: null,
 };
+
+const ScrollHeader = forwardRef(ScrollHeaderBase);
+ScrollHeader.displayName = 'ScrollHeader';
 
 export default ScrollHeader;

--- a/libraries/engage/components/ScrollHeader/index.jsx
+++ b/libraries/engage/components/ScrollHeader/index.jsx
@@ -31,15 +31,10 @@ function ScrollHeader({
     },
   });
 
-  const scrolledInStyle = classes?.scrolledIn ? classes.scrolledIn : scrolledIn;
-  const scrolledOutStyle = classes?.scrolledOut ? classes.scrolledOut : scrolledOut;
-  const transitionStyle = classes?.transition ? classes.transition : transition;
-  const rootStyle = classes?.root ? classes.root : root;
-
   return (
-    <div className={classNames(rootStyle, transitionStyle, className, {
-      [scrolledInStyle]: !shouldHideHeader,
-      [scrolledOutStyle]: shouldHideHeader,
+    <div className={classNames(root, transition, className, {
+      [classNames(scrolledIn, classes.scrolledIn)]: !shouldHideHeader,
+      [classNames(scrolledOut, classes.scrolledOut)]: shouldHideHeader,
     })}
     >
       {children}
@@ -50,10 +45,8 @@ function ScrollHeader({
 ScrollHeader.propTypes = {
   children: PropTypes.node.isRequired,
   classes: PropTypes.shape({
-    root: PropTypes.string,
-    scrolledIn: PropTypes.string,
-    scrolledOut: PropTypes.string,
-    transition: PropTypes.string,
+    scrolledIn: PropTypes.object,
+    scrolledOut: PropTypes.object,
   }),
   className: PropTypes.string,
   hideOnScroll: PropTypes.bool,


### PR DESCRIPTION
# Description

Adds a property to the ScrollHeader so now styling can be passed from outside.

## Type of change

Please add an "x" into the option that is relevant:

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Add external styling and see if ScrollHeader changes.