### PR TITLE
CURB-5253 implement image widget

### DIFF
--- a/libraries/engage/page/widgets/Image/Image.jsx
+++ b/libraries/engage/page/widgets/Image/Image.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useResponsiveValue, makeStyles } from '@shopgate/engage/styles';
+import { Link, ConditionalWrapper } from '@shopgate/engage/components';
+import { useImageWidget } from './hooks';
+
+const useStyles = makeStyles()(() => ({
+  root: {},
+  link: {},
+  image: {
+    width: '100%',
+  },
+}));
+/**
+ * The ImageWidget is used to display a image.
+ * @returns {JSX.Element}
+ */
+const Image = () => {
+  const { cx, classes } = useStyles();
+  const { link, altText, url } = useImageWidget();
+
+  // Regex to separate filename and file extension
+  const match = url.match(/^(.*)\.([^./]+)$/);
+
+  const responsiveUrl = useResponsiveValue({
+    xs: url,
+    md: !match ? url : `${match[1]}@2x.${match[2]}`,
+  });
+
+  if (!responsiveUrl) return null;
+
+  return (
+    <div className={cx(classes.root)}>
+      <ConditionalWrapper
+        condition={!!link}
+        wrapper={children => (
+          <Link href={link} className={cx(classes.link)}>
+            {children}
+          </Link>
+        )}
+      >
+        <img
+          loading="lazy"
+          src={responsiveUrl}
+          alt={altText}
+          aria-label={altText}
+          className={cx(classes.image)}
+        />
+      </ConditionalWrapper>
+    </div>
+  );
+};
+export default Image;

--- a/libraries/engage/page/widgets/Image/hooks.js
+++ b/libraries/engage/page/widgets/Image/hooks.js
@@ -1,0 +1,29 @@
+import { useWidget } from '@shopgate/engage/page/hooks';
+
+/**
+ * @typedef {Object} ImageWidgetConfig
+ * @property {Object} image The image object.
+ * @property {string} image.url The image URL.
+ * @property {string} [image.altText] The image alt text.
+ * @property {string} [link] The link URL.
+ */
+
+/**
+ * @typedef {ReturnType< typeof import('@shopgate/engage/page/hooks')
+ *   .useWidget<ImageWidgetConfig> >} UseWidgetReturnType
+ */
+
+// eslint-disable-next-line valid-jsdoc
+/**
+ * Hook to access the Image widget configuration and data.
+ */
+export const useImageWidget = () => {
+  /** @type {UseWidgetReturnType}  */
+  const { config } = useWidget();
+
+  return {
+    url: config?.image?.url,
+    altText: config?.image?.altText || '',
+    link: config?.link,
+  };
+};

--- a/libraries/engage/page/widgets/Image/index.js
+++ b/libraries/engage/page/widgets/Image/index.js
@@ -1,0 +1,1 @@
+export { default } from './Image';

--- a/libraries/engage/page/widgets/index.js
+++ b/libraries/engage/page/widgets/index.js
@@ -4,3 +4,4 @@ export { default as CategoryListWidget } from './CategoryList';
 export { default as HtmlWidget } from './HTML';
 export { default as ProductSliderWidget } from './ProductSlider';
 export { default as HeadlineWidget } from './Headline';
+export { default as ImageWidget } from './Image';

--- a/libraries/engage/page/widgets/widgets.json
+++ b/libraries/engage/page/widgets/widgets.json
@@ -16,5 +16,8 @@
   },
   "@shopgate/widgets/headlineWidget": {
     "path": "@shopgate/engage/page/widgets/Headline"
+  },
+  "@shopgate/widgets/imageWidget": {
+    "path": "@shopgate/engage/page/widgets/Image"
   }
 }


### PR DESCRIPTION
# Description

Implements a image widget

# Excluded

- @2x images can only be testet when cms service supports scaled images.
- acessability can only be implemented/tested when pwa cms page is implemented
- link can only be testet when pwa cms page is implemented
