### PR TITLE
Fix wrong empty results message for categories

### DIFF
--- a/libraries/commerce/product/reducers/resultsByHash.js
+++ b/libraries/commerce/product/reducers/resultsByHash.js
@@ -85,6 +85,7 @@ export default function resultsByHash(state = {}, action = {}) {
           ...state[action.hash],
           products: [],
           expires: 0,
+          totalResultCount: null,
         },
       };
     }

--- a/libraries/commerce/product/selectors/product.js
+++ b/libraries/commerce/product/selectors/product.js
@@ -890,6 +890,7 @@ export const getPopulatedProductsResult = (state, props, hash, result) => {
     sort,
     hash,
     expired,
+    isFetching: !!(result && result.isFetching),
   };
 };
 

--- a/themes/theme-gmd/pages/Category/components/Empty/selectors.js
+++ b/themes/theme-gmd/pages/Category/components/Empty/selectors.js
@@ -18,6 +18,10 @@ export const isCategoryEmpty = createSelector(
       return false;
     }
 
+    if (productCount === 0) {
+      return true;
+    }
+
     if (isFetching) {
       return false;
     }

--- a/themes/theme-gmd/pages/Category/components/Empty/selectors.js
+++ b/themes/theme-gmd/pages/Category/components/Empty/selectors.js
@@ -13,13 +13,17 @@ export const isCategoryEmpty = createSelector(
   getCategoryProductCount,
   getCategoryChildCount,
   getProductsResult,
-  (productCount, childrenCount, { products, totalProductCount }) => {
+  (productCount, childrenCount, { products, totalProductCount, isFetching }) => {
     if (childrenCount !== 0) {
       return false;
     }
 
-    if (productCount === 0) {
-      return true;
+    if (isFetching) {
+      return false;
+    }
+
+    if (productCount !== null && productCount > 0) {
+      return false;
     }
 
     if (totalProductCount !== null && products.length === 0) {

--- a/themes/theme-ios11/pages/Category/components/Empty/selectors.js
+++ b/themes/theme-ios11/pages/Category/components/Empty/selectors.js
@@ -18,6 +18,10 @@ export const isCategoryEmpty = createSelector(
       return false;
     }
 
+    if (productCount === 0) {
+      return true;
+    }
+
     if (isFetching) {
       return false;
     }

--- a/themes/theme-ios11/pages/Category/components/Empty/selectors.js
+++ b/themes/theme-ios11/pages/Category/components/Empty/selectors.js
@@ -13,13 +13,17 @@ export const isCategoryEmpty = createSelector(
   getCategoryProductCount,
   getCategoryChildCount,
   getProductsResult,
-  (productCount, childrenCount, { products, totalProductCount }) => {
+  (productCount, childrenCount, { products, totalProductCount, isFetching }) => {
     if (childrenCount !== 0) {
       return false;
     }
 
-    if (productCount === 0) {
-      return true;
+    if (isFetching) {
+      return false;
+    }
+
+    if (productCount !== null && productCount > 0) {
+      return false;
     }
 
     if (totalProductCount !== null && products.length === 0) {


### PR DESCRIPTION
# Description

We fixed a bug where sometimes items in a category do not appear directly, and until then the message "Ups! Keine Produkte gefunden." shows up. That message should not be displayed if a category contains items.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

