### PR TITLE
Added support for widget scheduling outside the preview mode

### DIFF
--- a/libraries/engage/page/components/Widgets/Widgets.jsx
+++ b/libraries/engage/page/components/Widgets/Widgets.jsx
@@ -7,6 +7,7 @@ import { ConditionalWrapper } from '@shopgate/engage/components';
 import WidgetsPreviewProvider from './WidgetsPreviewProvider';
 import Widget from './Widget';
 import Overlay from './Overlay';
+import { checkScheduled } from './helpers';
 import { usePreviewIframeCommunication } from './hooks';
 
 /**
@@ -49,7 +50,14 @@ const Widgets = ({
     }
 
     // Remove widgets that do not have a valid component.
-    return widgetsProp.filter(widget => !!widgetComponents[widget.widgetConfigDefinitionCode]);
+    return widgetsProp.filter(
+      widget =>
+        !!widgetComponents[widget.widgetConfigDefinitionCode] &&
+      checkScheduled({
+        from: widget?.visibility.scheduleStartDate,
+        to: widget?.visibility.scheduleEndDate,
+      }).isActive
+    );
   }, [isPreview, widgetComponents, widgetsProp]);
 
   if (!Array.isArray(widgets) || widgets.length === 0) {

--- a/libraries/engage/page/components/Widgets/helpers.js
+++ b/libraries/engage/page/components/Widgets/helpers.js
@@ -9,23 +9,23 @@ export const getScrollContainer = () => document.querySelector(`.route__${PAGE_P
 
 /**
  * @typedef {Object} ScheduledParams
- * @param {string} [from] The start date of the scheduling in ISO format.
- * @param {string} [to] The end date of the scheduling in ISO format.
- * @param {number} [timezoneOffset] The timezone offset in minutes. If not provided, the local
+ * @property {string} [from] The start date of the scheduling in ISO format.
+ * @property {string} [to] The end date of the scheduling in ISO format.
+ * @property {number} [timezoneOffset] The timezone offset in minutes. If not provided, the local
  * timezone offset will be used.
  */
 
 /**
  * @typedef {Object} ScheduledStatus
- * @param {boolean} isScheduled Indicates if the widget is scheduled.
- * @param {boolean} isActive Indicates if the widget is currently active within the
+ * @property {boolean} isScheduled Indicates if the widget is scheduled.
+ * @property {boolean} isActive Indicates if the widget is currently active within the
  * scheduled time frame.
- * @param {boolean} isExpired Indicates if the scheduled time frame has expired.
+ * @property {boolean} isExpired Indicates if the scheduled time frame has expired.
  */
 
 /**
  * Retrieves the scheduling status of a widget based on the provided parameters.
- * @param {ScheduledParams} params The parameters for the function.
+ * @param {ScheduledParams} [params] The parameters for the function.
  * @returns {ScheduledStatus} An object containing the scheduling status.
  */
 export function checkScheduled({ from, to, timezoneOffset } = {}) {


### PR DESCRIPTION
# Description

This pull request implements scheduling for widgets outside the preview mode. For now the widget list is filtered when Widgets component mounts. So users need to leave and re-enter pages to see updates.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
