### PR TITLE
Curb 4489 user not logged in to shopify

### DIFF
--- a/libraries/webcheckout/actions/login.js
+++ b/libraries/webcheckout/actions/login.js
@@ -35,11 +35,13 @@ const webCheckoutLogin = (user, password) => (dispatch) => {
     .dispatch()
     .then((response) => {
       const {
-        headers: { location } = {},
+        headers: { location, Location } = {},
         statusCode,
       } = response;
 
-      if (statusCode === 302 && location && location.endsWith('/account')) {
+      const redirectLocation = location || Location
+
+      if (statusCode === 302 && redirectLocation && redirectLocation.endsWith('/account')) {
         dispatch(successShopifyLogin());
       } else {
         dispatch(errorShopifyLogin());

--- a/libraries/webcheckout/actions/login.js
+++ b/libraries/webcheckout/actions/login.js
@@ -23,6 +23,7 @@ const webCheckoutLogin = (user, password) => (dispatch) => {
   new HttpRequest(`${getShopifyUrl()}/account/login`)
     .setMethod('POST')
     .setTimeout(20000)
+    .setHeaders({ 'content-type': 'application/x-www-form-urlencoded'})
     .setPayload({
       // eslint-disable-next-line camelcase
       form_type: 'customer_login',


### PR DESCRIPTION
# Description

In some cases, probably depending on the underlying HTTP library used, we would send POST requests without a `Content-Type` header or with it defaulting to the wrong value to the Shopify login page. Shopify seems to have changed their behavior and rejects any content type other than `application/x-www-form-urlencoded`. This fix will set the header Shopify login requests.

## Type of change

Please add an "x" into the option that is relevant:

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.

## How to test it

Start a Shopify app in TestFlight, log in, open checkout or profile page. Without the fix you'll be logged out in the checkout or redirected to the login page when trying to access profile. With the fix you're logged in in the checkout or be shown the profile page of your account.
