### PR TITLE
Fixed scroll container issue on iOS

### DIFF
--- a/libraries/engage/components/View/components/Content/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/libraries/engage/components/View/components/Content/__tests__/__snapshots__/index.spec.jsx.snap
@@ -6,37 +6,45 @@ exports[`engage > components > view > components > content should render content
   role="none"
   style={
     Object {
+      "--keyboard-height": "0px",
       "overflow": "auto",
-      "paddingBottom": "calc(var(--page-content-offset-bottom) + 0px)",
     }
   }
 >
-  <HelmetWrapper
-    defer={true}
-    encodeSpecialCharacters={true}
-    title="Test Shop"
-  />
-  <ViewAbove />
-  <ResponsiveContainer
-    appAlways={false}
-    appOnly={false}
-    breakpoint=">xs"
-    webAlways={false}
-    webOnly={true}
+  <div
+    className={
+      Object {
+        "data-css-18u3fb9": "",
+      }
+    }
   >
-    <div
-      id="PageHeaderBelow"
+    <HelmetWrapper
+      defer={true}
+      encodeSpecialCharacters={true}
+      title="Test Shop"
     />
-  </ResponsiveContainer>
-  <ConditionalWrapper
-    condition={true}
-    wrapper={[Function]}
-    wrapperFalsy={null}
-  >
-    <div>
-      Page #1
-    </div>
-  </ConditionalWrapper>
-  <ViewBelow />
+    <ViewAbove />
+    <ResponsiveContainer
+      appAlways={false}
+      appOnly={false}
+      breakpoint=">xs"
+      webAlways={false}
+      webOnly={true}
+    >
+      <div
+        id="PageHeaderBelow"
+      />
+    </ResponsiveContainer>
+    <ConditionalWrapper
+      condition={true}
+      wrapper={[Function]}
+      wrapperFalsy={null}
+    >
+      <div>
+        Page #1
+      </div>
+    </ConditionalWrapper>
+    <ViewBelow />
+  </div>
 </article>
 `;

--- a/libraries/engage/components/View/components/Content/index.jsx
+++ b/libraries/engage/components/View/components/Content/index.jsx
@@ -13,7 +13,7 @@ import { useScrollContainer } from '@shopgate/engage/core';
 import { ConditionalWrapper } from '../../../ConditionalWrapper';
 import Above from '../Above';
 import Below from '../Below';
-import styles from './style';
+import { container, containerInner } from './style';
 
 /**
  * The ViewContent component.
@@ -120,8 +120,8 @@ class ViewContent extends Component {
     }
 
     return {
+      '--keyboard-height': `${keyboardHeight}px`,
       overflow,
-      paddingBottom: `calc(var(--page-content-offset-bottom) + ${keyboardHeight}px)`,
     };
   }
 
@@ -150,29 +150,31 @@ class ViewContent extends Component {
   render() {
     return (
       <article
-        className={`${styles} engage__view__content ${this.props.className}`}
+        className={`${container} engage__view__content ${this.props.className}`}
         ref={this.scrollContainer ? this.ref : null}
         style={this.style}
         role="none"
       >
-        <Helmet title={appConfig.shopName} />
-        <Above />
-        <ResponsiveContainer breakpoint=">xs" webOnly>
-          {this.props.visible ? (
-            <div id="PageHeaderBelow" />
-          ) : null}
-        </ResponsiveContainer>
-        <ConditionalWrapper
-          condition={!this.props.noContentPortal}
-          wrapper={children =>
-            <SurroundPortals portalName={VIEW_CONTENT}>
-              {children}
-            </SurroundPortals>
+        <div className={containerInner}>
+          <Helmet title={appConfig.shopName} />
+          <Above />
+          <ResponsiveContainer breakpoint=">xs" webOnly>
+            {this.props.visible ? (
+              <div id="PageHeaderBelow" />
+            ) : null}
+          </ResponsiveContainer>
+          <ConditionalWrapper
+            condition={!this.props.noContentPortal}
+            wrapper={children =>
+              <SurroundPortals portalName={VIEW_CONTENT}>
+                {children}
+              </SurroundPortals>
             }
-        >
-          {this.props.children}
-        </ConditionalWrapper>
-        <Below />
+          >
+            {this.props.children}
+          </ConditionalWrapper>
+          <Below />
+        </div>
       </article>
     );
   }

--- a/libraries/engage/components/View/components/Content/style.js
+++ b/libraries/engage/components/View/components/Content/style.js
@@ -1,8 +1,8 @@
 import { css } from 'glamor';
-import { useScrollContainer } from '@shopgate/engage/core';
+import { useScrollContainer, isIOs } from '@shopgate/engage/core/helpers';
 import { responsiveMediaQuery } from '@shopgate/engage/styles';
 
-export default css({
+export const container = css({
   display: 'flex',
   flexDirection: 'column',
   width: '100vw',
@@ -18,5 +18,19 @@ export default css({
   }),
   [responsiveMediaQuery('>xs', { webOnly: true })]: {
     width: 'var(--page-content-width)',
+  },
+});
+
+export const containerInner = css({
+  ...isIOs ? {
+    // Make the scroll container content a bit higher than the actual scroll container to
+    // get a rubber band effect in all situations
+    minHeight: 'calc(100% + 12px)',
+  } : {},
+  ':after': {
+    content: "''",
+    display: 'block',
+    pointerEvents: 'none',
+    paddingBottom: 'calc(var(--page-content-offset-bottom) + var(--keyboard-height))',
   },
 });


### PR DESCRIPTION
# Description
This pull request fixes a scrolling issue on iOS related to the scroll container and InfiniteContainer in its loading state.

### Problem
On iOS, scrolling is only possible if the content is taller than the container. In rare cases, when the InfiniteContainer rendered in a loading state, its height exceeded the container slightly. Once the loading spinner disappeared (caused by scrolling), the container shrank back to its normal size. This caused two issues:
- The container was no longer tall enough to allow scrolling.
- Content became partially stuck and inaccessible outside the viewport.

### Solution

The scroll container’s content is now rendered slightly taller than the container height at all times. This ensures that:
- Scrolling remains possible even after the loading state changes.
- Content is never stuck or clipped out of view on iOS.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Goto a page without much content. In any situation the scroll container content should be scrollable, even if the content doesn't overflow the scroll container.