### PR TITLE
Fix fetchInventories request issues when called for too many products

### DIFF
--- a/libraries/engage/locations/subscriptions.js
+++ b/libraries/engage/locations/subscriptions.js
@@ -1,3 +1,4 @@
+import chunk from 'lodash/chunk';
 import {
   getProductsResult,
   productIsReady$, productsReceived$, productsReceivedCached$,
@@ -98,6 +99,8 @@ const setLocationOnceAvailable = async (locationCode, dispatch) => {
     // Location won't be set.
   }
 };
+
+const MAX_PRODUCT_CODES_PER_INVENTORY_REQUEST = 100;
 
 /**
  * Locations subscriptions.
@@ -346,7 +349,11 @@ function locationsSubscriber(subscribe) {
 
       const productCodes = products.map(({ id }) => id);
 
-      dispatch(fetchInventories(productCodes));
+      // fetchInventories requests for too many product codes can cause request errors, so we
+      // split them into chunked requests if necessary.
+      chunk(productCodes, MAX_PRODUCT_CODES_PER_INVENTORY_REQUEST).forEach((productCodesChunk) => {
+        dispatch(fetchInventories(productCodesChunk));
+      });
     }
   );
 
@@ -362,7 +369,11 @@ function locationsSubscriber(subscribe) {
     const productCodes = action.type !== RECEIVE_PRODUCTS_CACHED ?
       action.products.map(({ id }) => id) : action.products;
 
-    dispatch(fetchInventories(productCodes));
+    // fetchInventories requests for too many product codes can cause request errors, so we
+    // split them into chunked requests if necessary.
+    chunk(productCodes, MAX_PRODUCT_CODES_PER_INVENTORY_REQUEST).forEach((productCodesChunk) => {
+      dispatch(fetchInventories(productCodesChunk));
+    });
   });
 
   subscribe(
@@ -379,7 +390,11 @@ function locationsSubscriber(subscribe) {
         return;
       }
 
-      dispatch(fetchInventories(productIds));
+      // fetchInventories requests for too many product codes can cause request errors, so we
+      // split them into chunked requests if necessary.
+      chunk(productIds, MAX_PRODUCT_CODES_PER_INVENTORY_REQUEST).forEach((productIdsChunk) => {
+        dispatch(fetchInventories(productIdsChunk));
+      });
     }
   );
 


### PR DESCRIPTION
# Description

This pull request resolves request errors caused by dispatching `fetchInventories` with too many products at once. Inventory requests are now processed in chunks of up to 100 products to prevent oversized requests.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.
