### PR TITLE
Add support for updated products widget input

### DIFF
--- a/libraries/engage/page/helpers/index.d.ts
+++ b/libraries/engage/page/helpers/index.d.ts
@@ -1,0 +1,47 @@
+export type ProductsWidgetInputConfig = {
+  /**
+   * Source type for the product list
+   */
+  productSelectorType: 'searchTerm' | 'brand' | 'category' | 'manualItemNumbers' | 'productSelector';
+  /**
+   * A search term to filter products by
+   */
+  productsSearchTerm: string;
+  /**
+   * A brand to filter products by
+   */
+  productsBrand: string;
+  /**
+   * A category to filter products by
+   */
+  productsCategory: string;
+  /**
+   * Array of product item numbers (selected via manual input)
+   */
+  productsManualItemNumbers: string[];
+  /**
+   * Array of product item numbers (selected via product selector)
+   */
+  productsSelectorItemNumbers: string[];
+}
+
+export type GetProductSearchParamsFromProductsInputConfigReturnValue = {
+  /**
+   * The type of product search to perform.
+   */
+  productsSearchType: 'searchTerm' | 'brand' | 'category' | 'productIds';
+  /**
+   * The value to use for the product search. Can be a string or an array of strings (for product IDs).
+   */
+  productsSearchValue: string | string[];
+}
+
+/**
+ * Helper to extract relevant search parameters from the widget configuration of the "Products"
+ * input.
+ *
+ * The return value can be used to e.g. parametrize the useWidgetProducts hook.
+ */
+export declare function getProductSearchParamsFromProductsInputConfig(
+  products: ProductsWidgetInputConfig
+): GetProductSearchParamsFromProductsInputConfigReturnValue;

--- a/libraries/engage/page/helpers/index.js
+++ b/libraries/engage/page/helpers/index.js
@@ -1,0 +1,66 @@
+/* eslint-disable max-len */
+
+/**
+ * @typedef {import('./').ProductsWidgetInputConfig} ProductsWidgetInputConfig
+ */
+
+/**
+ * @typedef {import('./').GetProductSearchParamsFromProductsInputConfigReturnValue} GetProductSearchParamsFromProductsInputConfigReturnValue
+ */
+
+/* eslint-enable max-len */
+
+/**
+ * Helper to extract relevant search parameters from the widget configuration of the "Products"
+ * input.
+ * The return value can be used to e.g. parametrize the useWidgetProducts hook.
+ * @param {ProductsWidgetInputConfig} products Config object of the "Products" input.
+ * @returns {GetProductSearchParamsFromProductsInputConfigReturnValue}
+ */
+export const getProductSearchParamsFromProductsInputConfig = (products = {}) => {
+  const {
+    productSelectorType,
+    productsBrand,
+    productsCategory,
+    productsItemNumbers,
+    productsManualItemNumbers,
+    productsSelectorItemNumbers,
+    productsSearchTerm,
+  } = products || {};
+
+  let productsSearchType = productSelectorType;
+
+  /** @type {string|string[]} */
+  let productsSearchValue = '';
+
+  switch (productSelectorType) {
+    case 'brand':
+      productsSearchValue = productsBrand;
+      break;
+    case 'category':
+      productsSearchValue = productsCategory;
+      break;
+    // Kept for backward compatibility - was replaces by 'manualItemNumbers' and 'productSelector'
+    case 'itemNumbers':
+      productsSearchValue = productsItemNumbers.split(',').map(item => item.trim());
+      break;
+    case 'manualItemNumbers':
+      productsSearchValue = productsManualItemNumbers;
+      break;
+    case 'productSelector':
+      productsSearchValue = productsSelectorItemNumbers;
+      break;
+    case 'searchTerm':
+    default:
+      productsSearchValue = productsSearchTerm;
+  }
+
+  if (['itemNumbers', 'manualItemNumbers', 'productSelector'].includes(productSelectorType)) {
+    productsSearchType = 'productIds';
+  }
+
+  return {
+    productsSearchType,
+    productsSearchValue,
+  };
+};

--- a/libraries/engage/page/hooks/index.d.ts
+++ b/libraries/engage/page/hooks/index.d.ts
@@ -15,7 +15,7 @@ export type UseWidgetProductsOptions = {
   /**
    * The type of product search to perform.
    */
-  type: 'searchTerm' | 'itemNumbers' | 'brand' | 'category' | 'highlights';
+  type: 'searchTerm' | 'productIds' | 'brand' | 'category' | 'highlights';
   /**
    * The number of products to return per page.
    * @default 32

--- a/libraries/engage/page/hooks/index.js
+++ b/libraries/engage/page/hooks/index.js
@@ -31,7 +31,7 @@ const REQUEST_TYPE_MAPPING = {
   highlights: 1,
   searchTerm: 2,
   brand: 3,
-  itemNumbers: 4,
+  productIds: 4,
   category: 5,
 };
 

--- a/libraries/engage/page/selectors/index.js
+++ b/libraries/engage/page/selectors/index.js
@@ -125,7 +125,7 @@ export const makeGetWidgetsFromPage = ({
 
 /**
  * Creates a selector that generates a hash to select results for widget products.
- * @param {'searchTerm' | 'itemNumbers' | 'brand' | 'category' |'highlights'} type Type of the
+ * @param {'searchTerm' | 'productIds' | 'brand' | 'category' |'highlights'} type Type of the
  * request to make.
  * @param {Object} options Request options
  * @param {string} id Unique identifier to find the result in the state.
@@ -160,7 +160,7 @@ const makeGetWidgetProductsResultHash = (type, options, id) => {
             ...fulfillmentParams,
           };
           break;
-        case 'itemNumbers':
+        case 'productIds':
           hashParams = {
             id,
             productIds: value,
@@ -190,7 +190,7 @@ const makeGetWidgetProductsResultHash = (type, options, id) => {
 };
 
 /**
- * @param {'searchTerm' | 'itemNumbers' | 'brand' | 'category' |'highlights'} type Type of the
+ * @param {'searchTerm' | 'productIds' | 'brand' | 'category' |'highlights'} type Type of the
  * request to make.
  * @param {Object} options Request options
  * @param {string} id Unique identifier to find the result in the state.
@@ -208,7 +208,7 @@ const makeGetWidgetProductResultsByHash = (type, options, id) => {
 
 /**
  * Creates a selector that collects products for a widget.
- * @param {'searchTerm' | 'itemNumbers' | 'brand' | 'category' |'highlights'} type Type of the
+ * @param {'searchTerm' | 'productIds' | 'brand' | 'category' |'highlights'} type Type of the
  * request to make.
  * @param {Object} options Request options
  * @param {string} id Unique identifier to find the result in the state.
@@ -231,7 +231,7 @@ export const makeGetWidgetProducts = (type, options, id) => {
 
       // Since the getProducts pipeline does not support sorting when a product ID list is
       // provided, we need to sort the products manually here.
-      if (type === 'itemNumbers') {
+      if (type === 'productIds') {
         if (options.sort === SORT_PRICE_ASC) {
           result.products = result.products.sort(
             (p1, p2) => p1.price.unitPrice - p2.price.unitPrice

--- a/libraries/engage/page/widgets/ProductList/hooks.js
+++ b/libraries/engage/page/widgets/ProductList/hooks.js
@@ -1,23 +1,16 @@
 import { useMemo } from 'react';
 import { camelCase } from 'lodash';
 import { useWidget } from '@shopgate/engage/page/hooks';
+import { getProductSearchParamsFromProductsInputConfig } from '@shopgate/engage/page/helpers';
 
 /**
- * @typedef {Object} ProductListWidgetProducts
- * @property {"searchTerm" | "brand" | "category" | "manualItemNumbers" | "productSelector"
- * | "itemNumbers"} productSelectorType Source type for the product list.
- * @property {string} productsSearchTerm A search term to filter products by
- * @property {string} productsBrand A brand to filter products by
- * @property {string} productsCategory A category to filter products by
- * @property {string} productsItemNumbers A comma-separated list of item numbers to filter products
- * by
- * @property {string[]} productsManualItemNumbers Array of product item numbers (manual input)
- * @property {string[]} productsSelectorItemNumbers Array of product item numbers (product selector)
+ * @typedef {import('@shopgate/engage/page/helpers')
+ * .ProductsWidgetInputConfig} ProductsWidgetInputConfig
  */
 
 /**
  * @typedef {Object} ProductListWidgetConfig
- * @property {ProductListWidgetProducts} products The products configuration for the widget.
+ * @property {ProductsWidgetInputConfig} products The products configuration for the widget.
  * @property {number} productCount The number of products to display in the widget
  * @property {"relevance" | "PriceDesc" | "PriceAsc"} sort Sort order for the products
  * @property {boolean} loadMoreButton Whether to display a "Load more" button
@@ -49,52 +42,10 @@ export const useProductListWidget = () => {
     showRating = false,
   } = config;
 
-  const {
-    productSelectorType,
-    productsBrand,
-    productsCategory,
-    productsItemNumbers,
-    productsManualItemNumbers,
-    productsSelectorItemNumbers,
-    productsSearchTerm,
-  } = products;
-
-  const value = useMemo(() => {
-    switch (productSelectorType) {
-      case 'brand':
-        return productsBrand;
-      case 'category':
-        return productsCategory;
-      // Kept for backward compatibility - was replaces by 'manualItemNumbers' and 'productSelector'
-      case 'itemNumbers':
-        return productsItemNumbers.split(',').map(item => item.trim());
-      case 'manualItemNumbers':
-        return productsManualItemNumbers;
-      case 'productSelector':
-        return productsSelectorItemNumbers;
-      case 'searchTerm':
-      default:
-        return productsSearchTerm;
-    }
-  }, [
-    productSelectorType,
-    productsBrand,
-    productsCategory,
-    productsSearchTerm,
-    productsItemNumbers,
-    productsManualItemNumbers,
-    productsSelectorItemNumbers,
-  ]);
-
-  /** @type {"brand" | "category" | "productIds" | "searchTerm"} */
-  const productsSearchType = useMemo(() => {
-    // Map different input types that indicate arrays with item numbers to the same type
-    if (['itemNumbers', 'manualItemNumbers', 'productSelector'].includes(productSelectorType)) {
-      return 'productIds';
-    }
-
-    return productSelectorType;
-  }, [productSelectorType]);
+  const productSearchParams = useMemo(
+    () => getProductSearchParamsFromProductsInputConfig(products),
+    [products]
+  );
 
   const flags = useMemo(() => ({
     name: showName,
@@ -103,8 +54,7 @@ export const useProductListWidget = () => {
   }), [showName, showPrice, showRating]);
 
   return {
-    productsSearchType,
-    productsSearchValue: value,
+    ...productSearchParams,
     sort: camelCase(sort),
     productCount,
     showLoadMore: loadMoreButton,

--- a/libraries/engage/page/widgets/ProductList/hooks.js
+++ b/libraries/engage/page/widgets/ProductList/hooks.js
@@ -4,13 +4,15 @@ import { useWidget } from '@shopgate/engage/page/hooks';
 
 /**
  * @typedef {Object} ProductListWidgetProducts
- * @property {"searchTerm" | "brand" | "category" | "itemNumbers"} productSelectorType Source type
- * for the product list.
+ * @property {"searchTerm" | "brand" | "category" | "manualItemNumbers" | "productSelector"
+ * | "itemNumbers"} productSelectorType Source type for the product list.
  * @property {string} productsSearchTerm A search term to filter products by
  * @property {string} productsBrand A brand to filter products by
  * @property {string} productsCategory A category to filter products by
  * @property {string} productsItemNumbers A comma-separated list of item numbers to filter products
  * by
+ * @property {string[]} productsManualItemNumbers Array of product item numbers (manual input)
+ * @property {string[]} productsSelectorItemNumbers Array of product item numbers (product selector)
  */
 
 /**
@@ -52,6 +54,8 @@ export const useProductListWidget = () => {
     productsBrand,
     productsCategory,
     productsItemNumbers,
+    productsManualItemNumbers,
+    productsSelectorItemNumbers,
     productsSearchTerm,
   } = products;
 
@@ -61,8 +65,13 @@ export const useProductListWidget = () => {
         return productsBrand;
       case 'category':
         return productsCategory;
+      // Kept for backward compatibility - was replaces by 'manualItemNumbers' and 'productSelector'
       case 'itemNumbers':
         return productsItemNumbers.split(',').map(item => item.trim());
+      case 'manualItemNumbers':
+        return productsManualItemNumbers;
+      case 'productSelector':
+        return productsSelectorItemNumbers;
       case 'searchTerm':
       default:
         return productsSearchTerm;
@@ -71,9 +80,21 @@ export const useProductListWidget = () => {
     productSelectorType,
     productsBrand,
     productsCategory,
-    productsItemNumbers,
     productsSearchTerm,
+    productsItemNumbers,
+    productsManualItemNumbers,
+    productsSelectorItemNumbers,
   ]);
+
+  /** @type {"brand" | "category" | "productIds" | "searchTerm"} */
+  const productsSearchType = useMemo(() => {
+    // Map different input types that indicate arrays with item numbers to the same type
+    if (['itemNumbers', 'manualItemNumbers', 'productSelector'].includes(productSelectorType)) {
+      return 'productIds';
+    }
+
+    return productSelectorType;
+  }, [productSelectorType]);
 
   const flags = useMemo(() => ({
     name: showName,
@@ -82,7 +103,7 @@ export const useProductListWidget = () => {
   }), [showName, showPrice, showRating]);
 
   return {
-    productsSearchType: productSelectorType,
+    productsSearchType,
     productsSearchValue: value,
     sort: camelCase(sort),
     productCount,

--- a/libraries/engage/page/widgets/ProductSlider/hooks.js
+++ b/libraries/engage/page/widgets/ProductSlider/hooks.js
@@ -3,14 +3,16 @@ import { camelCase } from 'lodash';
 import { useWidget } from '@shopgate/engage/page/hooks';
 
 /**
- * @typedef {Object} ProductSliderWidgetProducts
- * @property {"searchTerm" | "brand" | "category" | "itemNumbers"} productSelectorType
- * Source type for the product list.
- * @property {string} [productsSearchTerm] A search term to filter products by.
- * @property {string} [productsBrand] A brand to filter products by.
- * @property {string} [productsCategory] A category to filter products by.
- * @property {string} [productsItemNumbers] A comma-separated list of item numbers
- * to filter products by.
+ * @typedef {Object} ProductListWidgetProducts
+ * @property {"searchTerm" | "brand" | "category" | "manualItemNumbers" | "productSelector"
+ * | "itemNumbers"} productSelectorType Source type for the product list.
+ * @property {string} productsSearchTerm A search term to filter products by
+ * @property {string} productsBrand A brand to filter products by
+ * @property {string} productsCategory A category to filter products by
+ * @property {string} productsItemNumbers A comma-separated list of item numbers to filter products
+ * by
+ * @property {string[]} productsManualItemNumbers Array of product item numbers (manual input)
+ * @property {string[]} productsSelectorItemNumbers Array of product item numbers (product selector)
  */
 
 /**
@@ -57,6 +59,8 @@ export const useProductSliderWidget = () => {
     productsBrand,
     productsCategory,
     productsItemNumbers,
+    productsManualItemNumbers,
+    productsSelectorItemNumbers,
     productsSearchTerm,
   } = products;
 
@@ -66,8 +70,13 @@ export const useProductSliderWidget = () => {
         return productsBrand;
       case 'category':
         return productsCategory;
+      // Kept for backward compatibility - was replaces by 'manualItemNumbers' and 'productSelector'
       case 'itemNumbers':
         return productsItemNumbers.split(',').map(item => item.trim());
+      case 'manualItemNumbers':
+        return productsManualItemNumbers;
+      case 'productSelector':
+        return productsSelectorItemNumbers;
       case 'searchTerm':
       default:
         return productsSearchTerm;
@@ -76,9 +85,21 @@ export const useProductSliderWidget = () => {
     productSelectorType,
     productsBrand,
     productsCategory,
-    productsItemNumbers,
     productsSearchTerm,
+    productsItemNumbers,
+    productsManualItemNumbers,
+    productsSelectorItemNumbers,
   ]);
+
+  /** @type {"brand" | "category" | "productIds" | "searchTerm"} */
+  const productsSearchType = useMemo(() => {
+    // Map different input types that indicate arrays with item numbers to the same type
+    if (['itemNumbers', 'manualItemNumbers', 'productSelector'].includes(productSelectorType)) {
+      return 'productIds';
+    }
+
+    return productSelectorType;
+  }, [productSelectorType]);
 
   const swiperProps = useMemo(() => ({
     autoplay: slideAutomatic,
@@ -93,7 +114,7 @@ export const useProductSliderWidget = () => {
   }), [showName, showPrice, showRating]);
 
   return {
-    productsSearchType: productSelectorType,
+    productsSearchType,
     productsSearchValue: value,
     sort: camelCase(sort),
     productCount,

--- a/libraries/engage/page/widgets/ProductSlider/hooks.js
+++ b/libraries/engage/page/widgets/ProductSlider/hooks.js
@@ -1,23 +1,16 @@
 import { useMemo } from 'react';
 import { camelCase } from 'lodash';
 import { useWidget } from '@shopgate/engage/page/hooks';
+import { getProductSearchParamsFromProductsInputConfig } from '@shopgate/engage/page/helpers';
 
 /**
- * @typedef {Object} ProductListWidgetProducts
- * @property {"searchTerm" | "brand" | "category" | "manualItemNumbers" | "productSelector"
- * | "itemNumbers"} productSelectorType Source type for the product list.
- * @property {string} productsSearchTerm A search term to filter products by
- * @property {string} productsBrand A brand to filter products by
- * @property {string} productsCategory A category to filter products by
- * @property {string} productsItemNumbers A comma-separated list of item numbers to filter products
- * by
- * @property {string[]} productsManualItemNumbers Array of product item numbers (manual input)
- * @property {string[]} productsSelectorItemNumbers Array of product item numbers (product selector)
+ * @typedef {import('@shopgate/engage/page/helpers')
+ * .ProductsWidgetInputConfig} ProductsWidgetInputConfig
  */
 
 /**
  * @typedef {Object} ProductSliderWidgetConfig
- * @property {ProductSliderWidgetProducts} products The products configuration for the widget.
+ * @property {ProductsWidgetInputConfig} products The products configuration for the widget.
  * @property {number} productCount The number of products to display in the widget.
  * @property {"relevance" | "priceDesc" | "priceAsc"} sort Sort order for the products.
  * @property {boolean} [showName] Whether to display product names.
@@ -54,53 +47,10 @@ export const useProductSliderWidget = () => {
     sliderSpeed = 7000,
   } = config;
 
-  const {
-    productSelectorType,
-    productsBrand,
-    productsCategory,
-    productsItemNumbers,
-    productsManualItemNumbers,
-    productsSelectorItemNumbers,
-    productsSearchTerm,
-  } = products;
-
-  const value = useMemo(() => {
-    switch (productSelectorType) {
-      case 'brand':
-        return productsBrand;
-      case 'category':
-        return productsCategory;
-      // Kept for backward compatibility - was replaces by 'manualItemNumbers' and 'productSelector'
-      case 'itemNumbers':
-        return productsItemNumbers.split(',').map(item => item.trim());
-      case 'manualItemNumbers':
-        return productsManualItemNumbers;
-      case 'productSelector':
-        return productsSelectorItemNumbers;
-      case 'searchTerm':
-      default:
-        return productsSearchTerm;
-    }
-  }, [
-    productSelectorType,
-    productsBrand,
-    productsCategory,
-    productsSearchTerm,
-    productsItemNumbers,
-    productsManualItemNumbers,
-    productsSelectorItemNumbers,
-  ]);
-
-  /** @type {"brand" | "category" | "productIds" | "searchTerm"} */
-  const productsSearchType = useMemo(() => {
-    // Map different input types that indicate arrays with item numbers to the same type
-    if (['itemNumbers', 'manualItemNumbers', 'productSelector'].includes(productSelectorType)) {
-      return 'productIds';
-    }
-
-    return productSelectorType;
-  }, [productSelectorType]);
-
+  const productSearchParams = useMemo(
+    () => getProductSearchParamsFromProductsInputConfig(products),
+    [products]
+  );
   const swiperProps = useMemo(() => ({
     autoplay: slideAutomatic,
     delay: sliderSpeed,
@@ -114,8 +64,7 @@ export const useProductSliderWidget = () => {
   }), [showName, showPrice, showRating]);
 
   return {
-    productsSearchType,
-    productsSearchValue: value,
+    ...productSearchParams,
     sort: camelCase(sort),
     productCount,
     swiperProps,


### PR DESCRIPTION
# Description
This pull requests adds support for the updated "Products" widget input. In the latest iteration, this was extended with additional / renamed fields. Additionally the pull request contains refactoring of duplicate code related to parsing of the products input conifg. 

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
