### PR TITLE
Fix image render issue in CMS preview

### DIFF
--- a/libraries/engage/development/components/ClientInformation/ClientInformation.jsx
+++ b/libraries/engage/development/components/ClientInformation/ClientInformation.jsx
@@ -64,7 +64,7 @@ const ClientInformation = () => {
       <p className={classes.unselectable}>
         {`App Version: ${appVersion} (${codebaseVersion})`}
         <br />
-        {`PWA Version: ${pckVersion}`}
+        {`Theme Version: ${pckVersion}`}
         <br />
         {`Lib Version: ${libVersion}`}
       </p>

--- a/libraries/engage/page/components/ResponsiveWidgetImage/ResponsiveWidgetImage.jsx
+++ b/libraries/engage/page/components/ResponsiveWidgetImage/ResponsiveWidgetImage.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles, useResponsiveValue } from '@shopgate/engage/styles';
 import { useParallax } from 'react-scroll-parallax';
+import { IS_PAGE_PREVIEW_ACTIVE } from '../../constants';
 import { parseImageUrl } from '../../helpers';
 
 /**
@@ -33,6 +34,8 @@ const useStyles = makeStyles()({
   },
   image: {
     width: '100%',
+    height: 'auto',
+    display: 'block',
   },
   container: {
     width: '100%',
@@ -140,7 +143,11 @@ const ResponsiveWidgetImage = ({
         src={imgSrc}
         ref={parallax.ref}
         alt={alt}
-        loading="lazy"
+        // In the CMS page-preview iframe, native lazy loading defers the image load after the admin
+        // re-posts an updated page config and never triggers it again, so widget images stay at
+        // height 0 until a resize forces the browser to re-evaluate. Load eagerly there; keep lazy
+        // loading for the live app.
+        loading={IS_PAGE_PREVIEW_ACTIVE ? 'eager' : 'lazy'}
         className={cx(classes.preventSave, classes.image, {
           [classes.banner]: isBanner,
         }, className)}

--- a/libraries/engage/page/components/Widgets/Widgets.jsx
+++ b/libraries/engage/page/components/Widgets/Widgets.jsx
@@ -4,6 +4,7 @@ import { makeStyles } from '@shopgate/engage/styles';
 import { useRoute, useThemeWidgets } from '@shopgate/engage/core/hooks';
 import { PAGE_PREVIEW_PATTERN } from '@shopgate/engage/page/constants';
 import { ConditionalWrapper } from '@shopgate/engage/components';
+import { isDev } from '@shopgate/engage/core/helpers';
 import WidgetsPreviewProvider from './WidgetsPreviewProvider';
 import Widget from './Widget';
 import Overlay from './Overlay';
@@ -82,7 +83,7 @@ const Widgets = ({
       >
         {widgets.map((widget) => {
           const component = widgetComponents[widget.widgetConfigDefinitionCode] ||
-          widgetComponents[PLACEHOLDER_COMPONENT];
+          (isDev ? widgetComponents[PLACEHOLDER_COMPONENT] : null);
 
           return <Widget
             key={widget.code}


### PR DESCRIPTION
# Description

The images in the CMS didn't render in the preview and we fixed this issue. The problem was that the browser didn't calculate the image size and start the lazy loading process after the admin has loaded.

## Type of change

- [x] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [ ] Internal :house: Only relates to internal processes.

## How to test it

Test in CMS of the admin with an image widget in the preview.
