### PR TITLE
v2 pages are not persisted in preview mode

### DIFF
--- a/themes/theme-gmd/pages/reducers.js
+++ b/themes/theme-gmd/pages/reducers.js
@@ -5,7 +5,7 @@ import {
   RESET_APP_REDUCERS,
   hasWebBridge,
 } from '@shopgate/engage/core';
-import { PAGE_PREVIEW_PATTERN } from '@shopgate/engage/page/constants';
+import { IS_PAGE_PREVIEW_ACTIVE } from '@shopgate/engage/page/constants';
 import backInStock from '@shopgate/engage/back-in-stock/reducers';
 import checkout from '@shopgate/engage/checkout/reducers';
 import client from '@shopgate/pwa-common/reducers/client';
@@ -39,7 +39,7 @@ persistedReducers.set([
   'client.info',
   'page',
   // Preview page data should not persist
-  ...PAGE_PREVIEW_PATTERN ? [] : ['pageV2'],
+  ...IS_PAGE_PREVIEW_ACTIVE ? [] : ['pageV2'],
   'locations.storage',
   'locations.userFormInput',
   'locations.userSearch',

--- a/themes/theme-gmd/pages/reducers.js
+++ b/themes/theme-gmd/pages/reducers.js
@@ -5,6 +5,7 @@ import {
   RESET_APP_REDUCERS,
   hasWebBridge,
 } from '@shopgate/engage/core';
+import { PAGE_PREVIEW_PATTERN } from '@shopgate/engage/page/constants';
 import backInStock from '@shopgate/engage/back-in-stock/reducers';
 import checkout from '@shopgate/engage/checkout/reducers';
 import client from '@shopgate/pwa-common/reducers/client';
@@ -37,7 +38,8 @@ persistedReducers.set([
   'cart.data',
   'client.info',
   'page',
-  'pageV2',
+  // Preview page data should not persist
+  ...PAGE_PREVIEW_PATTERN ? [] : ['pageV2'],
   'locations.storage',
   'locations.userFormInput',
   'locations.userSearch',

--- a/themes/theme-ios11/pages/reducers.js
+++ b/themes/theme-ios11/pages/reducers.js
@@ -4,6 +4,7 @@ import {
   configuration,
   RESET_APP_REDUCERS,
 } from '@shopgate/engage/core';
+import { PAGE_PREVIEW_PATTERN } from '@shopgate/engage/page/constants';
 import backInStock from '@shopgate/engage/back-in-stock/reducers';
 import checkout from '@shopgate/engage/checkout/reducers';
 import client from '@shopgate/pwa-common/reducers/client';
@@ -37,7 +38,8 @@ persistedReducers.set([
   'cart.data',
   'client.info',
   'page',
-  'pageV2',
+  // Preview page data should not persist
+  ...PAGE_PREVIEW_PATTERN ? [] : ['pageV2'],
   'locations.storage',
   'locations.userFormInput',
   'locations.userSearch',

--- a/themes/theme-ios11/pages/reducers.js
+++ b/themes/theme-ios11/pages/reducers.js
@@ -4,7 +4,7 @@ import {
   configuration,
   RESET_APP_REDUCERS,
 } from '@shopgate/engage/core';
-import { PAGE_PREVIEW_PATTERN } from '@shopgate/engage/page/constants';
+import { IS_PAGE_PREVIEW_ACTIVE } from '@shopgate/engage/page/constants';
 import backInStock from '@shopgate/engage/back-in-stock/reducers';
 import checkout from '@shopgate/engage/checkout/reducers';
 import client from '@shopgate/pwa-common/reducers/client';
@@ -39,7 +39,7 @@ persistedReducers.set([
   'client.info',
   'page',
   // Preview page data should not persist
-  ...PAGE_PREVIEW_PATTERN ? [] : ['pageV2'],
+  ...IS_PAGE_PREVIEW_ACTIVE ? [] : ['pageV2'],
   'locations.storage',
   'locations.userFormInput',
   'locations.userSearch',


### PR DESCRIPTION
# Description
This pull request disables persistence for the pagev2 Redux state in CMS preview mode.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

