### PR TITLE
Add Roboto as fallback font on Windows and Linux in iOS theme

### DIFF
--- a/libraries/common/helpers/environment/index.js
+++ b/libraries/common/helpers/environment/index.js
@@ -14,5 +14,5 @@ module.exports = {
   isStaging: (env === ENV_KEY_STAGING),
   isRemote: !!process.env.REMOTE,
   isWindows: /win/i.test(userAgent),
-  isLinux: /linux/i.test(userAgent),
+  isLinux: /linux/i.test(userAgent) && !/android/i.test(userAgent),
 };

--- a/libraries/common/helpers/environment/index.js
+++ b/libraries/common/helpers/environment/index.js
@@ -5,11 +5,14 @@ const ENV_KEY_STAGING = 'staging';
 const ENV_KEY_PRODUCTION = 'production';
 const env = process.env.NODE_ENV || ENV_KEY_DEVELOPMENT;
 
+const userAgent = window?.navigator?.userAgent ?? '';
+
 module.exports = {
   env,
   isDev: (env === ENV_KEY_DEVELOPMENT || env === ENV_KEY_TEST),
   isProd: (env === ENV_KEY_PRODUCTION),
   isStaging: (env === ENV_KEY_STAGING),
   isRemote: !!process.env.REMOTE,
-  isWindows: (window?.navigator?.userAgent ?? '').toLowerCase().includes('win'),
+  isWindows: /win/i.test(userAgent),
+  isLinux: /linux/i.test(userAgent),
 };

--- a/libraries/engage/core/helpers/index.js
+++ b/libraries/engage/core/helpers/index.js
@@ -49,6 +49,7 @@ export {
   isProd,
   isRemote,
   isStaging,
+  isLinux,
   isWindows,
 } from '@shopgate/pwa-common/helpers/environment';
 export { default as decodeHTML } from '@shopgate/pwa-common/helpers/html/decodeHTML';

--- a/libraries/engage/styles/reset/root.js
+++ b/libraries/engage/styles/reset/root.js
@@ -3,8 +3,6 @@ import {
   useScrollContainer,
   hasWebBridge,
   isIOSTheme,
-  isWindows,
-  isDev,
 } from '@shopgate/engage/core/helpers';
 import { themeConfig } from '@shopgate/engage';
 
@@ -38,8 +36,8 @@ css.global('html', {
   minHeight: '100%',
 });
 
-// Include Roboto font on Windows in dev mode on iOS theme, so that developers see nice fonts.
-const fontSuffix = isDev && iosThemeActive && isWindows && !(typography.family ?? '').includes('Roboto')
+// Include Roboto font as a fallback to the iOS theme when other fonts are not available
+const fontSuffix = iosThemeActive && !(typography.family || '').includes('Roboto')
   ? ', Roboto'
   : '';
 

--- a/themes/theme-ios11/pages/index.jsx
+++ b/themes/theme-ios11/pages/index.jsx
@@ -8,7 +8,7 @@ import { ThemeProvider, createTheme } from '@shopgate/engage/styles';
 import { ThemeConfigResolver, AppProvider } from '@shopgate/engage/core';
 import appConfig from '@shopgate/pwa-common/helpers/config';
 import { themeConfig } from '@shopgate/engage';
-import { isDev, isWindows } from '@shopgate/engage/core/helpers';
+import { isWindows, isLinux } from '@shopgate/engage/core/helpers';
 import { history } from '@shopgate/pwa-common/helpers/router';
 import routePortals from '@shopgate/pwa-common/helpers/portals/routePortals';
 import { Route, Router } from '@shopgate/pwa-common/components';
@@ -77,7 +77,15 @@ import { themeComponents, legacyThemeAPI } from '../themeApi';
 import * as routes from './routes';
 import { routesTransforms } from './routesTransforms';
 
-const devFontsUrl = 'https://connect.shopgate.com/assets/fonts/roboto/font.css';
+const fallbackFontsUrl = 'https://connect.shopgate.com/assets/fonts/roboto/font.css';
+
+// Add fallback font on known OS that don't have default iOS theme fonts available
+const needsFallbackFont = isWindows || isLinux;
+
+// Include Roboto font as a fallback when other fonts are not available
+const fontFamily = (themeConfig.typography.family || '').includes('Roboto')
+  ? themeConfig.typography.family
+  : `${(themeConfig.typography.family || '')}, Roboto`;
 
 new ThemeConfigResolver().resolveAll();
 
@@ -102,7 +110,7 @@ const Pages = ({ store }) => {
 
     return createTheme({
       typography: {
-        fontFamily: themeConfig.typography.family,
+        fontFamily,
         ...extendedTypography,
       },
     });
@@ -311,9 +319,9 @@ const Pages = ({ store }) => {
                           {React.Children.map(routePortals, Component => Component)}
                         </Router>
                         {/** Load the Roboto for Windows developers so that they see a nice font */}
-                        {isDev && isWindows && (
+                        {needsFallbackFont && (
                         <Helmet>
-                          <link href={devFontsUrl} rel="stylesheet" />
+                          <link href={fallbackFontsUrl} rel="stylesheet" />
                         </Helmet>
                         )}
                       </Viewport>


### PR DESCRIPTION
# Description

This pull request adds Roboto as fallback font to the iOS theme. This should fix ugly typography inside the CMS preview when the next admin is opened on a desktop OS that doesn't support the default iOS theme fonts.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it
Open the PWA on Windows in Firefox (Edge seems to be shipped with Roboto).