### PR TITLE
Modified logic to show base prices based on pricePerMeasureUnit product price property

### DIFF
--- a/libraries/engage/product/components/PriceInfo/PriceInfo.connector.js
+++ b/libraries/engage/product/components/PriceInfo/PriceInfo.connector.js
@@ -9,7 +9,7 @@ import { SHOP_SETTING_DISPLAY_PRICE_PER_MEASURE_UNIT } from '../../../core/const
 const makeMapStateToProps = () => {
   const getShopSetting = makeGetShopSettingByKey(
     SHOP_SETTING_DISPLAY_PRICE_PER_MEASURE_UNIT,
-    false
+    true
   );
 
   return (state, props) => ({

--- a/libraries/engage/product/components/PriceInfo/PriceInfo.jsx
+++ b/libraries/engage/product/components/PriceInfo/PriceInfo.jsx
@@ -27,7 +27,7 @@ const PriceInfo = ({
   const { pricePerMeasureUnit, info, currency } = price;
 
   const content = useMemo(() => {
-    if (!displayPricePerMeasureUnit) {
+    if (!displayPricePerMeasureUnit || !pricePerMeasureUnit) {
       return info;
     }
 
@@ -44,7 +44,8 @@ const PriceInfo = ({
 
     return i18n.text('price.pricePerMeasurementFormat', {
       price: i18n.price(pricePerMeasureUnit, currency || externalCurrency, 2),
-      refValue: unitPriceRefValue || '',
+      // Don't show base prices like 1.99€/1kg, but show 1.99€/kg instead
+      refValue: !!unitPriceRefValue && unitPriceRefValue !== 1 ? unitPriceRefValue : '',
       refUom: unit,
     });
   }, [
@@ -67,8 +68,8 @@ const PriceInfo = ({
       wrapper={wrapper}
     >
       <div
-        className={classNames(styles.container, className, {
-          [styles.noWrap]: displayPricePerMeasureUnit,
+        className={classNames(styles.container, className, 'engage__product__price-info', {
+          [styles.noWrap]: content !== info,
         })}
         dangerouslySetInnerHTML={{ __html: content }}
         data-test-id={`priceInfo: ${content}`}


### PR DESCRIPTION
# Description
This ticked enables to show base prices for products based on the `pricePerMeasureUnit` product price property and its related properties when properties are present, but the related shop setting is not set.

Till now base prices where always rendered based on the `info` property of the product price object for shops that don't fetch shop settings from the next admin on startup.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Connect to a shop that uses the catalog-extension to retrieve products. When `pricePerMeasureUnit` property is present the base price should be dynamically created based on the related product properties. When the shop can be configured via the next-admin, the setting needs to be activated via the `Design` tab,.
