### PR TITLE
Bugfix disappearing filter search bar

### DIFF
--- a/libraries/engage/components/ScrollHeader/index.jsx
+++ b/libraries/engage/components/ScrollHeader/index.jsx
@@ -48,7 +48,7 @@ function ScrollHeaderBase({
   // hidden when the user navigates back. `visible` is true only for the active route.
   const route = useRoute();
   const visible = route ? route.visible !== false : true;
-  console.log('AYAY: visible', visible);
+
   useScrollDirectionChange({
     enabled: hideOnScroll && visible,
     offset: scrollOffset,

--- a/libraries/engage/components/ScrollHeader/index.jsx
+++ b/libraries/engage/components/ScrollHeader/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState, forwardRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { useScrollDirectionChange } from '@shopgate/engage/core/hooks';
+import { useScrollDirectionChange, useRoute } from '@shopgate/engage/core/hooks';
 import {
   root, scrolledIn, scrolledOut, transition,
 } from './style';
@@ -42,8 +42,15 @@ function ScrollHeaderBase({
 }, ref) {
   const [shouldHideHeader, setShouldHideHeader] = useState(false);
 
+  // The `viewScroll$` stream is shared across all mounted views. Cached routes (e.g. a product
+  // list) stay mounted in the background while another route is active, so without this guard the
+  // header would react to scroll events emitted by a different, currently visible view and end up
+  // hidden when the user navigates back. `visible` is true only for the active route.
+  const route = useRoute();
+  const visible = route ? route.visible !== false : true;
+  console.log('AYAY: visible', visible);
   useScrollDirectionChange({
-    enabled: hideOnScroll,
+    enabled: hideOnScroll && visible,
     offset: scrollOffset,
     onlyFireOnScrollUpAtTop: onlyShowAtTop,
     onlyFireOnScrollUpAtTopOffset: onlyShowAtTopOffset,


### PR DESCRIPTION
# Description

This PR fixes a bug in the scroll header. The filter bar and search bar disappeared when navigating back from the product detail page to the product list. This happened because the scroll header component did not unsubscribe in the global stream via useScrollDirectionChange. Now, it checks which route is visible to receive the correct state.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Scroll on any pages which uses the scroll header and make sure it works as expected.
