### PR TITLE
Fix misaligned empty icons in cart, category, and search

### DIFF
--- a/libraries/engage/components/View/components/Content/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/libraries/engage/components/View/components/Content/__tests__/__snapshots__/index.spec.jsx.snap
@@ -18,12 +18,12 @@ exports[`engage > components > view > components > content should render content
     <div
       className={
         {
-          "data-css-18u3fb9": "",
+          "data-css-4yuqjm": "",
         }
       }
     >
       <div
-        className="engage__view__content__scrollable-content"
+        className="css-yagxrk engage__view__content__scrollable-content"
       >
         <HelmetWrapper
           defer={true}

--- a/libraries/engage/components/View/components/Content/index.jsx
+++ b/libraries/engage/components/View/components/Content/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
+import classNames from 'classnames';
 import ResponsiveContainer from '@shopgate/engage/components/ResponsiveContainer';
 import appConfig from '@shopgate/pwa-common/helpers/config';
 import event from '@shopgate/pwa-core/classes/Event';
@@ -14,7 +15,7 @@ import { ConditionalWrapper } from '../../../ConditionalWrapper';
 import Above from '../Above';
 import Below from '../Below';
 import ParallaxProvider from './components/ParallaxProvider';
-import { container, containerInner } from './style';
+import { container, containerInner, scrollableContent } from './style';
 
 /**
  * The ViewContent component.
@@ -200,7 +201,7 @@ class ViewContent extends Component {
         >
           <div className={containerInner}>
             {/** Class of this div is needed by the ParallaxProvider component */}
-            <div className="engage__view__content__scrollable-content">
+            <div className={classNames(scrollableContent, 'engage__view__content__scrollable-content')}>
               <Helmet title={appConfig.shopName} />
               <Above />
               <ResponsiveContainer breakpoint=">xs" webOnly>

--- a/libraries/engage/components/View/components/Content/style.js
+++ b/libraries/engage/components/View/components/Content/style.js
@@ -27,6 +27,9 @@ export const container = css({
 });
 
 export const containerInner = css({
+  display: 'flex',
+  flexGrow: 1,
+  flexDirection: 'column',
   ...isIOs && useScrollContainer() ? {
     // Make the scroll container content a bit higher than the actual scroll container to
     // get a rubber band effect in all situations
@@ -38,4 +41,10 @@ export const containerInner = css({
     pointerEvents: 'none',
     paddingBottom: 'calc(var(--page-content-offset-bottom) + var(--keyboard-height))',
   },
+});
+
+export const scrollableContent = css({
+  display: 'flex',
+  flexDirection: 'column',
+  flexGrow: 1,
 });


### PR DESCRIPTION
# Description

Fixed an issue where empty icons in the cart, category, and search views were not vertically centered.

## Type of change
- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Goto an empty cart, search for a search term that does't return products or filter a category by filters that don't match any products. You should see vertically centered "empty icons".

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes vertically misaligned empty-state icons in cart, category, and search views by propagating a `display: flex; flex-direction: column; flex-grow: 1` chain through the `ViewContent` layout — from `containerInner` down to the `scrollableContent` wrapper div.

- **`style.js`**: `containerInner` gains flex-column layout with `flexGrow: 1`, and a new `scrollableContent` export applies the same flex-column-grow pattern to the scrollable content div, allowing child empty-state components to vertically center themselves.
- **`index.jsx`**: The `scrollableContent` glamor class is combined with the required `engage__view__content__scrollable-content` string class via `classNames`, preserving the selector needed by `ParallaxProvider` while adding the new flex styles.
- **Snapshot**: Updated to reflect the new CSS class hash and the added glamor class on the scrollable content div.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are minimal and well-scoped to the layout chain in ViewContent.

Three small, focused changes: two CSS additions and a classNames call. The flex-column-grow chain correctly propagates through containerInner and scrollableContent without disrupting the iOS rubber-band minHeight, the :after bottom-spacing spacer, or the ParallaxProvider's required plain-string class. The snapshot is updated to match. No logic or data flow changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libraries/engage/components/View/components/Content/style.js | Adds flex-column-grow layout to containerInner and introduces new scrollableContent export; iOS minHeight behavior and :after spacer are unaffected. |
| libraries/engage/components/View/components/Content/index.jsx | Correctly wires the new scrollableContent style into the render via classNames, preserving the required plain-string class for ParallaxProvider. |
| libraries/engage/components/View/components/Content/__tests__/__snapshots__/index.spec.jsx.snap | Snapshot correctly updated to reflect new glamor hash on containerInner and added scrollableContent CSS class on the scrollable div. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["article.container\n(display:flex, flex-direction:column)"]
    B["div.containerInner\n(display:flex, flex-direction:column, flex-grow:1) NEW"]
    C["div.scrollableContent\n(display:flex, flex-direction:column, flex-grow:1) NEW"]
    D["Above / Children / Below"]
    E[":after (spacer)\n(padding-bottom: offset+keyboard)"]

    A --> B
    B --> C
    B --> E
    C --> D

    style B fill:#d4edda,stroke:#28a745
    style C fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (1): Last reviewed commit: ["CURB-5903 Updated snapshots"](https://github.com/shopgate/pwa/commit/09f08f06a1aad834a4bf1c75e4ff93bf53c1d10c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31944208)</sub>

<!-- /greptile_comment -->