### PR TITLE
Refactored internal ConnectedReactPortal component

### DIFF
--- a/libraries/common/components/Picker/__snapshots__/spec.jsx.snap
+++ b/libraries/common/components/Picker/__snapshots__/spec.jsx.snap
@@ -59,7 +59,6 @@ exports[`<Picker /> Given the component was mounted to the DOM should match snap
     </PickerButton>
     <ConnectedReactPortal
       isOpened={true}
-      onClose={[Function]}
     >
       <PickerModal
         duration={300}

--- a/libraries/common/components/Picker/index.jsx
+++ b/libraries/common/components/Picker/index.jsx
@@ -236,10 +236,7 @@ class Picker extends Component {
       >
         {React.createElement(this.props.buttonComponent, buttonProps)}
 
-        <ConnectedReactPortal
-          onClose={() => this.toggleOpenState(false)}
-          isOpened
-        >
+        <ConnectedReactPortal isOpened>
           {React.createElement(
             this.props.modalComponent,
             modalProps,

--- a/libraries/engage/components/ConnectedReactPortal/index.jsx
+++ b/libraries/engage/components/ConnectedReactPortal/index.jsx
@@ -9,7 +9,7 @@ const node = document.getElementById('portals');
  * @param {boolean} props.isOpened Whether the portal is open
  * @param {React.ReactNode} props.children The children to render inside the portal
  * @private
- * @returns {JSX.Element|null}
+ * @returns {React.ReactPortal|null}
  */
 const ConnectedReactPortal = ({ children, isOpened }) => {
   if (!isOpened) return null;

--- a/libraries/engage/components/ConnectedReactPortal/index.jsx
+++ b/libraries/engage/components/ConnectedReactPortal/index.jsx
@@ -1,41 +1,30 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import { Provider, ReactReduxContext } from 'react-redux';
-import Portal from 'react-portal';
+import { createPortal } from 'react-dom';
+
+const node = document.getElementById('portals');
 
 /**
- * @typedef {import('@types/react-portal')} ReactPortal
+ * The connected react portal component rendering its children into a react portal node.
+ * @param {Object} props The component props
+ * @param {boolean} props.isOpened Whether the portal is open
+ * @param {React.ReactNode} props.children The children to render inside the portal
+ * @private
+ * @returns {JSX.Element|null}
  */
+const ConnectedReactPortal = ({ children, isOpened }) => {
+  if (!isOpened) return null;
 
-// eslint-disable-next-line valid-jsdoc
-/**
- * ConnectedReactPortal is a wrapper around "react-portal" v3 that ensures
- * children rendered in the portal have access to the Redux store.
- *
- * This addresses the limitation introduced by the switch to the new Context API in react-redux v6,
- * where the Redux store is only accessible to components within the StoreProvider. Since the Portal
- * component renders its children outside the React component tree, this wrapper bridges the gap.
- *
- * @type {ReactPortal}
- */
-const ConnectedReactPortal = ({ children, ...props }) => (
-  <ReactReduxContext.Consumer>
-    {(ctx => (
-      <Portal {...props}>
-        <Provider store={ctx.store}>
-          {children}
-        </Provider>
-      </Portal>
-    ))}
-  </ReactReduxContext.Consumer>
-);
+  return createPortal(children, node);
+};
 
 ConnectedReactPortal.propTypes = {
   children: PropTypes.node,
+  isOpened: PropTypes.bool,
 };
 
 ConnectedReactPortal.defaultProps = {
   children: null,
+  isOpened: false,
 };
 
 export default ConnectedReactPortal;

--- a/libraries/engage/components/Picker/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/components/Picker/__snapshots__/spec.jsx.snap
@@ -75,7 +75,6 @@ exports[`<Picker /> Given the component was mounted to the DOM should match snap
       </PickerButton>
       <ConnectedReactPortal
         isOpened={true}
-        onClose={[Function]}
       >
         <PickerModal
           duration={300}

--- a/libraries/engage/components/Picker/index.jsx
+++ b/libraries/engage/components/Picker/index.jsx
@@ -232,7 +232,7 @@ class Picker extends Component {
         aria-haspopup
       >
         {React.createElement(this.props.buttonComponent, buttonProps)}
-        <ConnectedReactPortal onClose={() => this.toggleOpenState(false)} isOpened>
+        <ConnectedReactPortal isOpened>
           {React.createElement(
             this.props.modalComponent,
             modalProps,

--- a/libraries/engage/components/PickerUtilize/__snapshots__/spec.jsx.snap
+++ b/libraries/engage/components/PickerUtilize/__snapshots__/spec.jsx.snap
@@ -92,7 +92,6 @@ exports[`<Picker /> should render the picker 1`] = `
             </Button>
             <ConnectedReactPortal
               isOpened={true}
-              onClose={[Function]}
             >
               <Component
                 duration={300}

--- a/libraries/engage/favorites/components/Lists/ListsModal.jsx
+++ b/libraries/engage/favorites/components/Lists/ListsModal.jsx
@@ -21,7 +21,10 @@ const styles = {
 
 /**
  * @param {Object} props Props
- * @returns {Object}
+ * @param {'add_list'|'rename_list'} [props.type] The modal type
+ * @param {Function} props.onConfirm The confirm handler
+ * @param {Function} props.onDismiss The dismiss handler
+ * @returns {JSX.Element}
  */
 const ListsModal = ({ type, onConfirm, onDismiss }) => {
   const [input, setInput] = useState('');
@@ -75,7 +78,11 @@ const ListsModal = ({ type, onConfirm, onDismiss }) => {
 ListsModal.propTypes = {
   onConfirm: PropTypes.func.isRequired,
   onDismiss: PropTypes.func.isRequired,
-  type: PropTypes.string.isRequired,
+  type: PropTypes.string,
+};
+
+ListsModal.defaultProps = {
+  type: 'add_list',
 };
 
 export default ListsModal;

--- a/themes/theme-gmd/components/Picker/__snapshots__/spec.jsx.snap
+++ b/themes/theme-gmd/components/Picker/__snapshots__/spec.jsx.snap
@@ -92,7 +92,6 @@ exports[`<Picker /> should render the picker 1`] = `
             </Button>
             <ConnectedReactPortal
               isOpened={true}
-              onClose={[Function]}
             >
               <Component
                 duration={300}

--- a/themes/theme-ios11/components/Picker/__snapshots__/spec.jsx.snap
+++ b/themes/theme-ios11/components/Picker/__snapshots__/spec.jsx.snap
@@ -92,7 +92,6 @@ exports[`<Picker /> should render the picker 1`] = `
             </Button>
             <ConnectedReactPortal
               isOpened={true}
-              onClose={[Function]}
             >
               <Component
                 duration={300}


### PR DESCRIPTION
# Description

This pull request refactors the internally used `ConnectedReactPortal` component to use `createPortal` from `react-dom` instead of the `react-portal` module to render portals that are e.g. used to display dialogs or sheets.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.
