### PR TITLE
Add support for new app event to handle links in iframes

### DIFF
--- a/libraries/common/subscriptions/router.js
+++ b/libraries/common/subscriptions/router.js
@@ -8,7 +8,7 @@ import {
 } from '@virtuous/conductor';
 import Route from '@virtuous/conductor/Route';
 import { HISTORY_RESET_TO } from '@shopgate/pwa-common/constants/ActionTypes';
-import { logger } from '@shopgate/pwa-core';
+import { logger, APP_EVENT_WINDOW_OPEN_REQUESTED, event } from '@shopgate/pwa-core';
 import { IS_PAGE_PREVIEW_ACTIVE } from '@shopgate/engage/page/constants';
 import addCouponsToCart from '@shopgate/pwa-common-commerce/cart/actions/addCouponsToCart';
 import { getCurrentRoute, getRouterStackIndex } from '../selectors/router';
@@ -328,6 +328,20 @@ export default function routerSubscriptions(subscribe) {
   });
 
   subscribe(appWillStart$, ({ dispatch }) => {
+    /**
+     * Register a listener to the APP_EVENT_WINDOW_OPEN_REQUESTED event which is emitted when e.g.
+     * and iFrame tries to open a link in a new window. The handler will perform a history push,
+     * so that the router can decide how to handle the URL.
+     */
+    event.addCallback(APP_EVENT_WINDOW_OPEN_REQUESTED, (payload) => {
+      const { targetUrl } = payload;
+
+      dispatch(historyPush({
+        pathname: targetUrl,
+        state: {},
+      }));
+    });
+
     const windowOpenOriginal = window.open;
     /**
      * Override for the window.open method which is usually used by external SDKs to open URLs.

--- a/libraries/common/subscriptions/router.js
+++ b/libraries/common/subscriptions/router.js
@@ -334,7 +334,7 @@ export default function routerSubscriptions(subscribe) {
      * and iFrame tries to open a link in a new window. The handler will perform a history push,
      * so that the router can decide how to handle the URL.
      */
-    Linking.addEventListener('onWindowOpenRequested', (event) => {
+    Linking.addEventListener('windowOpenRequested', (event) => {
       const { targetUrl } = event.detail;
 
       dispatch(historyPush({

--- a/libraries/common/subscriptions/router.js
+++ b/libraries/common/subscriptions/router.js
@@ -7,8 +7,9 @@ import {
   ACTION_RESET,
 } from '@virtuous/conductor';
 import Route from '@virtuous/conductor/Route';
+import { Linking } from '@shopgate/native-modules';
 import { HISTORY_RESET_TO } from '@shopgate/pwa-common/constants/ActionTypes';
-import { logger, APP_EVENT_WINDOW_OPEN_REQUESTED, event } from '@shopgate/pwa-core';
+import { logger } from '@shopgate/pwa-core';
 import { IS_PAGE_PREVIEW_ACTIVE } from '@shopgate/engage/page/constants';
 import addCouponsToCart from '@shopgate/pwa-common-commerce/cart/actions/addCouponsToCart';
 import { getCurrentRoute, getRouterStackIndex } from '../selectors/router';
@@ -333,8 +334,8 @@ export default function routerSubscriptions(subscribe) {
      * and iFrame tries to open a link in a new window. The handler will perform a history push,
      * so that the router can decide how to handle the URL.
      */
-    event.addCallback(APP_EVENT_WINDOW_OPEN_REQUESTED, (payload) => {
-      const { targetUrl } = payload;
+    Linking.addEventListener('onWindowOpenRequested', (event) => {
+      const { targetUrl } = event.detail;
 
       dispatch(historyPush({
         pathname: targetUrl,

--- a/libraries/core/constants/AppEvents.js
+++ b/libraries/core/constants/AppEvents.js
@@ -7,6 +7,7 @@ export const APP_EVENT_VIEW_DID_DISAPPEAR = 'viewDidDisappear';
 
 export const APP_EVENT_APPLICATION_WILL_ENTER_FOREGROUND = 'applicationWillEnterForeground';
 export const APP_EVENT_APPLICATION_DID_ENTER_BACKGROUND = 'applicationDidEnterBackground';
+export const APP_EVENT_WINDOW_OPEN_REQUESTED = 'windowOpenRequested';
 
 export const APP_EVENT_SCANNER_DID_SCAN = 'scannerDidScan';
 export const APP_EVENT_SCANNER_DID_APPEAR = 'scannerDidAppear';

--- a/libraries/core/constants/AppEvents.js
+++ b/libraries/core/constants/AppEvents.js
@@ -7,7 +7,6 @@ export const APP_EVENT_VIEW_DID_DISAPPEAR = 'viewDidDisappear';
 
 export const APP_EVENT_APPLICATION_WILL_ENTER_FOREGROUND = 'applicationWillEnterForeground';
 export const APP_EVENT_APPLICATION_DID_ENTER_BACKGROUND = 'applicationDidEnterBackground';
-export const APP_EVENT_WINDOW_OPEN_REQUESTED = 'windowOpenRequested';
 
 export const APP_EVENT_SCANNER_DID_SCAN = 'scannerDidScan';
 export const APP_EVENT_SCANNER_DID_APPEAR = 'scannerDidAppear';


### PR DESCRIPTION
# Description
This pull request introduces handling for the `windowOpenRequested` app event, which is triggered by the native webview when a link inside an iframe requests a new window (e.g. target="_blank" or window.open).

When this event is received, the target URL is intercepted and passed to the app router. The router then determines the appropriate handling strategy based on the URL.

By default, unhandled links are opened via the in-app browser, ensuring that iframe-initiated navigations no longer break the WebView or app flow.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [x] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.