### PR TITLE
Add product list widget

### DIFF
--- a/extensions/@shopgate-product-reviews/frontend/RatingStars/index.jsx
+++ b/extensions/@shopgate-product-reviews/frontend/RatingStars/index.jsx
@@ -12,10 +12,14 @@ const { hasReviews } = appConfig;
  * The RatingStars component.
  * @return {JSX}
  */
-const RatingStars = ({ product }) => {
+const RatingStars = ({ product, display }) => {
   const { showEmptyRatingStars = false } = useWidgetSettings('@shopgate/engage/rating');
 
   const showRatings = useMemo(() => {
+    if (display?.reviews === false) {
+      return false;
+    }
+
     if (hasReviews && product?.rating?.average > 0) {
       return true;
     }
@@ -25,7 +29,7 @@ const RatingStars = ({ product }) => {
     }
 
     return false;
-  }, [product, showEmptyRatingStars]);
+  }, [display, product, showEmptyRatingStars]);
 
   if (!showRatings) {
     return null;
@@ -36,6 +40,13 @@ const RatingStars = ({ product }) => {
 
 RatingStars.propTypes = {
   product: PropTypes.shape().isRequired,
+  display: PropTypes.shape({
+    reviews: PropTypes.bool,
+  }),
+};
+
+RatingStars.defaultProps = {
+  display: null,
 };
 
 export default hot(module)(connect(RatingStars));

--- a/libraries/commerce/product/actions/fetchProductsByQuery.js
+++ b/libraries/commerce/product/actions/fetchProductsByQuery.js
@@ -27,11 +27,10 @@ const fetchProductsByQuery = (type, value, options = {}, id = null) => (dispatch
         ...sanitizedOptions,
       };
 
-      dispatch(fetchHighlightProducts({
+      return dispatch(fetchHighlightProducts({
         params,
         ...id && { id },
       }));
-      break;
     }
 
     // Search phrase
@@ -72,16 +71,14 @@ const fetchProductsByQuery = (type, value, options = {}, id = null) => (dispatch
         delete params.limit;
         delete params.offset;
 
-        dispatch(fetchProducts({
+        return dispatch(fetchProducts({
           params,
           ...id && { id },
           includeFilters: false,
         }));
-      } else {
-        dispatch(fetchProductsById(value, id));
       }
 
-      break;
+      return dispatch(fetchProductsById(value, id));
     }
 
     // Category

--- a/libraries/common/components/Backdrop/__snapshots__/spec.jsx.snap
+++ b/libraries/common/components/Backdrop/__snapshots__/spec.jsx.snap
@@ -6,18 +6,22 @@ exports[`<Backdrop /> should render 1`] = `
     Object {
       "appear": Object {
         "opacity": 0.5,
+        "pointerEvents": "auto",
       },
       "base": Object {
         "background": "#000",
         "opacity": 0,
+        "pointerEvents": "auto",
         "transition": "opacity 200ms ease-out",
         "zIndex": 2,
       },
       "enter": Object {
         "opacity": 0.5,
+        "pointerEvents": "auto",
       },
       "leave": Object {
         "opacity": 0,
+        "pointerEvents": "none",
       },
     }
   }
@@ -27,6 +31,7 @@ exports[`<Backdrop /> should render 1`] = `
     aria-hidden={true}
     className="css-30873t  common__backdrop"
     data-test-id="Backdrop"
+    key="backdrop"
     onClick={[Function]}
   />
 </Transition>

--- a/libraries/common/components/Backdrop/index.jsx
+++ b/libraries/common/components/Backdrop/index.jsx
@@ -108,15 +108,19 @@ class Backdrop extends Component {
         opacity: 0,
         transition: `opacity ${this.props.duration}ms ease-out`,
         zIndex: this.props.level,
+        pointerEvents: 'auto',
       },
       appear: {
         opacity,
+        pointerEvents: 'auto',
       },
       enter: {
         opacity,
+        pointerEvents: 'auto',
       },
       leave: {
         opacity: 0,
+        pointerEvents: 'none',
       },
     };
 
@@ -125,7 +129,7 @@ class Backdrop extends Component {
     return (
       <Transition childrenStyles={transition}>
         {this.props.isVisible ?
-          <div data-test-id="Backdrop" aria-hidden className={className} onClick={this.props.onClick} /> : null
+          <div data-test-id="Backdrop" key="backdrop" aria-hidden className={className} onClick={this.props.onClick} /> : null
         }
       </Transition>
     );

--- a/libraries/common/components/Swiper/index.jsx
+++ b/libraries/common/components/Swiper/index.jsx
@@ -49,6 +49,7 @@ const Swiper = ({
   onSlideChange,
   additionalModules,
   children,
+  paginationType: paginationTypeProp,
   ...swiperProps
 }) => {
   const useFraction = (maxIndicators && maxIndicators < children.length);
@@ -103,7 +104,7 @@ const Swiper = ({
     ...showPagination && {
       pagination: {
         el: undefined,
-        type: paginationType,
+        type: paginationTypeProp || paginationType,
         bulletClass: classNames.bulletClass || 'swiper-pagination-bullet',
         bulletActiveClass: classNames.bulletActiveClass || 'swiper-pagination-bullet-active',
         dynamicBullets: true,
@@ -115,10 +116,23 @@ const Swiper = ({
     allowSlideNext: !disabled,
     onSlideChange: handleSlideChange,
   }),
-  [additionalModules, classNames.container, classNames.bulletClass, classNames.bulletActiveClass,
-    swiperProps, autoPlay, interval, navigation, showPagination, paginationType, indicators,
+  [
+    additionalModules,
+    classNames.container,
+    classNames.bulletClass,
+    classNames.bulletActiveClass,
+    swiperProps,
+    autoPlay,
+    interval,
+    navigation,
+    showPagination,
+    paginationTypeProp,
+    paginationType,
+    indicators,
     children.length,
-    disabled, handleSlideChange]);
+    disabled,
+    handleSlideChange,
+  ]);
 
   useEffect(() => {
     if (!internalProps.autoplay && !swiperProps.autoplay) {
@@ -230,6 +244,10 @@ Swiper.propTypes = {
    * Invoked with the index of the new slide and the Swiper instance.
    */
   onSlideChange: PropTypes.func,
+  /**
+   * Config to determine slider pagination type
+   */
+  paginationType: PropTypes.string,
 };
 
 Swiper.defaultProps = {
@@ -244,6 +262,7 @@ Swiper.defaultProps = {
   maxIndicators: null,
   disabled: false,
   onSlideChange: null,
+  paginationType: null,
 };
 
 export default Swiper;

--- a/libraries/common/components/Swiper/styles.js
+++ b/libraries/common/components/Swiper/styles.js
@@ -25,9 +25,29 @@ export const innerContainer = css({
       opacity: '.5',
       margin: '0 4px',
       transition: 'opacity 300ms cubic-bezier(0.25, 0.1, 0.25, 1)',
+      border: `1px solid ${themeColors.dark}`,
     },
     ' .swiper-pagination-bullet-active.swiper-pagination-bullet-active-main': {
       opacity: 1,
+    },
+  },
+  ' .swiper-pagination-fraction': {
+    top: 'var(--swiper-pagination-fraction-top-offset, 4px)',
+    left: 'auto',
+    right: 0,
+    bottom: 'auto',
+    fontSize: 12,
+    background: themeColors.background,
+    borderRadius: '50px',
+    width: 'fit-content',
+    padding: '4px 8px',
+    margin: '4px 16px',
+    transition: 'opacity 300ms cubic-bezier(0.25, 0.1, 0.25, 1)',
+  },
+  ' .swiper-pagination-progressbar': {
+    background: themeColors.shade7,
+    ' .swiper-pagination-progressbar-fill': {
+      background: themeColors.dark,
     },
   },
 }).toString();

--- a/libraries/common/subscriptions/router.js
+++ b/libraries/common/subscriptions/router.js
@@ -9,6 +9,7 @@ import {
 import Route from '@virtuous/conductor/Route';
 import { HISTORY_RESET_TO } from '@shopgate/pwa-common/constants/ActionTypes';
 import { logger } from '@shopgate/pwa-core';
+import { IS_PAGE_PREVIEW_ACTIVE } from '@shopgate/engage/page/constants';
 import { getCurrentRoute, getRouterStackIndex } from '../selectors/router';
 import { LoadingProvider } from '../providers';
 import { redirects } from '../collections';
@@ -31,6 +32,11 @@ import ToastProvider from '../providers/toast';
  */
 export default function routerSubscriptions(subscribe) {
   subscribe(navigate$, async (params) => {
+    if (IS_PAGE_PREVIEW_ACTIVE) {
+      // No navigation is allowed in page preview mode.
+      return;
+    }
+
     const {
       action, dispatch, getState, events,
     } = params;

--- a/libraries/engage/components/View/context.js
+++ b/libraries/engage/components/View/context.js
@@ -1,3 +1,15 @@
 import React from 'react';
+import noop from 'lodash/noop';
 
-export const ViewContext = React.createContext();
+export const ViewContext = React.createContext({
+  top: null,
+  bottom: null,
+  ariaHidden: false,
+  set: noop,
+  setTop: noop,
+  setBottom: noop,
+  setContentRef: noop,
+  getContentRef: () => ({ current: null }),
+  scrollTop: noop,
+  setAriaHidden: noop,
+});

--- a/libraries/engage/page/components/Widgets/WidgetContext.js
+++ b/libraries/engage/page/components/Widgets/WidgetContext.js
@@ -13,4 +13,4 @@ import { createContext } from 'react';
  */
 
 /** @type {React.Context<WidgetContextType>} */
-export const WidgetContext = createContext();
+export const WidgetContext = createContext({});

--- a/libraries/engage/page/hooks/index.d.ts
+++ b/libraries/engage/page/hooks/index.d.ts
@@ -25,7 +25,7 @@ export type UseWidgetProductsOptions = {
    * Sort order for the products
    * @default 'relevance'
    */
-  sortOrder?: 'relevance' | 'priceAsc' | 'priceDesc' | 'nameAsc' | 'nameDesc';
+  sort?: 'relevance' | 'priceAsc' | 'priceDesc' | 'nameAsc' | 'nameDesc';
 };
 
 export type UseWidgetProductsResult = {

--- a/libraries/engage/page/hooks/index.d.ts
+++ b/libraries/engage/page/hooks/index.d.ts
@@ -5,3 +5,56 @@ import type { WidgetContextType } from '../components/Widgets/WidgetContext';
  * @returns The widget context.
  */
 export declare function useWidget<C = Record<string, any>>(): WidgetContextType<C>
+
+
+export type UseWidgetProductsOptions = {
+  /**
+   * The search value to use for the product search
+   */
+  value: string;
+  /**
+   * The type of product search to perform.
+   */
+  type: 'searchTerm' | 'itemNumbers' | 'brand' | 'category' | 'highlights';
+  /**
+   * The number of products to return per page.
+   * @default 32
+   */
+  limit?: number;
+  /**
+   * Sort order for the products
+   * @default 'relevance'
+   */
+  sortOrder?: 'relevance' | 'priceAsc' | 'priceDesc' | 'nameAsc' | 'nameDesc';
+};
+
+export type UseWidgetProductsResult = {
+  /**
+   * Function to fetch the next page of products.
+   */
+  fetchNext: () => void;
+  /**
+   * Whether there are more products to fetch.
+   */
+  hasNext: boolean;
+  /**
+   * Whether the products are currently being fetched.
+   */
+  isFetching: boolean;
+  /**
+   * Number of products available in the current result set.
+   */
+  totalResultCount: number;
+  /**
+   * Array of product results.
+   */
+  results: Object[];
+}
+
+/**
+ * The useWidgetProducts hook provides an easy way to retrieve products based on a search term or
+ * other criteria.
+ */
+export declare function useWidgetProducts(
+  options: UseWidgetProductsOptions
+): UseWidgetProductsResult;

--- a/libraries/engage/page/hooks/index.js
+++ b/libraries/engage/page/hooks/index.js
@@ -45,7 +45,7 @@ export const useWidgetProducts = (options = {}) => {
     type,
     value,
     limit = ITEMS_PER_LOAD,
-    sortOrder = 'relevance',
+    sort = 'relevance',
   } = options;
 
   const dispatch = useDispatch();
@@ -55,12 +55,12 @@ export const useWidgetProducts = (options = {}) => {
   const showInventoryInProductLists = useSelector(showInventoryInLists);
 
   const selectorOptions = useMemo(() => ({
-    sort: transformDisplayOptions(sortOrder),
+    sort: transformDisplayOptions(sort),
     value,
     ...(showInventoryInProductLists && {
       useDefaultRequestForProductIds: true,
     }),
-  }), [showInventoryInProductLists, sortOrder, value]);
+  }), [showInventoryInProductLists, sort, value]);
 
   const getWidgetProducts = useMemo(
     () => makeGetWidgetProducts(type, selectorOptions, code),
@@ -73,19 +73,21 @@ export const useWidgetProducts = (options = {}) => {
     typeof widgetProducts.totalProductCount !== 'number' || widgetProducts.products.length < widgetProducts.totalProductCount
   );
 
-  const offset = Math.min(widgetProducts.products.length, widgetProducts.totalProductCount ?? 0);
+  // const offset = Math.min(widgetProducts.products.length, widgetProducts.totalProductCount ?? 0);
+  const offset = 0;
 
   const requestOptions = useMemo(() => ({
     limit,
     offset,
-    sort: transformDisplayOptions(sortOrder),
+    sort: transformDisplayOptions(sort),
     ...(showInventoryInProductLists && {
       useDefaultRequestForProductIds: true,
     }),
-  }), [limit, offset, showInventoryInProductLists, sortOrder]);
+  }), [limit, offset, showInventoryInProductLists, sort]);
 
   const fetchProducts = useCallback(async () => {
-    if (!hasNext) {
+    console.warn('fectch', value, requestOptions, code, hasNext);
+    if (!hasNext || !value) {
       return;
     }
 
@@ -100,9 +102,10 @@ export const useWidgetProducts = (options = {}) => {
   }, [code, dispatch, hasNext, requestOptions, type, value]);
 
   useEffect(() => {
+    setHasNext(() => true);
     fetchProducts();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [type, value, limit, sort]);
 
   return {
     fetchNext: fetchProducts,

--- a/libraries/engage/page/hooks/index.js
+++ b/libraries/engage/page/hooks/index.js
@@ -1,8 +1,24 @@
-import { useContext } from 'react';
+import {
+  useContext, useMemo, useCallback, useEffect, useState,
+} from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { WidgetContext } from '@shopgate/engage/page/components/Widgets';
+import { showInventoryInLists } from '@shopgate/engage/locations/helpers';
+import { ITEMS_PER_LOAD } from '@shopgate/engage/core/constants';
+import { transformDisplayOptions } from '@shopgate/engage/core/helpers';
+import { fetchProductsByQuery } from '@shopgate/engage/product';
+import { makeGetWidgetProducts } from '../selectors';
 
 /**
  * @typedef {import('../components/Widgets/WidgetContext').WidgetContextType WidgetContextType}
+ */
+
+/**
+ * @typedef {import('./index').UseWidgetProductsOptions} UseWidgetProductsOptions
+ */
+
+/**
+ * @typedef {import('./index').UseWidgetProductsResult} UseWidgetProductsResult
  */
 
 /**
@@ -10,3 +26,89 @@ import { WidgetContext } from '@shopgate/engage/page/components/Widgets';
  * @returns {WidgetContextType} The widget context.
  */
 export const useWidget = () => useContext(WidgetContext);
+
+const REQUEST_TYPE_MAPPING = {
+  highlights: 1,
+  searchTerm: 2,
+  brand: 3,
+  itemNumbers: 4,
+  category: 5,
+};
+
+/**
+ * Retrieves the products for the current widget.
+ * @param {UseWidgetProductsOptions} options Hook options
+ * @returns {UseWidgetProductsResult} The products and a function to fetch more products.
+ */
+export const useWidgetProducts = (options = {}) => {
+  const {
+    type,
+    value,
+    limit = ITEMS_PER_LOAD,
+    sortOrder = 'relevance',
+  } = options;
+
+  const dispatch = useDispatch();
+
+  const { code = 'abc' } = useWidget();
+
+  const showInventoryInProductLists = useSelector(showInventoryInLists);
+
+  const selectorOptions = useMemo(() => ({
+    sort: transformDisplayOptions(sortOrder),
+    value,
+    ...(showInventoryInProductLists && {
+      useDefaultRequestForProductIds: true,
+    }),
+  }), [showInventoryInProductLists, sortOrder, value]);
+
+  const getWidgetProducts = useMemo(
+    () => makeGetWidgetProducts(type, selectorOptions, code),
+    [code, selectorOptions, type]
+  );
+
+  const widgetProducts = useSelector(getWidgetProducts);
+
+  const [hasNext, setHasNext] = useState(
+    typeof widgetProducts.totalProductCount !== 'number' || widgetProducts.products.length < widgetProducts.totalProductCount
+  );
+
+  const offset = Math.min(widgetProducts.products.length, widgetProducts.totalProductCount ?? 0);
+
+  const requestOptions = useMemo(() => ({
+    limit,
+    offset,
+    sort: transformDisplayOptions(sortOrder),
+    ...(showInventoryInProductLists && {
+      useDefaultRequestForProductIds: true,
+    }),
+  }), [limit, offset, showInventoryInProductLists, sortOrder]);
+
+  const fetchProducts = useCallback(async () => {
+    if (!hasNext) {
+      return;
+    }
+
+    const result = await dispatch(fetchProductsByQuery(
+      REQUEST_TYPE_MAPPING[type],
+      value,
+      requestOptions,
+      code
+    ));
+
+    setHasNext(() => result.products.length >= requestOptions.limit);
+  }, [code, dispatch, hasNext, requestOptions, type, value]);
+
+  useEffect(() => {
+    fetchProducts();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    fetchNext: fetchProducts,
+    hasNext,
+    isFetching: widgetProducts.isFetching,
+    results: widgetProducts.products,
+    totalResultCount: widgetProducts.totalProductCount,
+  };
+};

--- a/libraries/engage/page/selectors/index.js
+++ b/libraries/engage/page/selectors/index.js
@@ -1,7 +1,22 @@
 import { createSelector } from 'reselect';
-import { makeGetMenu, makeGetIsFetchingMenu } from '@shopgate/engage/core/selectors';
+import {
+  makeGetMenu,
+  makeGetIsFetchingMenu,
+} from '@shopgate/engage/core/selectors';
+import {
+  getFulfillmentParams,
+  getPopulatedProductsResult,
+  SHOPGATE_CATALOG_GET_HIGHLIGHT_PRODUCTS,
+} from '@shopgate/engage/product';
+import {
+  getProductState,
+} from '@shopgate/engage/product/selectors/product';
 import { LEGAL_MENU } from '@shopgate/engage/core/constants';
-import { hasNewServices } from '@shopgate/engage/core';
+import {
+  hasNewServices,
+  transformDisplayOptions,
+  generateResultHash,
+} from '@shopgate/engage/core/helpers';
 import { PRIVACY_PATH } from '../constants';
 
 export * from '@shopgate/pwa-common/selectors/page';
@@ -101,5 +116,107 @@ export const makeGetWidgetsFromPage = ({
 
       return (page.data?.dropzones ?? []).find(entry => entry.dropzone === dropzone)?.widgetList;
     }
+  );
+};
+
+/**
+ * Creates a selector that generates a hash to select results for widget products.
+ * @param {'searchTerm' | 'itemNumbers' | 'brand' | 'category' |'highlights'} type Type of the
+ * request to make.
+ * @param {Object} options Request options
+ * @param {string} id Unique identifier to find the result in the state.
+ * @returns {Function} A selector function that generates a hash for the widget products result.
+ */
+const makeGetWidgetProductsResultHash = (type, options, id) => {
+  const { value, sort } = options;
+
+  const transformedSort = transformDisplayOptions(sort);
+
+  return createSelector(
+    getFulfillmentParams,
+    (fulfillmentParams) => {
+      let hashParams = {};
+
+      switch (type) {
+        case 'highlights':
+          hashParams = {
+            id,
+            pipeline: SHOPGATE_CATALOG_GET_HIGHLIGHT_PRODUCTS,
+            sort: transformedSort,
+          };
+          break;
+        case 'searchTerm':
+        case 'brand':
+          hashParams = {
+            id,
+            searchPhrase: value,
+            sort: transformedSort,
+            ...fulfillmentParams,
+          };
+          break;
+        case 'itemNumbers':
+          hashParams = {
+            id,
+            productIds: value,
+            sort: transformedSort,
+            ...fulfillmentParams,
+          };
+
+          break;
+        case 'category':
+          hashParams = {
+            id,
+            categoryId: value,
+            sort: transformedSort,
+            ...fulfillmentParams,
+          };
+
+          break;
+        default:
+      }
+
+      return generateResultHash(hashParams, true, false);
+    }
+  );
+};
+
+/**
+ * @param {'searchTerm' | 'itemNumbers' | 'brand' | 'category' |'highlights'} type Type of the
+ * request to make.
+ * @param {Object} options Request options
+ * @param {string} id Unique identifier to find the result in the state.
+ * @returns {Function} A selector function that retrieves the widget products result by hash.
+ */
+const makeGetWidgetProductResultsByHash = (type, options, id) => {
+  const getWidgetProductResultsHash = makeGetWidgetProductsResultHash(type, options, id);
+
+  return createSelector(
+    getProductState,
+    getWidgetProductResultsHash,
+    (productState, hash) => productState.resultsByHash[hash]
+  );
+};
+
+/**
+ * Creates a selector that generates a hash to select results for widget products.
+ * @param {'searchTerm' | 'itemNumbers' | 'brand' | 'category' |'highlights'} type Type of the
+ * request to make.
+ * @param {Object} options Request options
+ * @param {string} id Unique identifier to find the result in the state.
+ * @returns {Function} A selector function that generates a hash for the widget products result.
+ */
+export const makeGetWidgetProducts = (type, options, id) => {
+  const getWidgetProductResultsHash = makeGetWidgetProductsResultHash(type, options, id);
+  const getWidgetProductResultsByHash = makeGetWidgetProductResultsByHash(type, options, id);
+
+  return createSelector(
+    state => state,
+    (state, props) => props ?? {},
+    getWidgetProductResultsHash,
+    getWidgetProductResultsByHash,
+    (state, props, resultsHash, resultsByHash) => ({
+      isFetching: resultsByHash?.isFetching || false,
+      ...getPopulatedProductsResult(state, props, resultsHash, resultsByHash),
+    })
   );
 };

--- a/libraries/engage/page/widgets/ProductList/ProductList.jsx
+++ b/libraries/engage/page/widgets/ProductList/ProductList.jsx
@@ -1,0 +1,90 @@
+import React, { useMemo } from 'react';
+import { camelCase } from 'lodash';
+import { ActionButton, I18n } from '@shopgate/engage/components';
+import { ProductGrid } from '@shopgate/engage/product/components';
+import { useWidgetProducts } from '@shopgate/engage/page/hooks';
+import { useProductListWidget } from './hooks';
+
+/**
+ * The ProductListWidget is used to display product lists.
+ * @returns {JSX.Element}
+ */
+const ProductListWidget = () => {
+  const {
+    config,
+  } = useProductListWidget();
+
+  const {
+    products,
+    productCount,
+    sort,
+    loadMoreButton = false,
+    showName = false,
+    showPrice = false,
+    showRating = false,
+  } = config;
+
+  const {
+    productSelectorType,
+    productsBrand,
+    productsCategory,
+    productsItemNumbers,
+    productsSearchTerm,
+  } = products;
+
+  const value = useMemo(() => {
+    switch (productSelectorType) {
+      case 'brand':
+        return productsBrand;
+      case 'category':
+        return productsCategory;
+      case 'itemNumbers':
+        return productsItemNumbers;
+      case 'searchTerm':
+      default:
+        return productsSearchTerm;
+    }
+  }, [
+    productSelectorType,
+    productsBrand,
+    productsCategory,
+    productsItemNumbers,
+    productsSearchTerm,
+  ]);
+
+  const {
+    fetchNext, hasNext, isFetching, results,
+  } = useWidgetProducts({
+    type: productSelectorType || 'searchTerm',
+    value: value || '',
+    limit: productCount,
+    sort: camelCase(sort),
+  });
+
+  const flags = useMemo(() => ({
+    name: showName,
+    price: showPrice,
+    reviews: showRating,
+  }), [showName, showPrice, showRating]);
+
+  return (
+    <>
+      <ProductGrid
+        products={results}
+        flags={flags}
+        scope="widgets"
+        infiniteLoad={false}
+      />
+      { hasNext && loadMoreButton && (
+      <ActionButton
+        loading={isFetching}
+        onClick={fetchNext}
+      >
+        <I18n.Text string="common.load_more" />
+      </ActionButton>
+      )}
+    </>
+  );
+};
+
+export default ProductListWidget;

--- a/libraries/engage/page/widgets/ProductList/hooks.js
+++ b/libraries/engage/page/widgets/ProductList/hooks.js
@@ -1,0 +1,34 @@
+import { useWidget } from '@shopgate/engage/page/hooks';
+
+/**
+ * @typedef {Object} ProductListWidgetProducts
+ * @property {"searchTerm" | "brand" | "category" | "itemNumbers"} productSelectorType Source type
+ * for the product list.
+ * @property {string} productsSearchTerm A search term to filter products by
+ * @property {string} productsBrand A brand to filter products by
+ * @property {string} productsCategory A category to filter products by
+ * @property {string} productsItemNumbers A comma-separated list of item numbers to filter products
+ * by
+ */
+
+/**
+ * @typedef {Object} ProductListWidgetConfig
+ * @property {ProductListWidgetProducts} products The products configuration for the widget.
+ * @property {number} productCount The number of products to display in the widget
+ * @property {"relevance" | "PriceDesc" | "PriceDesc"} sort Sort order for the products
+ * @property {boolean} loadMoreButton Whether to display a "Load more" button
+ * @property {boolean} showName Whether to display product names
+ * @property {boolean} showPrice Whether to display product prices
+ * @property {boolean} showRating Whether to display product ratings
+ */
+
+/**
+ * @typedef {ReturnType< typeof import('@shopgate/engage/page/hooks')
+ * .useWidget<ProductListWidgetConfig> >} HookReturnType
+ */
+
+/**
+ * Hook to access the Product List widget configuration.
+ * @returns {HookReturnType}
+ */
+export const useProductListWidget = () => useWidget();

--- a/libraries/engage/page/widgets/ProductList/index.js
+++ b/libraries/engage/page/widgets/ProductList/index.js
@@ -1,0 +1,1 @@
+export { default } from './ProductList';

--- a/libraries/engage/page/widgets/index.js
+++ b/libraries/engage/page/widgets/index.js
@@ -1,1 +1,2 @@
 export { default as PlaceholderWidget } from './Placeholder';
+export { default as ProductListWidget } from './ProductList';

--- a/libraries/engage/page/widgets/widgets.json
+++ b/libraries/engage/page/widgets/widgets.json
@@ -1,4 +1,7 @@
 {
+    "@shopgate/widgets/productListWidget": {
+    "path": "@shopgate/engage/page/widgets/ProductList"
+  },
   "@shopgate/widgetsInternal/Placeholder": {
     "path": "@shopgate/engage/page/widgets/Placeholder"
   }

--- a/libraries/engage/product/components/Media/MediaImage.jsx
+++ b/libraries/engage/product/components/Media/MediaImage.jsx
@@ -12,7 +12,7 @@ import { innerShadow } from './style';
 
 /**
  * The featured image component.
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 const MediaImage = ({
   url, altText, className, resolutions,

--- a/libraries/engage/product/components/MediaSlider/index.jsx
+++ b/libraries/engage/product/components/MediaSlider/index.jsx
@@ -15,10 +15,16 @@ const typeRenders = {
 
 /**
  * The product media slider component.
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 const MediaSlider = ({
-  navigate, featuredMedia, media, 'aria-hidden': ariaHidden, renderPlaceholder, className,
+  navigate,
+  featuredMedia,
+  media,
+  'aria-hidden': ariaHidden,
+  renderPlaceholder,
+  className,
+  paginationType,
 }) => {
   let currentSlide = 0;
 
@@ -46,6 +52,7 @@ const MediaSlider = ({
       <SurroundPortals portalName={PRODUCT_MEDIA}>
         {media &&
           <Swiper
+            paginationType={paginationType}
             loop={media.length > 1}
             indicators
             onSlideChange={setCurrentSlide}
@@ -87,6 +94,7 @@ MediaSlider.propTypes = {
     title: PropTypes.string,
     url: PropTypes.string,
   })),
+  paginationType: PropTypes.string,
   renderPlaceholder: PropTypes.func,
 };
 
@@ -94,6 +102,7 @@ MediaSlider.defaultProps = {
   'aria-hidden': null,
   className: null,
   featuredMedia: null,
+  paginationType: null,
   media: null,
   renderPlaceholder: featuredMedia => (<MediaImage {...featuredMedia} />),
 };

--- a/libraries/engage/product/components/ProductCard/index.jsx
+++ b/libraries/engage/product/components/ProductCard/index.jsx
@@ -46,7 +46,6 @@ function ProductCard(props) {
   const {
     product, hidePrice, hideRating, hideName, titleRows, url,
   } = props;
-
   const { meta } = useProductListType();
 
   const { ListImage: gridResolutions } = getProductImageSettings();

--- a/libraries/engage/product/components/ProductGrid/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/product/components/ProductGrid/__snapshots__/spec.jsx.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ProductGrid /> should render the original layout 1`] = `
+<ProductGrid
+  flags={null}
+  handleGetProducts={[Function]}
+  infiniteLoad={false}
+  meta={null}
+  products={Array []}
+  requestHash={null}
+  scope={null}
+  totalProductCount={null}
+>
+  <Layout>
+    <Grid
+      className="css-1qmdz0q-root theme__product-grid"
+      data-test-id="productGrid"
+      wrap={true}
+    />
+  </Layout>
+</ProductGrid>
+`;
+
+exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
+<ProductGrid
+  flags={null}
+  handleGetProducts={[Function]}
+  infiniteLoad={true}
+  meta={null}
+  products={Array []}
+  requestHash={null}
+  scope={null}
+  totalProductCount={null}
+>
+  <ProductListTypeProvider
+    meta={null}
+    subType={null}
+    type="productGrid"
+  >
+    <InfiniteContainer
+      containerRef={
+        Object {
+          "current": null,
+        }
+      }
+      enablePromiseBasedLoading={true}
+      initialLimit={32}
+      items={Array []}
+      iterator={[Function]}
+      limit={32}
+      loader={[Function]}
+      loadingIndicator={<UNDEFINED />}
+      requestHash={null}
+      totalItems={null}
+      wrapper={[Function]}
+    />
+  </ProductListTypeProvider>
+</ProductGrid>
+`;

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemDetails/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemDetails/__snapshots__/spec.jsx.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ItemDetails /> should render additional components with new services 1`] = `
+<Link
+  className="css-q9if5h-root theme__product-grid__item__item-details"
+  href="link-to-product/1234"
+  state={
+    Object {
+      "title": "Foo",
+    }
+  }
+  tabIndex={0}
+>
+  <Swatches
+    productId="1234"
+  />
+  <ItemName
+    display={null}
+    name="Foo"
+    productId="1234"
+  />
+  <MapPriceHint
+    productId="1234"
+  />
+  <OrderQuantityHint
+    className="css-1ke3znq-quantityHint"
+    productId="1234"
+  />
+  <EffectivityDates
+    productId="1234"
+  />
+  <Availability
+    showWhenAvailable={false}
+    state="AVAILABILITY_STATE_OK"
+    text="product.available.not"
+  />
+  <StockInfoLists
+    product={
+      Object {
+        "id": "1234",
+        "name": "Foo",
+        "price": Object {},
+      }
+    }
+  />
+  <ItemPrice
+    display={null}
+    product={
+      Object {
+        "id": "1234",
+        "name": "Foo",
+        "price": Object {},
+      }
+    }
+  />
+</Link>
+`;
+
+exports[`<ItemDetails /> should render with minimal props 1`] = `
+<Link
+  className="css-q9if5h-root theme__product-grid__item__item-details"
+  href="link-to-product/1234"
+  state={
+    Object {
+      "title": "Foo",
+    }
+  }
+  tabIndex={0}
+>
+  <Swatches
+    productId="1234"
+  />
+  <ItemName
+    display={null}
+    name="Foo"
+    productId="1234"
+  />
+  <MapPriceHint
+    productId="1234"
+  />
+  <OrderQuantityHint
+    className="css-1ke3znq-quantityHint"
+    productId="1234"
+  />
+  <EffectivityDates
+    productId="1234"
+  />
+  <ItemPrice
+    display={null}
+    product={
+      Object {
+        "id": "1234",
+        "name": "Foo",
+        "price": Object {},
+      }
+    }
+  />
+</Link>
+`;

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemDetails/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemDetails/index.jsx
@@ -1,0 +1,112 @@
+import React, { useMemo, memo } from 'react';
+import PropTypes from 'prop-types';
+import {
+  MapPriceHint,
+  OrderQuantityHint,
+  EffectivityDates,
+  Swatches,
+  AVAILABILITY_STATE_OK,
+  AVAILABILITY_STATE_ALERT,
+  getProductRoute,
+} from '@shopgate/engage/product';
+import { hasNewServices as checkHasNewServices, i18n } from '@shopgate/engage/core/helpers';
+import { Availability, Link } from '@shopgate/engage/components';
+import { StockInfoLists } from '@shopgate/engage/locations/components';
+import { makeStyles } from '@shopgate/engage/styles';
+import ItemName from '../ItemName';
+import ItemPrice from '../ItemPrice';
+
+const useStyles = makeStyles()({
+  root: {
+    lineHeight: 1.2,
+    ':not(:empty)': {
+      padding: '12px 0 30px',
+    },
+  },
+  quantityHint: {
+    paddingTop: 8,
+  },
+});
+
+/**
+ * The Product Grid Item Detail component.
+ * @param {Object} props The component props.
+ * @param {Object} props.product The product.
+ * @param {Object} props.display The display object.
+ * @param {Object} [props.productListTypeMeta] Optional meta object with data from the product list
+ * @returns {JSX.Element}
+ */
+const ItemDetails = ({ product, display, productListTypeMeta }) => {
+  const { id: productId, name = null, stock = null } = product;
+
+  const { classes, cx } = useStyles();
+  const hasNewServices = useMemo(() => checkHasNewServices(), []);
+
+  if (display && !display.name && !display.price && !display.reviews) {
+    return null;
+  }
+
+  return (
+    <Link
+      className={cx(classes.root, 'theme__product-grid__item__item-details')}
+      tabIndex={0}
+      href={getProductRoute(productId)}
+      state={{
+        title: product.name,
+        ...productListTypeMeta,
+      }}
+    >
+      {/*
+        This feature is currently in BETA testing.
+        It should only be used for approved BETA Client Projects
+      */}
+      <Swatches productId={productId} />
+
+      <ItemName display={display} productId={productId} name={name} />
+
+      {/*
+        This feature is currently in BETA testing.
+        It should only be used for approved BETA Client Projects
+      */}
+      <MapPriceHint productId={productId} />
+
+      {/*
+        This feature is currently in BETA testing.
+        It should only be used for approved BETA Client Projects
+      */}
+      <OrderQuantityHint productId={productId} className={classes.quantityHint} />
+
+      {/* This feature is currently in BETA testing.
+      It should only be used for approved BETA Client Projects */}
+      <EffectivityDates productId={productId} />
+      { hasNewServices && (
+        <>
+          <Availability
+            state={!stock || stock.orderable
+              ? AVAILABILITY_STATE_OK
+              : AVAILABILITY_STATE_ALERT
+        }
+            text={i18n.text('product.available.not')}
+            showWhenAvailable={false}
+          />
+          <StockInfoLists product={product} />
+        </>
+      )}
+
+      <ItemPrice product={product} display={display} />
+    </Link>
+  );
+};
+
+ItemDetails.propTypes = {
+  product: PropTypes.shape().isRequired,
+  display: PropTypes.shape(),
+  productListTypeMeta: PropTypes.shape(),
+};
+
+ItemDetails.defaultProps = {
+  display: null,
+  productListTypeMeta: null,
+};
+
+export default memo(ItemDetails);

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemDetails/spec.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemDetails/spec.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { hasNewServices } from '@shopgate/engage/core/helpers';
+import { Availability } from '@shopgate/engage/components';
+import { StockInfoLists } from '@shopgate/engage/locations/components';
+import ItemDetails from './index';
+
+jest.mock('@shopgate/engage/product', () => ({
+  MapPriceHint: () => null,
+  OrderQuantityHint: () => null,
+  EffectivityDates: () => null,
+  Swatches: () => null,
+  AVAILABILITY_STATE_OK: 'AVAILABILITY_STATE_OK',
+  AVAILABILITY_STATE_ALERT: 'AVAILABILITY_STATE_ALERT',
+  getProductRoute: jest.fn(productId => `link-to-product/${productId}`),
+}));
+jest.mock('@shopgate/engage/locations/components', () => ({
+  StockInfoLists: () => null,
+}));
+jest.mock('@shopgate/engage/core/helpers', () => ({
+  hasNewServices: jest.fn().mockReturnValue(false),
+  i18n: {
+    text: str => str,
+  },
+}));
+jest.mock('@shopgate/engage/components');
+jest.mock('@shopgate/engage/core', () => ({
+  isIOSTheme: jest.fn().mockReturnValue(true),
+  hasWebBridge: jest.fn().mockReturnValue(false),
+  i18n: {
+    text: text => text,
+  },
+}));
+jest.mock('../ItemName');
+jest.mock('../ItemPrice');
+
+describe('<ItemDetails />', () => {
+  const props = {
+    product: {
+      id: '1234',
+      name: 'Foo',
+      price: {},
+    },
+  };
+
+  const display = {
+    name: false,
+    price: false,
+    reviews: false,
+  };
+
+  it('should render with minimal props', () => {
+    const wrapper = shallow(<ItemDetails {...props} />);
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(Availability).exists()).toBe(false);
+    expect(wrapper.find(StockInfoLists).exists()).toBe(false);
+  });
+
+  it('should render additional components with new services', () => {
+    hasNewServices.mockReturnValueOnce(true);
+    const wrapper = shallow(<ItemDetails {...props} />);
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(Availability).exists()).toBe(true);
+    expect(wrapper.find(StockInfoLists).exists()).toBe(true);
+  });
+
+  it('should not render with display props set', () => {
+    const wrapper = shallow(<ItemDetails {...props} display={display} />);
+    expect(wrapper).toBeEmptyRender();
+  });
+});

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemDiscount/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemDiscount/index.jsx
@@ -1,0 +1,48 @@
+import React, { memo, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { SurroundPortals, DiscountBadge } from '@shopgate/engage/components';
+import { PRODUCT_ITEM_DISCOUNT } from '@shopgate/engage/category';
+import { makeStyles } from '@shopgate/engage/styles';
+
+const useStyles = makeStyles()({
+  root: {
+    minWidth: 40,
+  },
+});
+
+/**
+ * The item discount component
+ * @param {Object} props The component props.
+ * @returns {JSX.Element|null}
+ */
+const ItemDiscount = ({
+  productId,
+  discount,
+}) => {
+  const { classes, cx } = useStyles();
+
+  const portalProps = useMemo(() => ({ productId }), [productId]);
+
+  if (!discount) {
+    return null;
+  }
+
+  return (
+    <div className={cx(classes.root, 'theme__product-grid__item__item-discount')}>
+      <SurroundPortals portalName={PRODUCT_ITEM_DISCOUNT} portalProps={portalProps}>
+        <DiscountBadge text={`-${discount}%`} />
+      </SurroundPortals>
+    </div>
+  );
+};
+
+ItemDiscount.propTypes = {
+  productId: PropTypes.string.isRequired,
+  discount: PropTypes.number,
+};
+
+ItemDiscount.defaultProps = {
+  discount: null,
+};
+
+export default memo(ItemDiscount);

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemFavoritesButton/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemFavoritesButton/__snapshots__/spec.jsx.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ItemFavoritesButton /> should not render when its not a favorite 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "getServerState": undefined,
+      "noopCheck": "once",
+      "stabilityCheck": "once",
+      "store": Object {
+        "@@observable": [Function],
+        "dispatch": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Object {
+        "addNestedSub": [Function],
+        "getListeners": [Function],
+        "handleChangeWrapper": [Function],
+        "isSubscribed": [Function],
+        "notifyNestedSubs": [Function],
+        "trySubscribe": [Function],
+        "tryUnsubscribe": [Function],
+      },
+    }
+  }
+>
+  <ItemFavoritesButton
+    productId="1234"
+  />
+</ContextProvider>
+`;
+
+exports[`<ItemFavoritesButton /> should render if its a favorite 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "getServerState": undefined,
+      "noopCheck": "once",
+      "stabilityCheck": "once",
+      "store": Object {
+        "@@observable": [Function],
+        "dispatch": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "subscription": Object {
+        "addNestedSub": [Function],
+        "getListeners": [Function],
+        "handleChangeWrapper": [Function],
+        "isSubscribed": [Function],
+        "notifyNestedSubs": [Function],
+        "trySubscribe": [Function],
+        "tryUnsubscribe": [Function],
+      },
+    }
+  }
+>
+  <ItemFavoritesButton
+    isFavorite={true}
+    productId="1234"
+  />
+</ContextProvider>
+`;

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemFavoritesButton/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemFavoritesButton/index.jsx
@@ -1,0 +1,56 @@
+import React, { memo, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { SurroundPortals, FavoritesButton } from '@shopgate/engage/components';
+import { PRODUCT_ITEM_FAVORITES_BUTTON } from '@shopgate/engage/category';
+import { isRelativeProductOnList } from '@shopgate/engage/favorites';
+import { getLoadWishlistOnAppStartEnabled } from '@shopgate/engage/core';
+import { makeStyles } from '@shopgate/engage/styles';
+
+const useStyles = makeStyles()({
+  root: {
+    position: 'absolute',
+    top: 0,
+    right: 16,
+    left: 'auto',
+    transform: 'translate3d(0, -50%, 0)',
+  },
+});
+
+/**
+ * The item favorites button component.
+ * @param {Object} props The component props.
+ * @returns {JSX.Element}
+ */
+const ItemFavoritesButton = ({
+  productId,
+}) => {
+  const { classes } = useStyles();
+  const loadWishlistOnAppStartEnabled = useSelector(getLoadWishlistOnAppStartEnabled);
+  const isOnWishlist = useSelector(state => isRelativeProductOnList(state, { productId }));
+  const isFavorite = useMemo(
+    () => (!loadWishlistOnAppStartEnabled ? false : isOnWishlist),
+    [isOnWishlist, loadWishlistOnAppStartEnabled]
+  );
+
+  const portalProps = useMemo(() => ({ productId }), [productId]);
+
+  return (
+    <SurroundPortals portalName={PRODUCT_ITEM_FAVORITES_BUTTON} portalProps={portalProps}>
+      <div className={classes.root} data-test-id="favorites">
+        <FavoritesButton
+          active={isFavorite}
+          productId={productId}
+          noShadow
+          removeWithRelatives
+        />
+      </div>
+    </SurroundPortals>
+  );
+};
+
+ItemFavoritesButton.propTypes = {
+  productId: PropTypes.string.isRequired,
+};
+
+export default memo(ItemFavoritesButton);

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemFavoritesButton/spec.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemFavoritesButton/spec.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { combineReducers } from 'redux';
+import { Provider } from 'react-redux';
+import { createMockStore } from '@shopgate/pwa-common/store';
+import favorites from '@shopgate/pwa-common-commerce/favorites/reducers';
+import ItemFavoritesButton from './index';
+
+jest.mock('@shopgate/engage/components');
+
+const store = createMockStore(combineReducers({
+  favorites,
+}));
+
+describe('<ItemFavoritesButton />', () => {
+  it('should not render when its not a favorite', () => {
+    const wrapper = shallow((
+      <Provider store={store}>
+        <ItemFavoritesButton productId="1234" />
+      </Provider>
+    ));
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render if its a favorite', () => {
+    const wrapper = shallow((
+      <Provider store={store}>
+        <ItemFavoritesButton productId="1234" isFavorite />
+      </Provider>
+    ));
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemImage/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemImage/__snapshots__/spec.jsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ItemImage /> should render 1`] = `
+<Component
+  portalName="product-item.image"
+  portalProps={
+    Object {
+      "productId": "1234",
+    }
+  }
+>
+  <Connect(WithWidgetSettings(ProductImage))
+    alt="FooBar"
+    itemProp="image"
+    resolutions={
+      Array [
+        Object {
+          "height": 440,
+          "width": 440,
+        },
+      ]
+    }
+    src="http://www.google.com"
+  />
+</Component>
+`;

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemImage/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemImage/index.jsx
@@ -1,0 +1,44 @@
+import React, { useMemo, memo } from 'react';
+import PropTypes from 'prop-types';
+import { SurroundPortals } from '@shopgate/engage/components';
+import { PRODUCT_ITEM_IMAGE } from '@shopgate/engage/category/constants';
+import { getProductImageSettings, ProductImage } from '@shopgate/engage/product';
+
+const { ListImage: gridResolutions } = getProductImageSettings();
+
+/**
+ * The item image component.
+ * @param {Object} props The component props.
+ * @returns {JSX.Element}
+ */
+const ItemImage = ({
+  productId,
+  name,
+  imageUrl,
+}) => {
+  const portalProps = useMemo(() => ({ productId }), [productId]);
+
+  return (
+    <SurroundPortals portalName={PRODUCT_ITEM_IMAGE} portalProps={portalProps}>
+      <ProductImage
+        alt={name}
+        src={imageUrl}
+        resolutions={gridResolutions}
+        itemProp="image"
+      />
+    </SurroundPortals>
+  );
+};
+
+ItemImage.propTypes = {
+  productId: PropTypes.string.isRequired,
+  imageUrl: PropTypes.string,
+  name: PropTypes.string,
+};
+
+ItemImage.defaultProps = {
+  imageUrl: null,
+  name: null,
+};
+
+export default memo(ItemImage);

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemImage/spec.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemImage/spec.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ItemImage from './index';
+
+jest.mock('@shopgate/engage/components', () => ({
+  ProductImage: () => null,
+}));
+
+describe('<ItemImage />', () => {
+  it('should render', () => {
+    const wrapper = shallow(<ItemImage productId="1234" imageUrl="http://www.google.com" name="FooBar" />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemName/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemName/__snapshots__/spec.jsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ItemName /> should render with minimal props 1`] = `
+<ProductName
+  className="css-1ykint2-root theme__product-grid__item__item-name"
+  name="Foo"
+  portalName="product-item.name"
+  portalProps={
+    Object {
+      "productId": "1234",
+    }
+  }
+  testId="Productname: Foo"
+/>
+`;

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemName/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemName/index.jsx
@@ -1,0 +1,56 @@
+import React, { memo, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { PRODUCT_ITEM_NAME } from '@shopgate/engage/category/constants';
+import { ProductName } from '@shopgate/engage/product';
+import { makeStyles } from '@shopgate/engage/styles';
+
+const useStyles = makeStyles()({
+  root: {
+    fontWeight: '500',
+    lineHeight: 1.15,
+    marginTop: 1,
+    wordBreak: ['keep-all', 'break-word'],
+    hyphens: 'auto',
+  },
+});
+
+/**
+ * The item name component.
+ * @param {Object} props The component props.
+ * @returns {JSX.Element|null}
+ */
+const ItemName = ({
+  display,
+  productId,
+  name,
+}) => {
+  const { classes, cx } = useStyles();
+  const portalProps = useMemo(() => ({ productId }), [productId]);
+
+  if (display && !display.name) {
+    return null;
+  }
+
+  return (
+    <ProductName
+      name={name}
+      className={cx(classes.root, 'theme__product-grid__item__item-name')}
+      portalName={PRODUCT_ITEM_NAME}
+      portalProps={portalProps}
+      testId={`Productname: ${name}`}
+    />
+  );
+};
+
+ItemName.propTypes = {
+  productId: PropTypes.string.isRequired,
+  display: PropTypes.shape(),
+  name: PropTypes.string,
+};
+
+ItemName.defaultProps = {
+  display: null,
+  name: null,
+};
+
+export default memo(ItemName);

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemName/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemName/index.jsx
@@ -25,7 +25,10 @@ const ItemName = ({
   name,
 }) => {
   const { classes, cx } = useStyles();
-  const portalProps = useMemo(() => ({ productId }), [productId]);
+  const portalProps = useMemo(() => ({
+    productId,
+    display,
+  }), [display, productId]);
 
   if (display && !display.name) {
     return null;

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemName/spec.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemName/spec.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ItemName from './index';
+
+jest.mock('@shopgate/engage/product', () => ({
+  ProductName: () => null,
+}));
+
+const props = {
+  productId: '1234',
+  name: 'Foo',
+};
+
+const display = {
+  name: false,
+};
+
+describe('<ItemName />', () => {
+  it('should render with minimal props', () => {
+    const wrapper = shallow(<ItemName {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should not render with display props set', () => {
+    const wrapper = shallow(<ItemName {...props} display={display} />);
+    expect(wrapper).toBeEmptyRender();
+  });
+});

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemPrice/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemPrice/__snapshots__/spec.jsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ItemPrice /> should render with minimal props 1`] = `
+<Component
+  portalName="PRODUCT_ITEM_PRICE"
+  portalProps={
+    Object {
+      "location": "productGrid",
+      "productId": "1234",
+    }
+  }
+>
+  <ProductGridPrice
+    product={
+      Object {
+        "id": "1234",
+        "price": Object {},
+      }
+    }
+  />
+</Component>
+`;

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemPrice/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemPrice/index.jsx
@@ -1,0 +1,42 @@
+import React, { memo, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { SurroundPortals } from '@shopgate/engage/components';
+import {
+  PRODUCT_ITEM_PRICE,
+} from '@shopgate/engage/category';
+import { ProductGridPrice } from '@shopgate/engage/product';
+
+/**
+ * The item price component.
+ * @param {Object} props The component props.
+ * @returns {JSX.Element|null}
+ */
+const ItemPrice = ({ display, product }) => {
+  const { id: productId } = product;
+
+  const portalProps = useMemo(() => ({
+    productId,
+    location: 'productGrid',
+  }), [productId]);
+
+  if (display && !display.price) {
+    return null;
+  }
+
+  return (
+    <SurroundPortals portalName={PRODUCT_ITEM_PRICE} portalProps={portalProps}>
+      <ProductGridPrice product={product} />
+    </SurroundPortals>
+  );
+};
+
+ItemPrice.propTypes = {
+  product: PropTypes.shape().isRequired,
+  display: PropTypes.shape(),
+};
+
+ItemPrice.defaultProps = {
+  display: null,
+};
+
+export default memo(ItemPrice);

--- a/libraries/engage/product/components/ProductGrid/components/Item/components/ItemPrice/spec.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/components/ItemPrice/spec.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ItemPrice from './index';
+
+jest.mock('@shopgate/engage/product', () => ({
+  ProductGridPrice: () => null,
+}));
+jest.mock('@shopgate/engage/components', () => ({
+  Portal: ({ children }) => children,
+}));
+jest.mock('@shopgate/engage/category', () => ({
+  PRODUCT_ITEM_PRICE: 'PRODUCT_ITEM_PRICE',
+  PRODUCT_ITEM_PRICE_AFTER: 'PRODUCT_ITEM_PRICE_AFTER',
+  PRODUCT_ITEM_PRICE_BEFORE: 'PRODUCT_ITEM_PRICE_BEFORE',
+}));
+
+const props = {
+  product: {
+    id: '1234',
+    price: {},
+  },
+};
+
+const display = {
+  price: false,
+};
+
+describe('<ItemPrice />', () => {
+  it('should render with minimal props', () => {
+    const wrapper = shallow(<ItemPrice {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should not render with display props set', () => {
+    const wrapper = shallow(<ItemPrice {...props} display={display} />);
+    expect(wrapper).toBeEmptyRender();
+  });
+});

--- a/libraries/engage/product/components/ProductGrid/components/Item/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Item/index.jsx
@@ -1,0 +1,88 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+import { isBeta } from '@shopgate/engage/core';
+import { getProductRoute, FeaturedMedia, ProductBadges } from '@shopgate/engage/product';
+import { Link } from '@shopgate/engage/components';
+import { useProductListType } from '@shopgate/engage/product/hooks';
+import { themeConfig } from '@shopgate/engage';
+import { makeStyles } from '@shopgate/engage/styles';
+import ItemImage from './components/ItemImage';
+import ItemDiscount from './components/ItemDiscount';
+import ItemFavoritesButton from './components/ItemFavoritesButton';
+import ItemDetails from './components/ItemDetails';
+
+const { colors } = themeConfig;
+
+const useStyles = makeStyles()({
+  root: {
+    position: 'relative',
+    display: 'block',
+    background: colors.light,
+    height: '100%',
+  },
+  itemDetails: {
+    position: 'relative',
+  },
+});
+
+/**
+ * The Product Grid Item component.
+ * @param {Object} props The component props.
+ * @param {Object} props.product The product.
+ * @param {Object} props.display The display object.
+ * @return {JSX.Element}
+ */
+const Item = ({ product, display }) => {
+  const { classes, cx } = useStyles();
+  const { meta } = useProductListType();
+
+  return (
+    <div className={cx(classes.root, 'theme__product-grid__item')}>
+      <Link
+        role="none"
+        href={getProductRoute(product.id)}
+        state={{
+          title: product.name,
+          ...meta,
+        }}
+      >
+        {isBeta() && product.featuredMedia
+          ? <FeaturedMedia
+            type={product.featuredMedia.type}
+            url={product.featuredMedia.url}
+          />
+          : <ItemImage
+            productId={product.id}
+            name={product.name}
+            imageUrl={product.featuredImageBaseUrl}
+          />
+    }
+      </Link>
+      <ProductBadges location="productGrid" productId={product.id}>
+        <ItemDiscount
+          productId={product.id}
+          discount={product.price.discount || null}
+        />
+      </ProductBadges>
+      <div className={classes.itemDetails}>
+        <ItemDetails
+          product={product}
+          display={display}
+          productListTypeMeta={meta}
+        />
+        <ItemFavoritesButton productId={product.id} />
+      </div>
+    </div>
+  );
+};
+
+Item.propTypes = {
+  product: PropTypes.shape().isRequired,
+  display: PropTypes.shape(),
+};
+
+Item.defaultProps = {
+  display: null,
+};
+
+export default memo(Item);

--- a/libraries/engage/product/components/ProductGrid/components/Iterator/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Iterator/index.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Grid,
+  SurroundPortals,
+} from '@shopgate/engage/components';
+import { PRODUCT_ITEM } from '@shopgate/engage/category';
+import { ProductListEntryProvider } from '@shopgate/engage/product';
+import Item from '../Item';
+
+/**
+ * The Product Grid Iterator component.
+ * @param {Object} props The component props.
+ * @returns {JSX}
+ */
+const Iterator = (props) => {
+  const portalProps = { productId: props.id };
+  const { id, display } = props;
+
+  return (
+    <Grid.Item key={id} data-test-id={props.name}>
+      <ProductListEntryProvider productId={props.id}>
+        <SurroundPortals
+          portalName={PRODUCT_ITEM}
+          portalProps={portalProps}
+        >
+          <Item product={props} display={display} />
+        </SurroundPortals>
+      </ProductListEntryProvider>
+    </Grid.Item>
+  );
+};
+
+Iterator.propTypes = {
+  id: PropTypes.string.isRequired,
+  display: PropTypes.shape(),
+  name: PropTypes.string,
+};
+
+Iterator.defaultProps = {
+  display: null,
+  name: null,
+};
+
+export default Iterator;

--- a/libraries/engage/product/components/ProductGrid/components/Layout/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/components/Layout/index.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Grid } from '@shopgate/engage/components';
+import { themeConfig } from '@shopgate/engage';
+import { makeStyles } from '@shopgate/engage/styles';
+
+const { colors } = themeConfig;
+
+const useStyles = makeStyles()((theme, { columns }) => ({
+  root: {
+    background: colors.light,
+    padding: '0 16px',
+    ':not(:empty)': {
+      marginTop: 16,
+    },
+    ...columns <= 2 && {
+      ' > *': {
+        [`:nth-child(${columns}n)`]: {
+          paddingRight: 0,
+        },
+        [`:nth-child(${columns}n+1)`]: {
+          paddingLeft: 0,
+        },
+        padding: '0px 8px',
+        width: `${100 / columns}%`,
+      },
+    },
+    ...columns > 2 && {
+      display: 'grid',
+      gridGap: '0 16px',
+      gridTemplateColumns: `repeat(${columns}, 1fr)`,
+    },
+  },
+}));
+
+/**
+ * The product grid layout component.
+ * @param {Object} props The component props.
+ * @returns {JSX}
+ */
+const Layout = ({ children, columns }) => {
+  const { classes, cx } = useStyles({ columns });
+
+  return (
+    <Grid wrap className={cx(classes.root, 'theme__product-grid')} data-test-id="productGrid">
+      {children}
+    </Grid>
+  );
+};
+
+Layout.propTypes = {
+  columns: PropTypes.number.isRequired,
+  children: PropTypes.node,
+};
+
+Layout.defaultProps = {
+  children: null,
+};
+
+export default Layout;

--- a/libraries/engage/product/components/ProductGrid/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/index.jsx
@@ -48,7 +48,7 @@ const ProductGrid = ({
 
   const columns = useResponsiveValue({
     xs: 2,
-    lg: 4,
+    md: 4,
   });
 
   if (!infiniteLoad) {

--- a/libraries/engage/product/components/ProductGrid/index.jsx
+++ b/libraries/engage/product/components/ProductGrid/index.jsx
@@ -1,0 +1,126 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  ViewContext,
+  InfiniteContainer,
+  LoadingIndicator,
+} from '@shopgate/engage/components';
+import { ProductListTypeProvider } from '@shopgate/engage/product';
+import { ITEMS_PER_LOAD } from '@shopgate/engage/core/constants';
+import { useResponsiveValue } from '@shopgate/engage/styles';
+import Iterator from './components/Iterator';
+import Layout from './components/Layout';
+
+export const WIDGET_ID = '@shopgate/engage/product/ProductGrid';
+
+/**
+ * The Product Grid component.
+ * @param {Object} props The component props.
+ * @param {Array} props.products The list of products to display.
+ * @param {string} props.scope Optional scope of the component. Will be used as subType property of
+ * the ProductListTypeContext and is intended as a description in which "context" the component is
+ * used.
+ * @param {Object} props.meta Optional metadata for the product list type context.
+ * @param {Object} props.flags The flags object.
+ * @param {boolean} props.flags.name Whether to display product names.
+ * @param {boolean} props.flags.price Whether to display product prices.
+ * @param {boolean} props.flags.reviews Whether to display rating stars.
+ * @param {boolean} props.infiniteLoad Whether the grid should support infinite loading.
+ * @param {Function} props.handleGetProducts Callback function that's invoked to load more products
+ * when infinite loading is enabled.
+ * @param {number} props.totalProductCount The total number of products. Needed when infinite
+ * loading is enabled.
+ * @param {string} props.requestHash The hash for the current request. Needed when infinite loading
+ * is enabled
+ * @returns {JSX.Element}
+ */
+const ProductGrid = ({
+  flags,
+  infiniteLoad,
+  handleGetProducts,
+  products,
+  totalProductCount,
+  requestHash,
+  scope,
+  meta,
+}) => {
+  const { getContentRef } = useContext(ViewContext);
+
+  const columns = useResponsiveValue({
+    xs: 2,
+    lg: 4,
+  });
+
+  if (!infiniteLoad) {
+    return (
+      <Layout columns={columns}>
+        <ProductListTypeProvider type="productGrid" subType={scope} meta={meta}>
+          {products.map(product => (
+            <Iterator
+              display={flags}
+              id={product.id}
+              key={product.id}
+              {...product}
+            />
+          ))}
+        </ProductListTypeProvider>
+      </Layout>
+    );
+  }
+
+  return (
+    <ProductListTypeProvider type="productGrid" subType={scope} meta={meta}>
+      <InfiniteContainer
+        containerRef={getContentRef()}
+        wrapper={props => (
+          <Layout
+            columns={columns}
+            {...props}
+          />
+        )}
+        iterator={Iterator}
+        loader={handleGetProducts}
+        items={products}
+        loadingIndicator={<LoadingIndicator />}
+        totalItems={totalProductCount}
+        initialLimit={ITEMS_PER_LOAD}
+        limit={ITEMS_PER_LOAD}
+        requestHash={requestHash}
+        enablePromiseBasedLoading
+      />
+    </ProductListTypeProvider>
+  );
+};
+
+ProductGrid.propTypes = {
+  flags: PropTypes.shape({
+    name: PropTypes.bool,
+    price: PropTypes.bool,
+    reviews: PropTypes.bool,
+  }),
+  handleGetProducts: PropTypes.func,
+  infiniteLoad: PropTypes.bool,
+  meta: PropTypes.shape(),
+  products: PropTypes.arrayOf(PropTypes.shape()),
+  requestHash: PropTypes.string,
+  /**
+   * Optional scope of the component. Will be used as subType property of the ProductListTypeContext
+   * and is intended as a description in which "context" the component is used.
+   * @default null
+   */
+  scope: PropTypes.string,
+  totalProductCount: PropTypes.number,
+};
+
+ProductGrid.defaultProps = {
+  flags: null,
+  handleGetProducts: () => { },
+  infiniteLoad: true,
+  products: null,
+  requestHash: null,
+  totalProductCount: null,
+  scope: null,
+  meta: null,
+};
+
+export default ProductGrid;

--- a/libraries/engage/product/components/ProductGrid/spec.jsx
+++ b/libraries/engage/product/components/ProductGrid/spec.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ProductGrid from '.';
+
+global.console.error = jest.fn();
+
+jest.mock('@shopgate/engage/core', () => ({
+  hasWebBridge: jest.fn(() => false),
+  isIOSTheme: jest.fn(() => false),
+  withForwardedRef: jest.fn(),
+  withCurrentProduct: jest.fn(),
+  useWidgetSettings: jest.fn().mockReturnValue({}),
+}));
+jest.mock('@shopgate/engage/components', () => {
+  const { ViewContext } = jest.requireActual('@shopgate/engage/components/View/context');
+  return {
+    ViewContext,
+    InfiniteContainer: () => null,
+    Grid: () => null,
+  };
+});
+
+jest.mock('./components/Iterator', () =>
+  function Iterator() { return null; });
+
+jest.mock('@shopgate/engage/product', () => ({
+  ProductListTypeProvider: ({ children }) => children,
+  ProductListEntryProvider: ({ children }) => children,
+}));
+
+describe('<ProductGrid />', () => {
+  it('should render with the InfiniteContainer', () => {
+    const wrapper = mount((
+      <ProductGrid products={[]} />
+    ));
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('InfiniteContainer').exists()).toBe(true);
+    expect(wrapper.find('Layout').exists()).toBe(false);
+  });
+
+  it('should render the original layout', () => {
+    const wrapper = mount((
+      <ProductGrid infiniteLoad={false} products={[]} />
+    ));
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('InfiniteContainer').exists()).toBe(false);
+    expect(wrapper.find('Layout').exists()).toBe(true);
+  });
+});

--- a/libraries/engage/product/components/index.js
+++ b/libraries/engage/product/components/index.js
@@ -14,6 +14,7 @@ export { default as ProductBadges } from './ProductBadges';
 export { default as ProductCard } from './ProductCard';
 export { default as ProductCharacteristics } from './ProductCharacteristics';
 export { default as ProductDiscountBadge } from './ProductDiscountBadge';
+export { default as ProductGrid } from './ProductGrid';
 export { default as ProductGridPrice } from './ProductGridPrice';
 export { default as ProductImage } from './ProductImage';
 export { default as ProductList } from './ProductList';

--- a/libraries/engage/push-opt-in/subscriptions/optInTrigger.spec.js
+++ b/libraries/engage/push-opt-in/subscriptions/optInTrigger.spec.js
@@ -90,6 +90,8 @@ jest.mock('@shopgate/pwa-core/commands/appPermissions', () => {
   };
 });
 
+jest.mock('@shopgate/engage/product');
+
 jest.mock('@shopgate/engage/core/helpers', () => ({
   appSupportsPushOptIn: jest.fn().mockReturnValue(true),
   logger: {
@@ -99,6 +101,7 @@ jest.mock('@shopgate/engage/core/helpers', () => ({
   hasSGJavaScriptBridge: jest.fn(() => true),
   hasWebBridge: jest.fn(() => false),
   createMockedPermissions: jest.fn(() => 'mockedPermissions'),
+  useScrollContainer: jest.fn(() => true),
 }));
 
 describe('Push OptIn Subscriptions', () => {

--- a/libraries/ui-shared/Sheet/__snapshots__/spec.jsx.snap
+++ b/libraries/ui-shared/Sheet/__snapshots__/spec.jsx.snap
@@ -202,18 +202,22 @@ exports[`<Sheet /> should open 1`] = `
           Object {
             "appear": Object {
               "opacity": 0.2,
+              "pointerEvents": "auto",
             },
             "base": Object {
               "background": "#000",
               "opacity": 0,
+              "pointerEvents": "auto",
               "transition": "opacity 200ms ease-out",
               "zIndex": 4,
             },
             "enter": Object {
               "opacity": 0.2,
+              "pointerEvents": "auto",
             },
             "leave": Object {
               "opacity": 0,
+              "pointerEvents": "none",
             },
           }
         }
@@ -227,12 +231,14 @@ exports[`<Sheet /> should open 1`] = `
               childrenAppearStyle={
                 Object {
                   "opacity": 0.2,
+                  "pointerEvents": "auto",
                 }
               }
               childrenBaseStyle={
                 Object {
                   "background": "#000",
                   "opacity": 0,
+                  "pointerEvents": "auto",
                   "transition": "opacity 200ms ease-out",
                   "zIndex": 4,
                 }
@@ -240,24 +246,28 @@ exports[`<Sheet /> should open 1`] = `
               childrenEnterStyle={
                 Object {
                   "opacity": 0.2,
+                  "pointerEvents": "auto",
                 }
               }
               childrenLeaveStyle={
                 Object {
                   "opacity": 0,
+                  "pointerEvents": "none",
                 }
               }
-              key=".$.0"
+              key=".$.$backdrop"
             >
               <div
                 aria-hidden={true}
                 className="css-30873t  common__backdrop"
                 data-test-id="Backdrop"
+                key="backdrop"
                 onClick={[Function]}
                 style={
                   Object {
                     "background": "#000",
                     "opacity": 0,
+                    "pointerEvents": "auto",
                     "transition": "opacity 200ms ease-out",
                     "zIndex": 4,
                   }
@@ -637,18 +647,22 @@ exports[`<Sheet /> should trigger onClose callback and close the Sheet 1`] = `
           Object {
             "appear": Object {
               "opacity": 0.2,
+              "pointerEvents": "auto",
             },
             "base": Object {
               "background": "#000",
               "opacity": 0,
+              "pointerEvents": "auto",
               "transition": "opacity 200ms ease-out",
               "zIndex": 4,
             },
             "enter": Object {
               "opacity": 0.2,
+              "pointerEvents": "auto",
             },
             "leave": Object {
               "opacity": 0,
+              "pointerEvents": "none",
             },
           }
         }
@@ -662,12 +676,14 @@ exports[`<Sheet /> should trigger onClose callback and close the Sheet 1`] = `
               childrenAppearStyle={
                 Object {
                   "opacity": 0.2,
+                  "pointerEvents": "auto",
                 }
               }
               childrenBaseStyle={
                 Object {
                   "background": "#000",
                   "opacity": 0,
+                  "pointerEvents": "auto",
                   "transition": "opacity 200ms ease-out",
                   "zIndex": 4,
                 }
@@ -675,24 +691,28 @@ exports[`<Sheet /> should trigger onClose callback and close the Sheet 1`] = `
               childrenEnterStyle={
                 Object {
                   "opacity": 0.2,
+                  "pointerEvents": "auto",
                 }
               }
               childrenLeaveStyle={
                 Object {
                   "opacity": 0,
+                  "pointerEvents": "none",
                 }
               }
-              key=".$.0"
+              key=".$.$backdrop"
             >
               <div
                 aria-hidden={true}
                 className="css-30873t  common__backdrop"
                 data-test-id="Backdrop"
+                key="backdrop"
                 onClick={[Function]}
                 style={
                   Object {
                     "background": "#000",
                     "opacity": 0,
+                    "pointerEvents": "auto",
                     "transition": "opacity 200ms ease-out",
                     "zIndex": 4,
                   }

--- a/themes/theme-gmd/components/ProductGrid/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/components/ProductGrid/__snapshots__/spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`<ProductGrid /> should render the original layout 1`] = `
   flags={null}
   handleGetProducts={[Function]}
   infiniteLoad={false}
+  meta={null}
   products={Array []}
   requestHash={null}
   scope={null}
@@ -24,6 +25,7 @@ exports[`<ProductGrid /> should render the original layout 1`] = `
         data-test-id="productGrid"
       >
         <ProductListTypeProvider
+          meta={null}
           subType={null}
           type="productGrid"
         />
@@ -38,6 +40,7 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
   flags={null}
   handleGetProducts={[Function]}
   infiniteLoad={true}
+  meta={null}
   products={Array []}
   requestHash={null}
   scope={null}
@@ -45,6 +48,7 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
 >
   <Consumer>
     <ProductListTypeProvider
+      meta={null}
       subType={null}
       type="productGrid"
     >

--- a/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemDetails/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemDetails/__snapshots__/spec.jsx.snap
@@ -4,6 +4,11 @@ exports[`<ItemDetails /> should render additional components with new services 1
 <Link
   className="css-sr2jsa theme__product-grid__item__item-details"
   href=""
+  state={
+    Object {
+      "title": "Foo",
+    }
+  }
   tabIndex={0}
 >
   <div>
@@ -72,6 +77,11 @@ exports[`<ItemDetails /> should render with minimal props 1`] = `
 <Link
   className="css-sr2jsa theme__product-grid__item__item-details"
   href=""
+  state={
+    Object {
+      "title": "Foo",
+    }
+  }
   tabIndex={0}
 >
   <div>

--- a/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemDetails/index.jsx
+++ b/themes/theme-gmd/components/ProductGrid/components/Item/components/ItemDetails/index.jsx
@@ -19,9 +19,14 @@ import * as styles from './style';
 
 /**
  * The item details component.
+ * @param {Object} props The component props.
+ * @param {Object} props.product The product.
+ * @param {Object} props.display The display object.
+ * @param {Object} [props.productListTypeMeta] Optional meta object with data from the product list
+ * type context.
  * @returns {JSX.Element}
  */
-const ItemDetails = ({ product, display }) => {
+const ItemDetails = ({ product, display, productListTypeMeta }) => {
   const {
     id: productId, name = null, stock = null, shortDescription = null,
   } = product;
@@ -37,6 +42,10 @@ const ItemDetails = ({ product, display }) => {
       className={`${styles.details} theme__product-grid__item__item-details`}
       tabIndex={0}
       href={getProductRoute(productId)}
+      state={{
+        title: product.name,
+        ...productListTypeMeta,
+      }}
     >
       <div>
         {/*
@@ -94,10 +103,12 @@ const ItemDetails = ({ product, display }) => {
 ItemDetails.propTypes = {
   product: PropTypes.shape().isRequired,
   display: PropTypes.shape(),
+  productListTypeMeta: PropTypes.shape(),
 };
 
 ItemDetails.defaultProps = {
   display: null,
+  productListTypeMeta: null,
 };
 
 export default ItemDetails;

--- a/themes/theme-gmd/components/ProductGrid/components/Item/index.jsx
+++ b/themes/theme-gmd/components/ProductGrid/components/Item/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { isBeta } from '@shopgate/engage/core';
 import { getProductRoute, FeaturedMedia, ProductBadges } from '@shopgate/engage/product';
 import { Link } from '@shopgate/engage/components';
+import { useProductListType } from '@shopgate/engage/product/hooks';
 import ItemImage from './components/ItemImage';
 import ItemDiscount from './components/ItemDiscount';
 import ItemFavoritesButton from './components/ItemFavoritesButton';
@@ -14,42 +15,50 @@ import styles, { itemDetails, itemImage, badgesPortal } from './style';
  * @param {Object} props The component props.
  * @return {JSX.Element}
  */
-const Item = ({ product, display }) => (
-  <div className={`${styles} theme__product-grid__item`}>
-    <Link
-      tag="a"
-      role="none"
-      href={getProductRoute(product.id)}
-      state={{ title: product.name }}
-      className={itemImage}
-    >
-      {isBeta() && product.featuredMedia
-        ? <FeaturedMedia
-          type={product.featuredMedia.type}
-          url={product.featuredMedia.url}
-        />
-        : <ItemImage
-          productId={product.id}
-          name={product.name}
-          imageUrl={product.featuredImageBaseUrl}
-        />
+const Item = ({ product, display }) => {
+  const { meta } = useProductListType();
+
+  return (
+    <div className={`${styles} theme__product-grid__item`}>
+      <Link
+        tag="a"
+        role="none"
+        href={getProductRoute(product.id)}
+        state={{
+          title: product.name,
+          ...meta,
+        }}
+        className={itemImage}
+      >
+        {isBeta() && product.featuredMedia
+          ? <FeaturedMedia
+            type={product.featuredMedia.type}
+            url={product.featuredMedia.url}
+          />
+          : <ItemImage
+            productId={product.id}
+            name={product.name}
+            imageUrl={product.featuredImageBaseUrl}
+          />
         }
-    </Link>
-    <ProductBadges location="productGrid" productId={product.id} className={badgesPortal}>
-      <ItemDiscount
-        productId={product.id}
-        discount={product.price.discount || null}
-      />
-    </ProductBadges>
-    <div className={itemDetails}>
-      <ItemDetails
-        product={product}
-        display={display}
-      />
-      <ItemFavoritesButton productId={product.id} />
+      </Link>
+      <ProductBadges location="productGrid" productId={product.id} className={badgesPortal}>
+        <ItemDiscount
+          productId={product.id}
+          discount={product.price.discount || null}
+        />
+      </ProductBadges>
+      <div className={itemDetails}>
+        <ItemDetails
+          product={product}
+          display={display}
+          productListTypeMeta={meta}
+        />
+        <ItemFavoritesButton productId={product.id} />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 Item.propTypes = {
   product: PropTypes.shape().isRequired,

--- a/themes/theme-gmd/components/ProductGrid/index.jsx
+++ b/themes/theme-gmd/components/ProductGrid/index.jsx
@@ -14,7 +14,23 @@ export const WIDGET_ID = '@shopgate/engage/product/ProductGrid';
 /**
  * The Product Grid component.
  * @param {Object} props The component props.
- * @returns {JSX}
+ * @param {Array} props.products The list of products to display.
+ * @param {string} props.scope Optional scope of the component. Will be used as subType property of
+ * the ProductListTypeContext and is intended as a description in which "context" the component is
+ * used.
+ * @param {Object} props.meta Optional metadata for the product list type context.
+ * @param {Object} props.flags The flags object.
+ * @param {boolean} props.flags.name Whether to display product names.
+ * @param {boolean} props.flags.price Whether to display product prices.
+ * @param {boolean} props.flags.reviews Whether to display rating stars.
+ * @param {boolean} props.infiniteLoad Whether the grid should support infinite loading.
+ * @param {Function} props.handleGetProducts Callback function that's invoked to load more products
+ * when infinite loading is enabled.
+ * @param {number} props.totalProductCount The total number of products. Needed when infinite
+ * loading is enabled.
+ * @param {string} props.requestHash The hash for the current request. Needed when infinite loading
+ * is enabled
+ * @returns {JSX.Element}
  */
 const ProductGrid = ({
   flags,
@@ -24,13 +40,14 @@ const ProductGrid = ({
   totalProductCount,
   requestHash,
   scope,
+  meta,
 }) => {
   const { columns = 2 } = useWidgetSettings(WIDGET_ID) || {};
 
   if (!infiniteLoad) {
     return (
       <Layout columns={columns}>
-        <ProductListTypeProvider type="productGrid" subType={scope}>
+        <ProductListTypeProvider type="productGrid" subType={scope} meta={meta}>
           {products.map(product => (
             <Iterator
               display={flags}
@@ -47,7 +64,7 @@ const ProductGrid = ({
   return (
     <ViewContext.Consumer>
       {({ getContentRef }) => (
-        <ProductListTypeProvider type="productGrid" subType={scope}>
+        <ProductListTypeProvider type="productGrid" subType={scope} meta={meta}>
           <InfiniteContainer
             containerRef={getContentRef()}
             wrapper={props => (
@@ -73,9 +90,14 @@ const ProductGrid = ({
 };
 
 ProductGrid.propTypes = {
-  flags: PropTypes.shape(),
+  flags: PropTypes.shape({
+    name: PropTypes.bool,
+    price: PropTypes.bool,
+    reviews: PropTypes.bool,
+  }),
   handleGetProducts: PropTypes.func,
   infiniteLoad: PropTypes.bool,
+  meta: PropTypes.shape(),
   products: PropTypes.arrayOf(PropTypes.shape()),
   requestHash: PropTypes.string,
   /**
@@ -95,6 +117,7 @@ ProductGrid.defaultProps = {
   requestHash: null,
   totalProductCount: null,
   scope: null,
+  meta: null,
 };
 
 export default ProductGrid;

--- a/themes/theme-gmd/extension-config.json
+++ b/themes/theme-gmd/extension-config.json
@@ -220,6 +220,15 @@
         "label": "If the Back-in-Stock feature is enabled / disabled."
       }
     },
+    "pdpImageSliderPaginationType": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": "bullets",
+      "params": {
+        "type": "text",
+        "label": "Pagination type for the image slider on the product detail page. Possible variants: bullets (a.k.a dynamic), fraction, progressbar"
+      }
+    },
     "theme": {
       "type": "admin",
       "destination": "frontend",

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -11,7 +11,10 @@ import {
   ProductImage,
   getProductImageSettings,
 } from '@shopgate/engage/product';
+import { appConfig } from '@shopgate/engage';
 import connect from './connector';
+
+const { pdpImageSliderPaginationType } = appConfig || {};
 
 /**
  * The product image slider component.
@@ -146,6 +149,7 @@ class ProductImageSlider extends Component {
     if (images && images.length > 1) {
       content = (
         <Swiper
+          paginationType={pdpImageSliderPaginationType}
           loop
           indicators
           onSlideChange={this.handleSlideChange}

--- a/themes/theme-gmd/pages/Product/components/Media/components/ProductMediaSlider/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/components/ProductMediaSlider/index.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { MediaSlider, MediaImage } from '@shopgate/engage/product';
+import { appConfig } from '@shopgate/engage';
 import connect from './connector';
+
+const { pdpImageSliderPaginationType } = appConfig || {};
 
 /**
  * The product media slider component.
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 const ProductMediaSlider = ({
   productId,
@@ -14,6 +17,7 @@ const ProductMediaSlider = ({
   className,
 }) => (
   <MediaSlider
+    paginationType={pdpImageSliderPaginationType}
     productId={productId}
     className={className}
     renderPlaceholder={(featuredMedia) => {

--- a/themes/theme-gmd/pages/Product/components/Media/index.jsx
+++ b/themes/theme-gmd/pages/Product/components/Media/index.jsx
@@ -28,7 +28,7 @@ const styles = {
 
 /**
  * The product media component.
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 const Media = ({ 'aria-hidden': ariaHidden, className }) => (
   <ProductContext.Consumer>

--- a/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
@@ -66,7 +66,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
             className="css-f7yea6"
           >
             <Swiper
-              className="css-sa13d4"
+              className="css-2ypihg"
               classNames={
                 Object {
                   "container": "css-sa13d4",
@@ -220,7 +220,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
             className="css-f7yea6"
           >
             <Swiper
-              className="css-sa13d4"
+              className="css-2ypihg"
               classNames={
                 Object {
                   "container": "css-sa13d4",

--- a/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/index.jsx
+++ b/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/index.jsx
@@ -4,14 +4,17 @@ import { useWidgetSettings } from '@shopgate/engage/core';
 import { getProductImageSettings } from '@shopgate/engage/product/helpers';
 import { Image, SurroundPortals, Swiper } from '@shopgate/engage/components';
 import { PRODUCT_GALLERY_IMAGES } from '@shopgate/engage/product';
+import { appConfig } from '@shopgate/engage';
 import { GALLERY_SLIDER_ZOOM } from '../../../../constants';
 import styles from './style';
 import connect from './connector';
 
+const { pdpImageSliderPaginationType } = appConfig || {};
+
 /**
  * The Product Gallery content component.
  * @param {Object} props The component props.
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const ProductGalleryImages = ({ initialSlide, images }) => {
   const { zoom = {} } = useWidgetSettings('@shopgate/engage/product/Gallery') || {};
@@ -25,6 +28,7 @@ const ProductGalleryImages = ({ initialSlide, images }) => {
   return (
     <div className={styles.container}>
       <Swiper
+        paginationType={pdpImageSliderPaginationType}
         classNames={styles.sliderStyles}
         className={styles.slider}
         initialSlide={initialSlide}
@@ -63,7 +67,7 @@ ProductGalleryImages.propTypes = {
 
 /**
  * @param {Object} props The component props.
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const Wrapper = props => (
   <SurroundPortals portalName={PRODUCT_GALLERY_IMAGES} portalProps={props}>

--- a/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/style.js
+++ b/themes/theme-gmd/pages/ProductGallery/components/Content/components/ImagesSlider/style.js
@@ -21,6 +21,8 @@ const container = css({
 
 const slider = css({
   height: '100%',
+  '--swiper-pagination-fraction-top-offset': 'calc(4px + var(--safe-area-inset-top))',
+  '--swiper-pagination-bottom': 'max(var(--safe-area-inset-bottom), 8px)',
 }).toString();
 
 const slide = css({

--- a/themes/theme-gmd/pages/ProductGallery/components/Content/components/MediaSlider/index.jsx
+++ b/themes/theme-gmd/pages/ProductGallery/components/Content/components/MediaSlider/index.jsx
@@ -3,9 +3,12 @@ import PropTypes from 'prop-types';
 import { useWidgetSettings } from '@shopgate/engage/core/hooks';
 import { getProductImageSettings } from '@shopgate/engage/product/helpers';
 import { Swiper, Image } from '@shopgate/engage/components';
+import { appConfig } from '@shopgate/engage';
 import { GALLERY_SLIDER_ZOOM } from '../../../../constants';
 import styles from './style';
 import connect from './connector';
+
+const { pdpImageSliderPaginationType } = appConfig || {};
 
 /**
  * The Product media gallery component.
@@ -24,6 +27,7 @@ const ProductGalleryMedia = ({ initialSlide, media }) => {
   return (
     <div className={styles.container}>
       <Swiper
+        paginationType={pdpImageSliderPaginationType}
         classNames={styles.sliderStyles}
         className={styles.slider}
         initialSlide={initialSlide}

--- a/themes/theme-gmd/pages/ProductGallery/components/Content/components/MediaSlider/style.js
+++ b/themes/theme-gmd/pages/ProductGallery/components/Content/components/MediaSlider/style.js
@@ -21,6 +21,8 @@ const container = css({
 
 const slider = css({
   height: '100%',
+  '--swiper-pagination-fraction-top-offset': 'calc(4px + var(--safe-area-inset-top))',
+  '--swiper-pagination-bottom': 'max(var(--safe-area-inset-bottom), 8px)',
 }).toString();
 
 const slide = css({

--- a/themes/theme-gmd/widgets/Liveshopping/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/widgets/Liveshopping/__snapshots__/spec.jsx.snap
@@ -29,6 +29,7 @@ exports[`<LiveshoppingWidget /> should render the widget with a slider for multi
       loop={true}
       maxIndicators={null}
       onSlideChange={null}
+      paginationType={null}
     >
       <SwiperSlide
         className={null}

--- a/themes/theme-gmd/widgets/NestedCategoryFilter/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-gmd/widgets/NestedCategoryFilter/__snapshots__/index.spec.jsx.snap
@@ -164,18 +164,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget for a category 
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -708,18 +712,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget for a category 
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -733,12 +741,14 @@ exports[`<NestedCategoryFilterWidget /> should render the widget for a category 
                               childrenAppearStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenBaseStyle={
                                 Object {
                                   "background": "#000",
                                   "opacity": 0,
+                                  "pointerEvents": "auto",
                                   "transition": "opacity 200ms ease-out",
                                   "zIndex": 4,
                                 }
@@ -746,24 +756,28 @@ exports[`<NestedCategoryFilterWidget /> should render the widget for a category 
                               childrenEnterStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenLeaveStyle={
                                 Object {
                                   "opacity": 0,
+                                  "pointerEvents": "none",
                                 }
                               }
-                              key=".$.0"
+                              key=".$.$backdrop"
                             >
                               <div
                                 aria-hidden={true}
                                 className="css-30873t  common__backdrop"
                                 data-test-id="Backdrop"
+                                key="backdrop"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "background": "#000",
                                     "opacity": 0,
+                                    "pointerEvents": "auto",
                                     "transition": "opacity 200ms ease-out",
                                     "zIndex": 4,
                                   }
@@ -1076,18 +1090,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -1229,18 +1247,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -1365,18 +1387,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -1941,18 +1967,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -1966,12 +1996,14 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenAppearStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenBaseStyle={
                                 Object {
                                   "background": "#000",
                                   "opacity": 0,
+                                  "pointerEvents": "auto",
                                   "transition": "opacity 200ms ease-out",
                                   "zIndex": 4,
                                 }
@@ -1979,24 +2011,28 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenEnterStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenLeaveStyle={
                                 Object {
                                   "opacity": 0,
+                                  "pointerEvents": "none",
                                 }
                               }
-                              key=".$.0"
+                              key=".$.$backdrop"
                             >
                               <div
                                 aria-hidden={true}
                                 className="css-30873t  common__backdrop"
                                 data-test-id="Backdrop"
+                                key="backdrop"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "background": "#000",
                                     "opacity": 0,
+                                    "pointerEvents": "auto",
                                     "transition": "opacity 200ms ease-out",
                                     "zIndex": 4,
                                   }
@@ -2136,18 +2172,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -2698,18 +2738,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -2723,12 +2767,14 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenAppearStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenBaseStyle={
                                 Object {
                                   "background": "#000",
                                   "opacity": 0,
+                                  "pointerEvents": "auto",
                                   "transition": "opacity 200ms ease-out",
                                   "zIndex": 4,
                                 }
@@ -2736,24 +2782,28 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenEnterStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenLeaveStyle={
                                 Object {
                                   "opacity": 0,
+                                  "pointerEvents": "none",
                                 }
                               }
-                              key=".$.0"
+                              key=".$.$backdrop"
                             >
                               <div
                                 aria-hidden={true}
                                 className="css-30873t  common__backdrop"
                                 data-test-id="Backdrop"
+                                key="backdrop"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "background": "#000",
                                     "opacity": 0,
+                                    "pointerEvents": "auto",
                                     "transition": "opacity 200ms ease-out",
                                     "zIndex": 4,
                                   }
@@ -3143,18 +3193,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -3168,12 +3222,14 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenAppearStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenBaseStyle={
                                 Object {
                                   "background": "#000",
                                   "opacity": 0,
+                                  "pointerEvents": "auto",
                                   "transition": "opacity 200ms ease-out",
                                   "zIndex": 4,
                                 }
@@ -3181,24 +3237,28 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenEnterStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenLeaveStyle={
                                 Object {
                                   "opacity": 0,
+                                  "pointerEvents": "none",
                                 }
                               }
-                              key=".$.0"
+                              key=".$.$backdrop"
                             >
                               <div
                                 aria-hidden={true}
                                 className="css-30873t  common__backdrop"
                                 data-test-id="Backdrop"
+                                key="backdrop"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "background": "#000",
                                     "opacity": 0,
+                                    "pointerEvents": "auto",
                                     "transition": "opacity 200ms ease-out",
                                     "zIndex": 4,
                                   }
@@ -3487,18 +3547,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget without a headl
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -4025,18 +4089,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget without a headl
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -4050,12 +4118,14 @@ exports[`<NestedCategoryFilterWidget /> should render the widget without a headl
                               childrenAppearStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenBaseStyle={
                                 Object {
                                   "background": "#000",
                                   "opacity": 0,
+                                  "pointerEvents": "auto",
                                   "transition": "opacity 200ms ease-out",
                                   "zIndex": 4,
                                 }
@@ -4063,24 +4133,28 @@ exports[`<NestedCategoryFilterWidget /> should render the widget without a headl
                               childrenEnterStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenLeaveStyle={
                                 Object {
                                   "opacity": 0,
+                                  "pointerEvents": "none",
                                 }
                               }
-                              key=".$.0"
+                              key=".$.$backdrop"
                             >
                               <div
                                 aria-hidden={true}
                                 className="css-30873t  common__backdrop"
                                 data-test-id="Backdrop"
+                                key="backdrop"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "background": "#000",
                                     "opacity": 0,
+                                    "pointerEvents": "auto",
                                     "transition": "opacity 200ms ease-out",
                                     "zIndex": 4,
                                   }

--- a/themes/theme-gmd/widgets/NestedCategoryFilter/components/Picker/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-gmd/widgets/NestedCategoryFilter/components/Picker/__snapshots__/index.spec.jsx.snap
@@ -333,18 +333,22 @@ exports[`<NestedCategoryFilterPicker /> should accept user interaction when the 
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -358,12 +362,14 @@ exports[`<NestedCategoryFilterPicker /> should accept user interaction when the 
                         childrenAppearStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenBaseStyle={
                           Object {
                             "background": "#000",
                             "opacity": 0,
+                            "pointerEvents": "auto",
                             "transition": "opacity 200ms ease-out",
                             "zIndex": 4,
                           }
@@ -371,24 +377,28 @@ exports[`<NestedCategoryFilterPicker /> should accept user interaction when the 
                         childrenEnterStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenLeaveStyle={
                           Object {
                             "opacity": 0,
+                            "pointerEvents": "none",
                           }
                         }
-                        key=".$.0"
+                        key=".$.$backdrop"
                       >
                         <div
                           aria-hidden={true}
                           className="css-30873t  common__backdrop"
                           data-test-id="Backdrop"
+                          key="backdrop"
                           onClick={[Function]}
                           style={
                             Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             }
@@ -741,18 +751,22 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -766,12 +780,14 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                         childrenAppearStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenBaseStyle={
                           Object {
                             "background": "#000",
                             "opacity": 0,
+                            "pointerEvents": "auto",
                             "transition": "opacity 200ms ease-out",
                             "zIndex": 4,
                           }
@@ -779,24 +795,28 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                         childrenEnterStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenLeaveStyle={
                           Object {
                             "opacity": 0,
+                            "pointerEvents": "none",
                           }
                         }
-                        key=".$.0"
+                        key=".$.$backdrop"
                       >
                         <div
                           aria-hidden={true}
                           className="css-30873t  common__backdrop"
                           data-test-id="Backdrop"
+                          key="backdrop"
                           onClick={[Function]}
                           style={
                             Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             }
@@ -1189,18 +1209,22 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -1214,12 +1238,14 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                         childrenAppearStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenBaseStyle={
                           Object {
                             "background": "#000",
                             "opacity": 0,
+                            "pointerEvents": "auto",
                             "transition": "opacity 200ms ease-out",
                             "zIndex": 4,
                           }
@@ -1227,24 +1253,28 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                         childrenEnterStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenLeaveStyle={
                           Object {
                             "opacity": 0,
+                            "pointerEvents": "none",
                           }
                         }
-                        key=".$.0"
+                        key=".$.$backdrop"
                       >
                         <div
                           aria-hidden={true}
                           className="css-30873t  common__backdrop"
                           data-test-id="Backdrop"
+                          key="backdrop"
                           onClick={[Function]}
                           style={
                             Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             }
@@ -1598,18 +1628,22 @@ exports[`<NestedCategoryFilterPicker /> should highlight the preselected subcate
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -1623,12 +1657,14 @@ exports[`<NestedCategoryFilterPicker /> should highlight the preselected subcate
                         childrenAppearStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenBaseStyle={
                           Object {
                             "background": "#000",
                             "opacity": 0,
+                            "pointerEvents": "auto",
                             "transition": "opacity 200ms ease-out",
                             "zIndex": 4,
                           }
@@ -1636,24 +1672,28 @@ exports[`<NestedCategoryFilterPicker /> should highlight the preselected subcate
                         childrenEnterStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenLeaveStyle={
                           Object {
                             "opacity": 0,
+                            "pointerEvents": "none",
                           }
                         }
-                        key=".$.0"
+                        key=".$.$backdrop"
                       >
                         <div
                           aria-hidden={true}
                           className="css-30873t  common__backdrop"
                           data-test-id="Backdrop"
+                          key="backdrop"
                           onClick={[Function]}
                           style={
                             Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             }
@@ -1806,18 +1846,22 @@ exports[`<NestedCategoryFilterPicker /> should not accept user interaction when 
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -1973,18 +2017,22 @@ exports[`<NestedCategoryFilterPicker /> should render the picker with no initial
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -2135,18 +2183,22 @@ exports[`<NestedCategoryFilterPicker /> should render the picker without a label
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }

--- a/themes/theme-ios11/components/ProductGrid/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/components/ProductGrid/__snapshots__/spec.jsx.snap
@@ -5,6 +5,7 @@ exports[`<ProductGrid /> should render the original layout 1`] = `
   flags={null}
   handleGetProducts={[Function]}
   infiniteLoad={false}
+  meta={null}
   products={Array []}
   requestHash={null}
   scope={null}
@@ -24,6 +25,7 @@ exports[`<ProductGrid /> should render the original layout 1`] = `
         data-test-id="productGrid"
       >
         <ProductListTypeProvider
+          meta={null}
           subType={null}
           type="productGrid"
         />
@@ -38,6 +40,7 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
   flags={null}
   handleGetProducts={[Function]}
   infiniteLoad={true}
+  meta={null}
   products={Array []}
   requestHash={null}
   scope={null}
@@ -45,6 +48,7 @@ exports[`<ProductGrid /> should render with the InfiniteContainer 1`] = `
 >
   <Consumer>
     <ProductListTypeProvider
+      meta={null}
       subType={null}
       type="productGrid"
     >

--- a/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemDetails/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemDetails/__snapshots__/spec.jsx.snap
@@ -4,6 +4,11 @@ exports[`<ItemDetails /> should render additional components with new services 1
 <Link
   className="css-t5ln4b theme__product-grid__item__item-details"
   href="link-to-product/1234"
+  state={
+    Object {
+      "title": "Foo",
+    }
+  }
   tabIndex={0}
 >
   <Swatches
@@ -55,6 +60,11 @@ exports[`<ItemDetails /> should render with minimal props 1`] = `
 <Link
   className="css-t5ln4b theme__product-grid__item__item-details"
   href="link-to-product/1234"
+  state={
+    Object {
+      "title": "Foo",
+    }
+  }
   tabIndex={0}
 >
   <Swatches

--- a/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemDetails/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/components/Item/components/ItemDetails/index.jsx
@@ -20,9 +20,10 @@ import * as styles from './style';
  * @param {Object} props The component props.
  * @param {Object} props.product The product.
  * @param {Object} props.display The display object.
+ * @param {Object} [props.productListTypeMeta] Optional meta object with data from the product list
  * @returns {JSX.Element}
  */
-const ItemDetails = ({ product, display }) => {
+const ItemDetails = ({ product, display, productListTypeMeta }) => {
   const { id: productId, name = null, stock = null } = product;
 
   const hasNewServices = useMemo(() => checkHasNewServices(), []);
@@ -36,6 +37,10 @@ const ItemDetails = ({ product, display }) => {
       className={`${styles.details} theme__product-grid__item__item-details`}
       tabIndex={0}
       href={getProductRoute(productId)}
+      state={{
+        title: product.name,
+        ...productListTypeMeta,
+      }}
     >
       {/*
         This feature is currently in BETA testing.
@@ -82,10 +87,12 @@ const ItemDetails = ({ product, display }) => {
 ItemDetails.propTypes = {
   product: PropTypes.shape().isRequired,
   display: PropTypes.shape(),
+  productListTypeMeta: PropTypes.shape(),
 };
 
 ItemDetails.defaultProps = {
   display: null,
+  productListTypeMeta: null,
 };
 
 export default ItemDetails;

--- a/themes/theme-ios11/components/ProductGrid/components/Item/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/components/Item/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { isBeta } from '@shopgate/engage/core';
 import { getProductRoute, FeaturedMedia, ProductBadges } from '@shopgate/engage/product';
 import { Link } from '@shopgate/engage/components';
+import { useProductListType } from '@shopgate/engage/product/hooks';
 import ItemImage from './components/ItemImage';
 import ItemDiscount from './components/ItemDiscount';
 import ItemFavoritesButton from './components/ItemFavoritesButton';
@@ -16,46 +17,48 @@ import styles, { itemDetails } from './style';
  * @param {Object} props.display The display object.
  * @return {JSX.Element}
  */
-const Item = ({ product, display }) => (
-  <div className={`${styles} theme__product-grid__item`}>
-    <Link
-      role="none"
-      href={getProductRoute(product.id)}
-      state={{ title: product.name }}
-    >
-      {isBeta() && product.featuredMedia
-        ? <FeaturedMedia
-          type={product.featuredMedia.type}
-          url={product.featuredMedia.url}
-        />
-        : <ItemImage
-          productId={product.id}
-          name={product.name}
-          imageUrl={product.featuredImageBaseUrl}
-        />
-    }
-    </Link>
-    <ProductBadges location="productGrid" productId={product.id}>
-      <ItemDiscount
-        productId={product.id}
-        discount={product.price.discount || null}
-      />
-    </ProductBadges>
-    <div className={itemDetails}>
+const Item = ({ product, display }) => {
+  const { meta } = useProductListType();
+
+  return (
+    <div className={`${styles} theme__product-grid__item`}>
       <Link
-        tabIndex={0}
+        role="none"
         href={getProductRoute(product.id)}
-        state={{ title: product.name }}
+        state={{
+          title: product.name,
+          ...meta,
+        }}
       >
+        {isBeta() && product.featuredMedia
+          ? <FeaturedMedia
+            type={product.featuredMedia.type}
+            url={product.featuredMedia.url}
+          />
+          : <ItemImage
+            productId={product.id}
+            name={product.name}
+            imageUrl={product.featuredImageBaseUrl}
+          />
+    }
+      </Link>
+      <ProductBadges location="productGrid" productId={product.id}>
+        <ItemDiscount
+          productId={product.id}
+          discount={product.price.discount || null}
+        />
+      </ProductBadges>
+      <div className={itemDetails}>
         <ItemDetails
           product={product}
           display={display}
+          productListTypeMeta={meta}
         />
-      </Link>
-      <ItemFavoritesButton productId={product.id} />
+        <ItemFavoritesButton productId={product.id} />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 Item.propTypes = {
   product: PropTypes.shape().isRequired,

--- a/themes/theme-ios11/components/ProductGrid/index.jsx
+++ b/themes/theme-ios11/components/ProductGrid/index.jsx
@@ -14,7 +14,23 @@ export const WIDGET_ID = '@shopgate/engage/product/ProductGrid';
 /**
  * The Product Grid component.
  * @param {Object} props The component props.
- * @returns {JSX}
+ * @param {Array} props.products The list of products to display.
+ * @param {string} props.scope Optional scope of the component. Will be used as subType property of
+ * the ProductListTypeContext and is intended as a description in which "context" the component is
+ * used.
+ * @param {Object} props.meta Optional metadata for the product list type context.
+ * @param {Object} props.flags The flags object.
+ * @param {boolean} props.flags.name Whether to display product names.
+ * @param {boolean} props.flags.price Whether to display product prices.
+ * @param {boolean} props.flags.reviews Whether to display rating stars.
+ * @param {boolean} props.infiniteLoad Whether the grid should support infinite loading.
+ * @param {Function} props.handleGetProducts Callback function that's invoked to load more products
+ * when infinite loading is enabled.
+ * @param {number} props.totalProductCount The total number of products. Needed when infinite
+ * loading is enabled.
+ * @param {string} props.requestHash The hash for the current request. Needed when infinite loading
+ * is enabled
+ * @returns {JSX.Element}
  */
 const ProductGrid = ({
   flags,
@@ -24,13 +40,14 @@ const ProductGrid = ({
   totalProductCount,
   requestHash,
   scope,
+  meta,
 }) => {
   const { columns = 2 } = useWidgetSettings(WIDGET_ID) || {};
 
   if (!infiniteLoad) {
     return (
       <Layout columns={columns}>
-        <ProductListTypeProvider type="productGrid" subType={scope}>
+        <ProductListTypeProvider type="productGrid" subType={scope} meta={meta}>
           {products.map(product => (
             <Iterator
               display={flags}
@@ -47,7 +64,7 @@ const ProductGrid = ({
   return (
     <ViewContext.Consumer>
       {({ getContentRef }) => (
-        <ProductListTypeProvider type="productGrid" subType={scope}>
+        <ProductListTypeProvider type="productGrid" subType={scope} meta={meta}>
           <InfiniteContainer
             containerRef={getContentRef()}
             wrapper={props => (
@@ -73,9 +90,14 @@ const ProductGrid = ({
 };
 
 ProductGrid.propTypes = {
-  flags: PropTypes.shape(),
+  flags: PropTypes.shape({
+    name: PropTypes.bool,
+    price: PropTypes.bool,
+    reviews: PropTypes.bool,
+  }),
   handleGetProducts: PropTypes.func,
   infiniteLoad: PropTypes.bool,
+  meta: PropTypes.shape(),
   products: PropTypes.arrayOf(PropTypes.shape()),
   requestHash: PropTypes.string,
   /**
@@ -95,6 +117,7 @@ ProductGrid.defaultProps = {
   requestHash: null,
   totalProductCount: null,
   scope: null,
+  meta: null,
 };
 
 export default ProductGrid;

--- a/themes/theme-ios11/extension-config.json
+++ b/themes/theme-ios11/extension-config.json
@@ -211,6 +211,15 @@
         "label": "If the Back-in-Stock feature is enabled / disabled."
       }
     },
+    "pdpImageSliderPaginationType": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": "bullets",
+      "params": {
+        "type": "text",
+        "label": "Pagination type for the image slider on the product detail page. Possible variants: bullets (a.k.a dynamic), fraction, progressbar"
+      }
+    },
     "theme": {
       "type": "admin",
       "destination": "frontend",

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductImageSlider/index.jsx
@@ -11,7 +11,10 @@ import {
   ProductImage,
   getProductImageSettings,
 } from '@shopgate/engage/product';
+import { appConfig } from '@shopgate/engage';
 import connect from './connector';
+
+const { pdpImageSliderPaginationType } = appConfig || {};
 
 /**
  * The product image slider component.
@@ -143,6 +146,7 @@ class ProductImageSlider extends Component {
     if (images && images.length > 1) {
       content = (
         <Swiper
+          paginationType={pdpImageSliderPaginationType}
           loop
           indicators
           onSlideChange={this.handleSlideChange}

--- a/themes/theme-ios11/pages/Product/components/Media/components/ProductMediaSlider/index.jsx
+++ b/themes/theme-ios11/pages/Product/components/Media/components/ProductMediaSlider/index.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { MediaSlider, MediaImage } from '@shopgate/engage/product';
+import { appConfig } from '@shopgate/engage';
 import connect from './connector';
+
+const { pdpImageSliderPaginationType } = appConfig || {};
 
 /**
  * The product media slider component.
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 const ProductMediaSlider = ({
   productId,
@@ -14,6 +17,7 @@ const ProductMediaSlider = ({
   className,
 }) => (
   <MediaSlider
+    paginationType={pdpImageSliderPaginationType}
     productId={productId}
     className={className}
     renderPlaceholder={(featuredMedia) => {

--- a/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/__snapshots__/spec.jsx.snap
@@ -66,7 +66,7 @@ exports[`<ProductGallery.Content> page should pass initialSlide prop 1`] = `
             className="css-f7yea6"
           >
             <Swiper
-              className="css-sa13d4"
+              className="css-2ypihg"
               classNames={
                 Object {
                   "container": "css-sa13d4",
@@ -220,7 +220,7 @@ exports[`<ProductGallery.Content> page should render Swiper with images 1`] = `
             className="css-f7yea6"
           >
             <Swiper
-              className="css-sa13d4"
+              className="css-2ypihg"
               classNames={
                 Object {
                   "container": "css-sa13d4",

--- a/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/index.jsx
+++ b/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/index.jsx
@@ -4,14 +4,17 @@ import { useWidgetSettings } from '@shopgate/engage/core';
 import { getProductImageSettings } from '@shopgate/engage/product/helpers';
 import { Image, SurroundPortals, Swiper } from '@shopgate/engage/components';
 import { PRODUCT_GALLERY_IMAGES } from '@shopgate/engage/product';
+import { appConfig } from '@shopgate/engage';
 import { GALLERY_SLIDER_ZOOM } from '../../../../constants';
 import styles from './style';
 import connect from './connector';
 
+const { pdpImageSliderPaginationType } = appConfig || {};
+
 /**
  * The Product Gallery content component.
  * @param {Object} props The component props.
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const ProductGalleryImages = ({ initialSlide, images }) => {
   const { zoom = {} } = useWidgetSettings('@shopgate/engage/product/Gallery') || {};
@@ -25,6 +28,7 @@ const ProductGalleryImages = ({ initialSlide, images }) => {
   return (
     <div className={styles.container}>
       <Swiper
+        paginationType={pdpImageSliderPaginationType}
         classNames={styles.sliderStyles}
         className={styles.slider}
         initialSlide={initialSlide}
@@ -63,7 +67,7 @@ ProductGalleryImages.propTypes = {
 
 /**
  * @param {Object} props The component props.
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const Wrapper = props => (
   <SurroundPortals portalName={PRODUCT_GALLERY_IMAGES} portalProps={props}>

--- a/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/style.js
+++ b/themes/theme-ios11/pages/ProductGallery/components/Content/components/ImagesSlider/style.js
@@ -21,6 +21,8 @@ const container = css({
 
 const slider = css({
   height: '100%',
+  '--swiper-pagination-fraction-top-offset': 'calc(4px + var(--safe-area-inset-top))',
+  '--swiper-pagination-bottom': 'max(var(--safe-area-inset-bottom), 8px)',
 }).toString();
 
 const slide = css({

--- a/themes/theme-ios11/pages/ProductGallery/components/Content/components/MediaSlider/index.jsx
+++ b/themes/theme-ios11/pages/ProductGallery/components/Content/components/MediaSlider/index.jsx
@@ -3,9 +3,12 @@ import PropTypes from 'prop-types';
 import { useWidgetSettings } from '@shopgate/engage/core/hooks';
 import { getProductImageSettings } from '@shopgate/engage/product/helpers';
 import { Swiper, Image } from '@shopgate/engage/components';
+import { appConfig } from '@shopgate/engage';
 import { GALLERY_SLIDER_ZOOM } from '../../../../constants';
 import styles from './style';
 import connect from './connector';
+
+const { pdpImageSliderPaginationType } = appConfig || {};
 
 /**
  * The Product media gallery component.
@@ -24,6 +27,7 @@ const ProductGalleryMedia = ({ initialSlide, media }) => {
   return (
     <div className={styles.container}>
       <Swiper
+        paginationType={pdpImageSliderPaginationType}
         classNames={styles.sliderStyles}
         className={styles.slider}
         initialSlide={initialSlide}

--- a/themes/theme-ios11/pages/ProductGallery/components/Content/components/MediaSlider/style.js
+++ b/themes/theme-ios11/pages/ProductGallery/components/Content/components/MediaSlider/style.js
@@ -21,6 +21,8 @@ const container = css({
 
 const slider = css({
   height: '100%',
+  '--swiper-pagination-fraction-top-offset': 'calc(4px + var(--safe-area-inset-top))',
+  '--swiper-pagination-bottom': 'max(var(--safe-area-inset-bottom), 8px)',
 }).toString();
 
 const slide = css({

--- a/themes/theme-ios11/widgets/Liveshopping/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/widgets/Liveshopping/__snapshots__/spec.jsx.snap
@@ -29,6 +29,7 @@ exports[`<LiveshoppingWidget /> should render the widget with a slider for multi
       loop={true}
       maxIndicators={null}
       onSlideChange={null}
+      paginationType={null}
     >
       <SwiperSlide
         className={null}

--- a/themes/theme-ios11/widgets/NestedCategoryFilter/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/widgets/NestedCategoryFilter/__snapshots__/index.spec.jsx.snap
@@ -172,18 +172,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget for a category 
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -724,18 +728,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget for a category 
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -749,12 +757,14 @@ exports[`<NestedCategoryFilterWidget /> should render the widget for a category 
                               childrenAppearStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenBaseStyle={
                                 Object {
                                   "background": "#000",
                                   "opacity": 0,
+                                  "pointerEvents": "auto",
                                   "transition": "opacity 200ms ease-out",
                                   "zIndex": 4,
                                 }
@@ -762,24 +772,28 @@ exports[`<NestedCategoryFilterWidget /> should render the widget for a category 
                               childrenEnterStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenLeaveStyle={
                                 Object {
                                   "opacity": 0,
+                                  "pointerEvents": "none",
                                 }
                               }
-                              key=".$.0"
+                              key=".$.$backdrop"
                             >
                               <div
                                 aria-hidden={true}
                                 className="css-30873t  common__backdrop"
                                 data-test-id="Backdrop"
+                                key="backdrop"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "background": "#000",
                                     "opacity": 0,
+                                    "pointerEvents": "auto",
                                     "transition": "opacity 200ms ease-out",
                                     "zIndex": 4,
                                   }
@@ -1100,18 +1114,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -1253,18 +1271,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -1389,18 +1411,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -1973,18 +1999,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -1998,12 +2028,14 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenAppearStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenBaseStyle={
                                 Object {
                                   "background": "#000",
                                   "opacity": 0,
+                                  "pointerEvents": "auto",
                                   "transition": "opacity 200ms ease-out",
                                   "zIndex": 4,
                                 }
@@ -2011,24 +2043,28 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenEnterStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenLeaveStyle={
                                 Object {
                                   "opacity": 0,
+                                  "pointerEvents": "none",
                                 }
                               }
-                              key=".$.0"
+                              key=".$.$backdrop"
                             >
                               <div
                                 aria-hidden={true}
                                 className="css-30873t  common__backdrop"
                                 data-test-id="Backdrop"
+                                key="backdrop"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "background": "#000",
                                     "opacity": 0,
+                                    "pointerEvents": "auto",
                                     "transition": "opacity 200ms ease-out",
                                     "zIndex": 4,
                                   }
@@ -2168,18 +2204,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -2738,18 +2778,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -2763,12 +2807,14 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenAppearStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenBaseStyle={
                                 Object {
                                   "background": "#000",
                                   "opacity": 0,
+                                  "pointerEvents": "auto",
                                   "transition": "opacity 200ms ease-out",
                                   "zIndex": 4,
                                 }
@@ -2776,24 +2822,28 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenEnterStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenLeaveStyle={
                                 Object {
                                   "opacity": 0,
+                                  "pointerEvents": "none",
                                 }
                               }
-                              key=".$.0"
+                              key=".$.$backdrop"
                             >
                               <div
                                 aria-hidden={true}
                                 className="css-30873t  common__backdrop"
                                 data-test-id="Backdrop"
+                                key="backdrop"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "background": "#000",
                                     "opacity": 0,
+                                    "pointerEvents": "auto",
                                     "transition": "opacity 200ms ease-out",
                                     "zIndex": 4,
                                   }
@@ -3183,18 +3233,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -3208,12 +3262,14 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenAppearStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenBaseStyle={
                                 Object {
                                   "background": "#000",
                                   "opacity": 0,
+                                  "pointerEvents": "auto",
                                   "transition": "opacity 200ms ease-out",
                                   "zIndex": 4,
                                 }
@@ -3221,24 +3277,28 @@ exports[`<NestedCategoryFilterWidget /> should render the widget with a persiste
                               childrenEnterStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenLeaveStyle={
                                 Object {
                                   "opacity": 0,
+                                  "pointerEvents": "none",
                                 }
                               }
-                              key=".$.0"
+                              key=".$.$backdrop"
                             >
                               <div
                                 aria-hidden={true}
                                 className="css-30873t  common__backdrop"
                                 data-test-id="Backdrop"
+                                key="backdrop"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "background": "#000",
                                     "opacity": 0,
+                                    "pointerEvents": "auto",
                                     "transition": "opacity 200ms ease-out",
                                     "zIndex": 4,
                                   }
@@ -3529,18 +3589,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget without a headl
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -4069,18 +4133,22 @@ exports[`<NestedCategoryFilterWidget /> should render the widget without a headl
                           Object {
                             "appear": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "base": Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             },
                             "enter": Object {
                               "opacity": 0.2,
+                              "pointerEvents": "auto",
                             },
                             "leave": Object {
                               "opacity": 0,
+                              "pointerEvents": "none",
                             },
                           }
                         }
@@ -4094,12 +4162,14 @@ exports[`<NestedCategoryFilterWidget /> should render the widget without a headl
                               childrenAppearStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenBaseStyle={
                                 Object {
                                   "background": "#000",
                                   "opacity": 0,
+                                  "pointerEvents": "auto",
                                   "transition": "opacity 200ms ease-out",
                                   "zIndex": 4,
                                 }
@@ -4107,24 +4177,28 @@ exports[`<NestedCategoryFilterWidget /> should render the widget without a headl
                               childrenEnterStyle={
                                 Object {
                                   "opacity": 0.2,
+                                  "pointerEvents": "auto",
                                 }
                               }
                               childrenLeaveStyle={
                                 Object {
                                   "opacity": 0,
+                                  "pointerEvents": "none",
                                 }
                               }
-                              key=".$.0"
+                              key=".$.$backdrop"
                             >
                               <div
                                 aria-hidden={true}
                                 className="css-30873t  common__backdrop"
                                 data-test-id="Backdrop"
+                                key="backdrop"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "background": "#000",
                                     "opacity": 0,
+                                    "pointerEvents": "auto",
                                     "transition": "opacity 200ms ease-out",
                                     "zIndex": 4,
                                   }

--- a/themes/theme-ios11/widgets/NestedCategoryFilter/components/Picker/__snapshots__/index.spec.jsx.snap
+++ b/themes/theme-ios11/widgets/NestedCategoryFilter/components/Picker/__snapshots__/index.spec.jsx.snap
@@ -333,18 +333,22 @@ exports[`<NestedCategoryFilterPicker /> should accept user interaction when the 
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -358,12 +362,14 @@ exports[`<NestedCategoryFilterPicker /> should accept user interaction when the 
                         childrenAppearStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenBaseStyle={
                           Object {
                             "background": "#000",
                             "opacity": 0,
+                            "pointerEvents": "auto",
                             "transition": "opacity 200ms ease-out",
                             "zIndex": 4,
                           }
@@ -371,24 +377,28 @@ exports[`<NestedCategoryFilterPicker /> should accept user interaction when the 
                         childrenEnterStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenLeaveStyle={
                           Object {
                             "opacity": 0,
+                            "pointerEvents": "none",
                           }
                         }
-                        key=".$.0"
+                        key=".$.$backdrop"
                       >
                         <div
                           aria-hidden={true}
                           className="css-30873t  common__backdrop"
                           data-test-id="Backdrop"
+                          key="backdrop"
                           onClick={[Function]}
                           style={
                             Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             }
@@ -741,18 +751,22 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -766,12 +780,14 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                         childrenAppearStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenBaseStyle={
                           Object {
                             "background": "#000",
                             "opacity": 0,
+                            "pointerEvents": "auto",
                             "transition": "opacity 200ms ease-out",
                             "zIndex": 4,
                           }
@@ -779,24 +795,28 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                         childrenEnterStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenLeaveStyle={
                           Object {
                             "opacity": 0,
+                            "pointerEvents": "none",
                           }
                         }
-                        key=".$.0"
+                        key=".$.$backdrop"
                       >
                         <div
                           aria-hidden={true}
                           className="css-30873t  common__backdrop"
                           data-test-id="Backdrop"
+                          key="backdrop"
                           onClick={[Function]}
                           style={
                             Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             }
@@ -1189,18 +1209,22 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -1214,12 +1238,14 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                         childrenAppearStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenBaseStyle={
                           Object {
                             "background": "#000",
                             "opacity": 0,
+                            "pointerEvents": "auto",
                             "transition": "opacity 200ms ease-out",
                             "zIndex": 4,
                           }
@@ -1227,24 +1253,28 @@ exports[`<NestedCategoryFilterPicker /> should handle user interaction as expect
                         childrenEnterStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenLeaveStyle={
                           Object {
                             "opacity": 0,
+                            "pointerEvents": "none",
                           }
                         }
-                        key=".$.0"
+                        key=".$.$backdrop"
                       >
                         <div
                           aria-hidden={true}
                           className="css-30873t  common__backdrop"
                           data-test-id="Backdrop"
+                          key="backdrop"
                           onClick={[Function]}
                           style={
                             Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             }
@@ -1598,18 +1628,22 @@ exports[`<NestedCategoryFilterPicker /> should highlight the preselected subcate
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -1623,12 +1657,14 @@ exports[`<NestedCategoryFilterPicker /> should highlight the preselected subcate
                         childrenAppearStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenBaseStyle={
                           Object {
                             "background": "#000",
                             "opacity": 0,
+                            "pointerEvents": "auto",
                             "transition": "opacity 200ms ease-out",
                             "zIndex": 4,
                           }
@@ -1636,24 +1672,28 @@ exports[`<NestedCategoryFilterPicker /> should highlight the preselected subcate
                         childrenEnterStyle={
                           Object {
                             "opacity": 0.2,
+                            "pointerEvents": "auto",
                           }
                         }
                         childrenLeaveStyle={
                           Object {
                             "opacity": 0,
+                            "pointerEvents": "none",
                           }
                         }
-                        key=".$.0"
+                        key=".$.$backdrop"
                       >
                         <div
                           aria-hidden={true}
                           className="css-30873t  common__backdrop"
                           data-test-id="Backdrop"
+                          key="backdrop"
                           onClick={[Function]}
                           style={
                             Object {
                               "background": "#000",
                               "opacity": 0,
+                              "pointerEvents": "auto",
                               "transition": "opacity 200ms ease-out",
                               "zIndex": 4,
                             }
@@ -1806,18 +1846,22 @@ exports[`<NestedCategoryFilterPicker /> should not accept user interaction when 
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -1973,18 +2017,22 @@ exports[`<NestedCategoryFilterPicker /> should render the picker with no initial
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }
@@ -2135,18 +2183,22 @@ exports[`<NestedCategoryFilterPicker /> should render the picker without a label
                     Object {
                       "appear": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "base": Object {
                         "background": "#000",
                         "opacity": 0,
+                        "pointerEvents": "auto",
                         "transition": "opacity 200ms ease-out",
                         "zIndex": 4,
                       },
                       "enter": Object {
                         "opacity": 0.2,
+                        "pointerEvents": "auto",
                       },
                       "leave": Object {
                         "opacity": 0,
+                        "pointerEvents": "none",
                       },
                     }
                   }


### PR DESCRIPTION
# Description
This pull request adds the `@shopgate/widgets/productListWidget` to the CMS 2.0 widgets.

Additionally it introduces the new `useWidgetProducts` hook that simplifies handling product requests and data selection for widget products.

It also adds a shared version of the `ProductGrid` component to `@shopgate/engage/product/components` that can be imported from extensions in the common way.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

