### PR TITLE
Added support for custom legacy widgets in new widget system

### DIFF
--- a/libraries/engage/page/components/Widgets/Widget.jsx
+++ b/libraries/engage/page/components/Widgets/Widget.jsx
@@ -59,12 +59,15 @@ const useStyles = makeStyles()((theme, {
  * @param {React.ComponentType} props.component The widget component to render.
  * @param {WidgetDefinition} props.definition The widget definition data.
  * @param {boolean} props.isPreview Whether the widget is in preview mode.
+ * @param {boolean} props.isCustomLegacyWidget Whether the widget is a legacy custom widget provided
+ * by an extension that's configured via an HTML comment inside a HTML widget.
  * @returns {JSX.Element}
  */
 const Widget = ({
   component: Component,
   definition,
   isPreview,
+  isCustomLegacyWidget,
 }) => {
   const { classes, cx } = useStyles({
     marginTop: definition?.layout?.marginTop ?? 0,
@@ -128,7 +131,11 @@ const Widget = ({
       )}
       <WidgetProvider definition={definition} isPreview={isPreview}>
         <Suspense fallback={<Loading />}>
-          <Component />
+          <Component
+            {...(isCustomLegacyWidget ? {
+              settings: definition.widgetConfig,
+            } : {})}
+          />
         </Suspense>
       </WidgetProvider>
     </section>
@@ -139,6 +146,11 @@ Widget.propTypes = {
   component: PropTypes.elementType.isRequired,
   definition: PropTypes.shape().isRequired,
   isPreview: PropTypes.bool.isRequired,
+  isCustomLegacyWidget: PropTypes.bool,
+};
+
+Widget.defaultProps = {
+  isCustomLegacyWidget: false,
 };
 
 export default Widget;

--- a/libraries/engage/page/components/Widgets/Widgets.jsx
+++ b/libraries/engage/page/components/Widgets/Widgets.jsx
@@ -55,6 +55,7 @@ const Widgets = ({
   if (!Array.isArray(widgets) || widgets.length === 0) {
     return null;
   }
+
   return (
     <ConditionalWrapper
       condition={isPreview}
@@ -80,6 +81,7 @@ const Widgets = ({
             definition={widget}
             isPreview={isPreview}
             component={component}
+            isCustomLegacyWidget={widget.isCustomLegacyWidget}
           />;
         })}
       </div>

--- a/libraries/engage/page/components/Widgets/types.d.ts
+++ b/libraries/engage/page/components/Widgets/types.d.ts
@@ -55,6 +55,11 @@ export interface WidgetDefinition {
    */
   widgetConfig: Record<string, any>;
   /**
+   * Whether the widget is a legacy custom widget provided by an extension that's configured
+   * via an HTML comment inside a HTML widget.
+   */
+  isCustomLegacyWidget?: boolean;
+  /**
    * Visibility settings for the widget.
    */
   visibility: WidgetDefinitionVisibility;

--- a/libraries/engage/page/reducers/index.js
+++ b/libraries/engage/page/reducers/index.js
@@ -6,6 +6,70 @@ import {
   PAGE_STATE_LIFETIME,
 } from '../constants';
 
+const customWidgetRegex = /<!--Widget(.*)-->/gmus;
+
+/**
+ * Decodes entities from a HTML string
+ * @param {string} html HTML string to decode
+ * @returns {string}
+ */
+const decodeHTMLEntities = (html = '') => {
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = html;
+  return textarea.value;
+};
+
+/**
+ * @param {Object} data The page data object
+ * @returns {Object} The sanitized page data
+ */
+const transformCustomLegacyWidgets = (data) => {
+  if (!Array.isArray(data?.dropzones?.cmsWidgetList)) {
+    return data;
+  }
+
+  const { cmsWidgetList } = data.dropzones;
+  const transformedWidgets = cmsWidgetList.map((widget) => {
+    if (widget.widgetConfigDefinitionCode !== '@shopgate/widgets/htmlWidget' || !widget?.widgetConfig?.html) {
+      return widget;
+    }
+
+    const content = decodeHTMLEntities(widget.widgetConfig.html.trim());
+
+    if (content.startsWith('<!--Widget')) {
+      try {
+        const settings = customWidgetRegex.exec(content);
+
+        customWidgetRegex.lastIndex = 0;
+
+        if (settings[0] === content) {
+          const customLegacyWidget = JSON.parse(settings[1]);
+
+          // Convert legacy widget data to the new format
+          return {
+            ...widget,
+            widgetConfig: customLegacyWidget.settings || {},
+            widgetConfigDefinitionCode: customLegacyWidget.type || '',
+            isCustomLegacyWidget: true,
+          };
+        }
+      } catch (err) {
+        // Nothing to do here
+      }
+    }
+
+    return widget;
+  });
+
+  return {
+    ...data,
+    dropzones: {
+      ...data.dropzones,
+      cmsWidgetList: transformedWidgets,
+    },
+  };
+};
+
 const defaultState = {};
 
 /**
@@ -33,7 +97,7 @@ export function pageV2(state = defaultState, action) {
         const { pageType, pageSlug, data } = action;
         draft[pageType] = draft[pageType] || {};
         draft[pageType][pageSlug] = {
-          data,
+          data: transformCustomLegacyWidgets(data),
           isFetching: false,
           expires: Date.now() + PAGE_STATE_LIFETIME,
         };

--- a/utils/webpack/lib/getComponentsSettings.js
+++ b/utils/webpack/lib/getComponentsSettings.js
@@ -66,6 +66,9 @@ module.exports = function getComponentsSettings(themePath) {
       },
       widgetsV2: {
         ...defaultConfig.widgetsV2,
+        // To enable backwards compatibility for custom legacy widgets that are provided by
+        // extensions we include them in the list of V2 widgets.
+        ...defaultConfig.widgets,
         ...loadConfig(themeWidgetsV2Config),
       },
     };

--- a/utils/webpack/lib/getComponentsSettings.js
+++ b/utils/webpack/lib/getComponentsSettings.js
@@ -65,10 +65,10 @@ module.exports = function getComponentsSettings(themePath) {
         ...loadConfig(themeWidgetsV1Config),
       },
       widgetsV2: {
-        ...defaultConfig.widgetsV2,
         // To enable backwards compatibility for custom legacy widgets that are provided by
         // extensions we include them in the list of V2 widgets.
         ...defaultConfig.widgets,
+        ...defaultConfig.widgetsV2,
         ...loadConfig(themeWidgetsV2Config),
       },
     };


### PR DESCRIPTION
# Description

This pull request adds support for widgets that are provided by extensions into the new CMS. Similar to the old system, users need to configure a HTML widget with a HTML comment that contains the widget configuration.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

A simple way to test the feature is to attach the [Recently Viewed Products](https://github.com/shopgate/ext-recently-viewed-products) extension and configure its widget via a CMS 2.0 HTML widget. Since this extension needs visits of PDP to show content, you need to do this outside the Next Admin.
