### PR TITLE
CURB-6001: gate colour swatches behind swatches.enabled config

### DIFF
--- a/libraries/engage/core/__mocks__/index.js
+++ b/libraries/engage/core/__mocks__/index.js
@@ -9,6 +9,7 @@ export const useScrollContainer = () => true;
 export const withForwardedRef = jest.fn(Component => Component);
 export const hasWebBridge = () => false;
 export const isBeta = () => false;
+export const swatchesEnabled = () => false;
 export const isIOSTheme = () => false;
 export const getThemeSettings = () => {};
 export const grantCameraPermissions = jest.fn().mockResolvedValue(true);

--- a/libraries/engage/core/config/__tests__/swatchesEnabled.spec.js
+++ b/libraries/engage/core/config/__tests__/swatchesEnabled.spec.js
@@ -1,0 +1,30 @@
+import { swatchesEnabled } from '../swatchesEnabled';
+import { getThemeSettings } from '../getThemeSettings';
+
+jest.mock('../getThemeSettings', () => ({
+  getThemeSettings: jest.fn(),
+}));
+
+describe('engage > core > config', () => {
+  describe('swatchesEnabled()', () => {
+    it('should return false when the swatches setting is not available.', () => {
+      getThemeSettings.mockReturnValueOnce(undefined);
+      expect(swatchesEnabled()).toBe(false);
+    });
+
+    it('should return false when swatches.enabled is not explicitly true.', () => {
+      getThemeSettings.mockReturnValueOnce({ enabled: false });
+      expect(swatchesEnabled()).toBe(false);
+    });
+
+    it('should return false when swatches.enabled is missing.', () => {
+      getThemeSettings.mockReturnValueOnce({});
+      expect(swatchesEnabled()).toBe(false);
+    });
+
+    it('should return true when swatches.enabled is true.', () => {
+      getThemeSettings.mockReturnValueOnce({ enabled: true });
+      expect(swatchesEnabled()).toBe(true);
+    });
+  });
+});

--- a/libraries/engage/core/config/index.js
+++ b/libraries/engage/core/config/index.js
@@ -24,6 +24,7 @@ export {
 
 export { ThemeConfigResolver } from './ThemeConfigResolver';
 export { isBeta } from './isBeta';
+export { swatchesEnabled } from './swatchesEnabled';
 
 export { getPageConfig } from './getPageConfig';
 export { getPageSettings } from './getPageSettings';

--- a/libraries/engage/core/config/swatchesEnabled.js
+++ b/libraries/engage/core/config/swatchesEnabled.js
@@ -1,0 +1,10 @@
+import { getThemeSettings } from './getThemeSettings';
+
+/**
+ * Whether colour/image swatches are enabled for the shop.
+ * @returns {boolean}
+ */
+export function swatchesEnabled() {
+  const swatches = getThemeSettings('swatches');
+  return !!(swatches && swatches.enabled === true);
+}

--- a/libraries/engage/core/helpers/index.js
+++ b/libraries/engage/core/helpers/index.js
@@ -13,6 +13,7 @@ export * from './appPermissions';
 export * from './baseUrl';
 export * from './bridge';
 export { isBeta } from '../config/isBeta';
+export { swatchesEnabled } from '../config/swatchesEnabled';
 export { getFullImageSource } from './getFullImageSource';
 export { getImageFormat } from './getImageFormat';
 export { svgToDataUrl } from './svgToDataUrl';

--- a/libraries/engage/product/components/Characteristics/index.jsx
+++ b/libraries/engage/product/components/Characteristics/index.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { isBeta } from '@shopgate/engage/core';
+import { swatchesEnabled } from '@shopgate/engage/core';
 import { Portal } from '@shopgate/engage/components';
 import {
   PRODUCT_VARIANT_SELECT,
@@ -52,7 +52,7 @@ class Characteristics extends PureComponent {
    * @returns {JSX}
    */
   renderer = (props) => {
-    if (isBeta() && !!props.swatch) {
+    if (swatchesEnabled() && !!props.swatch) {
       return <Swatch {...props} />;
     }
     return <Characteristic {...props} />;

--- a/libraries/engage/product/components/Swatches/Swatches.jsx
+++ b/libraries/engage/product/components/Swatches/Swatches.jsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { PRODUCT_SWATCHES } from '@shopgate/pwa-common-commerce/product/constants/Portals';
 import { SurroundPortals } from '../../../components';
-import { isBeta, useWidgetSettings } from '../../../core';
+import { swatchesEnabled, useWidgetSettings } from '../../../core';
 import { Swatch } from '../Swatch';
 import { swatchesClass } from './style';
 import connect from './connector';
@@ -17,7 +17,7 @@ const WIDGET_ID = '@shopgate/engage/product/Swatches';
 const Swatches = ({ productId, characteristics }) => {
   const settings = useWidgetSettings(WIDGET_ID);
 
-  if (!isBeta()) {
+  if (!swatchesEnabled()) {
     return null;
   }
 
@@ -29,7 +29,7 @@ const Swatches = ({ productId, characteristics }) => {
   if (settings.filter && settings.filter.length) {
     swatches = swatches.filter(swatch => settings.filter.includes(swatch.id));
   }
-  if (!swatches) {
+  if (!swatches.length) {
     return null;
   }
 

--- a/libraries/engage/product/components/Swatches/Swatches.spec.jsx
+++ b/libraries/engage/product/components/Swatches/Swatches.spec.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { swatchesEnabled, useWidgetSettings } from '../../../core';
+import Swatches from './Swatches';
+
+jest.mock('@shopgate/engage/components');
+jest.mock('../../../core', () => ({
+  swatchesEnabled: jest.fn(),
+  useWidgetSettings: jest.fn(() => ({})),
+}));
+// Render the unconnected component by turning the connector into a pass-through HOC.
+jest.mock('./connector', () => Component => Component);
+jest.mock('../Swatch', () => ({
+  // eslint-disable-next-line react/prop-types
+  Swatch: ({ swatch }) => <div data-test-swatch={swatch.id} />,
+}));
+
+const characteristics = [
+  {
+    id: 'color',
+    label: 'Color',
+    swatch: true,
+    values: [
+      {
+        id: 'red',
+        label: 'Red',
+        swatch: { color: '#ff0000' },
+      },
+      {
+        id: 'blue',
+        label: 'Blue',
+        swatch: { color: '#0000ff' },
+      },
+    ],
+  },
+  {
+    id: 'size',
+    label: 'Size',
+    swatch: false,
+    values: [
+      {
+        id: 's',
+        label: 'S',
+      },
+      {
+        id: 'm',
+        label: 'M',
+      },
+    ],
+  },
+];
+
+describe('<Swatches />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useWidgetSettings.mockReturnValue({});
+  });
+
+  it('should render one Swatch per swatch characteristic when enabled', () => {
+    swatchesEnabled.mockReturnValue(true);
+
+    const wrapper = mount(<Swatches productId="123" characteristics={characteristics} />);
+
+    expect(wrapper.find('Swatch').length).toBe(1);
+  });
+
+  it('should render nothing when enabled but no characteristic is a swatch', () => {
+    swatchesEnabled.mockReturnValue(true);
+
+    const noSwatchCharacteristics = [
+      {
+        id: 'size',
+        label: 'Size',
+        swatch: false,
+        values: [
+          {
+            id: 's',
+            label: 'S',
+          },
+        ],
+      },
+    ];
+
+    const wrapper = mount(
+      <Swatches productId="123" characteristics={noSwatchCharacteristics} />
+    );
+
+    expect(wrapper.find('Swatch').length).toBe(0);
+    expect(wrapper.find('SurroundPortals').length).toBe(0);
+  });
+
+  it('should render nothing when swatches are disabled', () => {
+    swatchesEnabled.mockReturnValue(false);
+
+    const wrapper = mount(<Swatches productId="123" characteristics={characteristics} />);
+
+    expect(wrapper.find('Swatch').length).toBe(0);
+    expect(wrapper.find('SurroundPortals').length).toBe(0);
+  });
+});

--- a/libraries/engage/product/helpers/__tests__/index.spec.js
+++ b/libraries/engage/product/helpers/__tests__/index.spec.js
@@ -1,0 +1,123 @@
+import configuration from '@shopgate/pwa-common/collections/Configuration';
+import { DEFAULT_PRODUCTS_FETCH_PARAMS } from '@shopgate/pwa-common/constants/Configuration';
+import { isBeta, swatchesEnabled } from '@shopgate/engage/core/helpers';
+import { buildShowScheduledParams } from '../../components/EffectivityDates/helpers';
+import {
+  buildFetchCategoryProductsParams,
+  setDefaultProductFetchParams,
+} from '../index';
+
+jest.mock('@shopgate/pwa-common/collections/Configuration', () => ({
+  set: jest.fn(),
+}));
+
+jest.mock('@shopgate/engage/core/helpers', () => ({
+  getFullImageSource: jest.fn(),
+  loadImage: jest.fn(),
+  isBeta: jest.fn(),
+  swatchesEnabled: jest.fn(),
+}));
+
+jest.mock('@shopgate/engage/core/config', () => ({
+  getThemeSettings: jest.fn(),
+}));
+
+jest.mock('../../components/EffectivityDates/helpers', () => ({
+  buildShowScheduledParams: jest.fn(),
+}));
+
+jest.mock('@shopgate/pwa-common-commerce/product/helpers', () => ({}), { virtual: true });
+jest.mock('../../components/Media/helpers', () => ({}), { virtual: true });
+jest.mock('../redirects', () => ({}), { virtual: true });
+
+describe('engage > product > helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('buildFetchCategoryProductsParams()', () => {
+    it('returns empty params when beta is off and swatches are off', () => {
+      isBeta.mockReturnValue(false);
+      swatchesEnabled.mockReturnValue(false);
+
+      expect(buildFetchCategoryProductsParams()).toEqual({ params: {} });
+      // EffectivityDates is not consulted when beta is off
+      expect(buildShowScheduledParams).not.toHaveBeenCalled();
+    });
+
+    it('returns characteristics only when beta is off and swatches are on', () => {
+      isBeta.mockReturnValue(false);
+      swatchesEnabled.mockReturnValue(true);
+
+      expect(buildFetchCategoryProductsParams()).toEqual({
+        params: { characteristics: true },
+      });
+      expect(buildShowScheduledParams).not.toHaveBeenCalled();
+    });
+
+    it('includes scheduled params but not characteristics when beta is on and swatches are off', () => {
+      isBeta.mockReturnValue(true);
+      swatchesEnabled.mockReturnValue(false);
+      buildShowScheduledParams.mockReturnValue({
+        params: { showScheduled: 'P1Y' },
+      });
+
+      const result = buildFetchCategoryProductsParams();
+
+      expect(result).toEqual({ params: { showScheduled: 'P1Y' } });
+      expect(result.params).not.toHaveProperty('characteristics');
+    });
+
+    it('includes both characteristics and scheduled params when beta and swatches are both on', () => {
+      isBeta.mockReturnValue(true);
+      swatchesEnabled.mockReturnValue(true);
+      buildShowScheduledParams.mockReturnValue({
+        params: { showScheduled: 'P1Y' },
+      });
+
+      expect(buildFetchCategoryProductsParams()).toEqual({
+        params: {
+          characteristics: true,
+          showScheduled: 'P1Y',
+        },
+      });
+    });
+
+    it('adds cachedTime from the scheduled EffectivityDates params when present', () => {
+      isBeta.mockReturnValue(true);
+      swatchesEnabled.mockReturnValue(true);
+      buildShowScheduledParams.mockReturnValue({
+        cachedTime: 60000,
+        params: { showScheduled: 'PT0S' },
+      });
+
+      expect(buildFetchCategoryProductsParams()).toEqual({
+        params: {
+          characteristics: true,
+          showScheduled: 'PT0S',
+        },
+        cachedTime: 60000,
+      });
+    });
+  });
+
+  describe('setDefaultProductFetchParams()', () => {
+    it('is a no-op when swatches are off', () => {
+      swatchesEnabled.mockReturnValue(false);
+
+      setDefaultProductFetchParams();
+
+      expect(configuration.set).not.toHaveBeenCalled();
+    });
+
+    it('sets the characteristics default params when swatches are on', () => {
+      swatchesEnabled.mockReturnValue(true);
+
+      setDefaultProductFetchParams();
+
+      expect(configuration.set).toHaveBeenCalledWith(DEFAULT_PRODUCTS_FETCH_PARAMS, {
+        characteristics: true,
+      });
+    });
+  });
+});

--- a/libraries/engage/product/helpers/index.js
+++ b/libraries/engage/product/helpers/index.js
@@ -1,6 +1,8 @@
 import configuration from '@shopgate/pwa-common/collections/Configuration';
 import { DEFAULT_PRODUCTS_FETCH_PARAMS } from '@shopgate/pwa-common/constants/Configuration';
-import { getFullImageSource, isBeta, loadImage } from '@shopgate/engage/core/helpers';
+import {
+  getFullImageSource, isBeta, loadImage, swatchesEnabled,
+} from '@shopgate/engage/core/helpers';
 import { getThemeSettings } from '@shopgate/engage/core/config';
 import { buildShowScheduledParams } from '../components/EffectivityDates/helpers';
 
@@ -13,17 +15,21 @@ export * from './redirects';
  * @returns {undefined|{params: Object}}
  */
 export const buildFetchCategoryProductsParams = () => {
+  const params = {};
+
+  if (swatchesEnabled()) {
+    params.characteristics = true;
+  }
+
   if (!isBeta()) {
-    return {
-      params: {},
-    };
+    return { params };
   }
 
   const scheduled = buildShowScheduledParams();
 
   return {
     params: {
-      characteristics: true,
+      ...params,
       ...scheduled.params,
     },
     ...scheduled.cachedTime && { cachedTime: scheduled.cachedTime },
@@ -40,7 +46,7 @@ export const buildFetchSearchResultsParams = buildFetchCategoryProductsParams;
  * Set default params for fetching products
  */
 export const setDefaultProductFetchParams = () => {
-  if (!isBeta()) {
+  if (!swatchesEnabled()) {
     return;
   }
   configuration.set(DEFAULT_PRODUCTS_FETCH_PARAMS, {


### PR DESCRIPTION
implements: https://jira.shopgate.guru/browse/CURB-6001

Frontend slice of colour-swatches feature CURB-6000. Replaces the three swatch-specific `isBeta()` checks with a dedicated `swatches.enabled` config flag (default **OFF**), with no change to how swatches look or behave.

## Changes
- **New `swatchesEnabled()` helper** (`core/config/swatchesEnabled.js`) reading `appConfig.theme.settings.swatches.enabled` (default OFF), exported via `core/config`, `core/helpers`, and the manual mock — mirrors the existing `isBeta` helper, so it maps 1:1 onto a future Boolean `configInput`.
- **PLP / slider render gate** (`Swatches.jsx`) and **PDP variant-select render gate** (`Characteristics/index.jsx`) swapped from `isBeta()` → `swatchesEnabled()`.
- **Empty-array render fix** in `Swatches.jsx`: `!swatches` → `!swatches.length` (a filtered array is always truthy, so a no-swatch shop rendered an empty container/portal).
- **Data-fetch gate** in `product/helpers/index.js`: `characteristics: true` in `buildFetchCategoryProductsParams()` and `setDefaultProductFetchParams()` now gated on `swatchesEnabled()`, while the **EffectivityDates** `scheduled` params remain gated on `isBeta()` (the two concerns were previously bundled).

The global `appConfig.beta` flag and all other beta features are untouched; `theme-gmd` is not changed.

## Behaviour
- **Flag OFF (= today):** PLP product requests omit characteristics; no swatch markup renders anywhere — byte-for-byte current behaviour for non-swatch shops.
- **Flag ON + swatch data:** colour/image swatches render on lists, sliders and PDP exactly as behind the beta flag today.
- A product with no swatch characteristics renders nothing (no empty container).

## Tests
- `swatchesEnabled.spec.js` — default-OFF semantics.
- `Swatches.spec.jsx` — renders when enabled + data; nothing when the swatch list is empty; nothing when disabled.
- `product/helpers/__tests__/index.spec.js` — `buildFetchCategoryProductsParams` across the beta×swatches matrix (incl. EffectivityDates `scheduled` staying on `isBeta()`) + `setDefaultProductFetchParams`.

> Note: the PLP data-fetch gate lives in engage helpers, not the theme — the theme-side `includeCharacteristics` arg is dropped by the page connector (dead since PWA-1902), so the originally-planned theme ticket (CURB-6002) was superseded by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)