### PR TITLE
Fixed handling of links with coupons

### DIFF
--- a/libraries/common/subscriptions/router.js
+++ b/libraries/common/subscriptions/router.js
@@ -10,6 +10,7 @@ import Route from '@virtuous/conductor/Route';
 import { HISTORY_RESET_TO } from '@shopgate/pwa-common/constants/ActionTypes';
 import { logger } from '@shopgate/pwa-core';
 import { IS_PAGE_PREVIEW_ACTIVE } from '@shopgate/engage/page/constants';
+import addCouponsToCart from '@shopgate/pwa-common-commerce/cart/actions/addCouponsToCart';
 import { getCurrentRoute, getRouterStackIndex } from '../selectors/router';
 import { LoadingProvider } from '../providers';
 import { redirects } from '../collections';
@@ -242,6 +243,18 @@ export default function routerSubscriptions(subscribe) {
       // The URL is not valid - show a toast message
       showConnectivityError();
       return;
+    }
+
+    if (parsed?.query?.coupon) {
+      const hasBase = location.startsWith('http://') || location.startsWith('https://');
+
+      // Remove the coupon query parameter from internal URLs and redeem the coupon.
+      if (!hasBase) {
+        dispatch(addCouponsToCart([parsed.query.coupon], false));
+        const u = new URL(location, hasBase ? undefined : 'http://example.com');
+        u.searchParams.delete('coupon');
+        location = hasBase ? u.toString() : u.pathname + u.search + u.hash;
+      }
     }
 
     // Override the location if is Shop link is found.


### PR DESCRIPTION
# Description
This pull request fixes an issue with links that contain coupon codes. Till now there where situations where the page that contained the link was accidentally replaced with the target page.

As a fix, the coupon inside the link query is now redeemed during the navigation process. When included, the coupon code is removed from the target url before the actual navigation happens. So the history will never contain an entry with the coupon code.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
- Create a CMS 2.0 page with a link that contains a coupon
- Navigate the to page
- Coupon is redeemed and you can navigate back to the page with the link as expected
