### PR TITLE
Fix CategoryList sorting when sort config is not set

### DIFF
--- a/libraries/engage/page/widgets/CategoryList/hooks.js
+++ b/libraries/engage/page/widgets/CategoryList/hooks.js
@@ -9,11 +9,13 @@ import { getCategoriesById } from './selectors';
 /**
  * @typedef {Object} CategoryListWidgetConfig
  * @property {string} category The parent category ID to display categories for.
- * @property {string} [sort] The sort order for categories
+ * @property {'relevance' | 'nameAsc' | 'nameDesc'} [sort] The sort order for categories
  * @property {boolean} [showImages] Whether to display images for categories.
  * @property {boolean} [showHeadline] Whether to show the headline.
  * @property {Object} [headline] The headline to be displayed.
  */
+
+const EMPTY_ARRAY = [];
 
 /**
  * @typedef {ReturnType< typeof import('@shopgate/engage/page/hooks')
@@ -31,13 +33,11 @@ export const useCategoryListWidget = () => {
 
   const {
     category,
-    sort,
+    sort = 'relevance',
     showImages,
     showHeadline = false,
     headline,
   } = config;
-
-  const sortCC = useMemo(() => camelCase(sort), [sort]);
 
   // Get the parent category object from the selected category
   const parentCategory = useSelector(state =>
@@ -49,17 +49,21 @@ export const useCategoryListWidget = () => {
 
   const sortedCategories = useMemo(() => {
     if (!categories) {
-      return [];
+      return EMPTY_ARRAY;
     }
 
-    if (sortCC === 'relevance') {
-      return categories;
-    }
-    const isAsc = sortCC === 'nameAsc';
+    /** @type {CategoryListWidgetConfig['sort']} */
+    const sortCC = camelCase(sort);
 
-    return [...categories].sort((a, b) =>
-      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) * (isAsc ? 1 : -1));
-  }, [categories, sortCC]);
+    if (sortCC === 'nameAsc' || sortCC === 'nameDesc') {
+      const dir = sortCC === 'nameAsc' ? 1 : -1;
+
+      return [...categories].sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) * dir);
+    }
+
+    return categories;
+  }, [categories, sort]);
 
   useEffect(() => {
     dispatch(fetchCategoryOrRootCategories(category));


### PR DESCRIPTION
# Description
This pull request corrects the sorting logic in the `CategoryList` widget.

When the `sort` configuration was undefined or empty, the widget defaulted to sorting categories by name (descending), which was unintended. The logic has been adjusted so that categories are no longer re-sorted unless a valid sort option (`relevance`, `nameAsc`, `nameDesc`) is explicitly provided.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Please describe here any specialty that the tester should be aware of.
