### PR TITLE
Fix image flickering when navigating back via browser history

### DIFF
--- a/libraries/engage/page/components/ResponsiveWidgetImage/ResponsiveWidgetImage.jsx
+++ b/libraries/engage/page/components/ResponsiveWidgetImage/ResponsiveWidgetImage.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { useTheme, makeStyles } from '@shopgate/engage/styles';
+import { makeStyles, useResponsiveValue } from '@shopgate/engage/styles';
 import { parseImageUrl } from '../../helpers';
 
 /** @typedef {import('@shopgate/engage/styles').Theme} Theme */
@@ -11,10 +11,7 @@ import { parseImageUrl } from '../../helpers';
 const useStyles = makeStyles()({
   preventSave: {
     userSelect: 'none',
-    ' img': {
-      userSelect: 'none',
-      pointerEvents: 'none',
-    },
+    pointerEvents: 'none',
   },
 });
 
@@ -29,35 +26,37 @@ const ResponsiveWidgetImage = ({
   src,
   alt,
   breakpoint,
+  className,
   ...imgProps
 }) => {
-  const { breakpoints } = useTheme();
-  const { classes } = useStyles();
+  const { classes, cx } = useStyles();
+
   const src2x = useMemo(() => parseImageUrl(src, true), [src]);
+
+  const imgSrc = useResponsiveValue({
+    xs: src,
+    [breakpoint]: src2x,
+  });
 
   if (!src) {
     return null;
   }
 
   return (
-    <picture
-      onContextMenu={e => e.preventDefault()}
-      className={classes.preventSave}
-    >
-      <source media={`(width >= ${breakpoints.values[breakpoint]}px)`} srcSet={src2x} />
-      <img
-        src={src}
-        alt={alt}
-        loading="lazy"
-        {...imgProps}
-      />
-    </picture>
+    <img
+      src={imgSrc}
+      alt={alt}
+      loading="lazy"
+      className={cx(classes.preventSave, className)}
+      {...imgProps}
+    />
   );
 };
 
 ResponsiveWidgetImage.propTypes = {
   alt: PropTypes.string,
   breakpoint: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
+  className: PropTypes.string,
   src: PropTypes.string,
 };
 
@@ -65,6 +64,7 @@ ResponsiveWidgetImage.defaultProps = {
   src: null,
   alt: null,
   breakpoint: 'md',
+  className: null,
 };
 
 export default ResponsiveWidgetImage;


### PR DESCRIPTION
# Description
This pull request fixes an issue where images of CMS 2.0 widgets flickered when navigating back and forth a page and different routes. The issue was caused by usage of `picture` elements to support images with higher resolutions on wide screens. This is now fixed by replacing the picture element with custom logic.

This pull request addresses an issue where images in CMS 2.0 widgets would flicker when navigating between pages.

The root cause was the use of `<picture>` elements for serving higher-resolution images on wide screens. This implementation led to unnecessary reloads and layout shifts of the images during navigation.

The fix replaces the `<picture>` element with custom logic that ensures the correct image is displayed.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
- Configure a CMS 2.0 page with different widgets that show images
- Configure links to different pages (e.g. a category list)
- Navigation back and forth between pages and check if images still flicker when page re-appears
- Also check if scroll position is rehydrated as expected
