### PR TITLE
Remove Universal Link handling in PWA, move it to extension

### DIFF
--- a/libraries/common/actions/app/handleUniversalLink.js
+++ b/libraries/common/actions/app/handleUniversalLink.js
@@ -1,5 +1,4 @@
 import { openUniversalLink } from '../../action-creators/app';
-import handleLink from './handleLink';
 
 /**
  * Opens an universal link.
@@ -9,6 +8,5 @@ import handleLink from './handleLink';
 export default function handleUniversalLink(payload) {
   return (dispatch) => {
     dispatch(openUniversalLink(payload));
-    dispatch(handleLink(payload));
   };
 }


### PR DESCRIPTION
# Description

This pull request disables the handling of Universal Links in the PWA. It should now be handled via the omni-core-features extension.

## Type of change
- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.