### PR TITLE
Simplify writing unit tests in extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ export FORCE_COLOR = true
 # If LIBRARIES or UTILS is extended and the npm package should not be prefixed with
 # "@shopgate/pwa-", then you need to modify the "get-npm-package-name" function below as well!
 LIBRARIES = engage commerce common core tracking tracking-core webcheckout ui-ios ui-material ui-shared
-TRANSPILED_UTILS = benchmark
-UTILS = eslint-config unit-tests e2e webpack
+TRANSPILED_UTILS = benchmark unit-tests
+UTILS = eslint-config e2e webpack
 THEMES = theme-gmd theme-ios11
 
 # Adds "@shopgate/pwa-" in front of all package names except "@shopgate/eslint-config" and "@shopgate/tracking-core".
@@ -163,19 +163,24 @@ endef
 release-dry-run:
 	@echo "Purging dist"
 	$(foreach library, $(LIBRARIES), $(call clean-npm-package, libraries, $(library))$(NL))
+	$(foreach transpiled_util, $(TRANSPILED_UTILS), $(call clean-npm-package, utils, $(transpiled_util))$(NL))
 	@echo "Running babel"
 	$(foreach library, $(LIBRARIES), $(call build-npm-package, libraries, $(library))$(NL))
+	$(foreach transpiled_util, $(TRANSPILED_UTILS), $(call build-npm-package, utils, $(transpiled_util))$(NL))
 	@echo "Normalizing dist"
 	$(foreach library, $(LIBRARIES), $(call normalize-build, libraries, $(library))$(NL))
+	$(foreach transpiled_util, $(TRANSPILED_UTILS), $(call normalize-build, utils, $(transpiled_util))$(NL))
 	@echo "You can check dist folder"
 
 release-normalize:
 	@echo "Normalizing dist"
 	$(foreach library, $(LIBRARIES), $(call normalize-build, libraries, $(library)))
+	$(foreach transpiled_util, $(TRANSPILED_UTILS), $(call normalize-build, utils, $(transpiled_util)))
 
 release-purge:
 	@echo "Purging dist"
 	$(foreach library, $(LIBRARIES), $(call clean-npm-package, libraries, $(library)))
+	$(foreach transpiled_util, $(TRANSPILED_UTILS), $(call clean-npm-package, utils, $(transpiled_util)))
 
 # Clean the repository before starting a release.
 clean:
@@ -376,12 +381,17 @@ define build-npm-package
 	fi;
 endef
 
-# tests,spec.js,spec.jsx,__snapshots__,.eslintrc.js,jest.config.js,dist,coverage,node_modules;
+# Removes everything from the build which is not meant to be published.
+# The --ignore patterns of the babel call above only match at the root of a package, and ignored
+# files are copied by --copy-files anyway, so test files have to be removed here.
+# Only the jest manual mocks in "__mocks__" folders are removed. Folders named "mocks" contain
+# fixtures which are shared with consumers like extensions, so they are published.
 define normalize-build
-	@-find ./$(strip $(1))/$(strip $(2))/dist -type d -name '*tests*' -exec rm -Rf {} \;
-	@-find ./$(strip $(1))/$(strip $(2))/dist -type d -name '*mocks*' -exec rm -Rf {} \;
-	@-find ./$(strip $(1))/$(strip $(2))/dist -type d -name '*snapshots*' -exec rm -Rf {} \;
-	@-find ./$(strip $(1))/$(strip $(2))/dist -type f -name '*.spec.*' -delete
+	@-find ./$(strip $(1))/$(strip $(2))/dist -type d \( -name '__tests__' -o -name 'tests' \) -exec rm -Rf {} \;
+	@-find ./$(strip $(1))/$(strip $(2))/dist -type d -name '__mocks__' -exec rm -Rf {} \;
+	@-find ./$(strip $(1))/$(strip $(2))/dist -type d -name '__snapshots__' -exec rm -Rf {} \;
+	@-find ./$(strip $(1))/$(strip $(2))/dist -type f \( -name '*.spec.*' -o -name 'spec.*' \) -delete
+	@-find ./$(strip $(1))/$(strip $(2))/dist -type f -name 'tsconfig*.json' -delete
 
 endef
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -63,18 +63,16 @@ module.exports = {
     ...skipPatterns,
   ],
   transformIgnorePatterns: [
-    'node_modules/(?!(swiper|dom7|intl-messageformat|@formatjs)/)',
+    // Spread the defaults, since they would be replaced otherwise
+    ...jestConfig.transformIgnorePatterns,
     '/themes/*/extensions/',
     '/themes/*/e2e/',
     '/dist/',
   ],
   moduleNameMapper: {
-    '\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js',
-    '\\.(css|less)$': '<rootDir>/__mocks__/fileMock.js',
-    // Fix issue with Swiper ES module imports that work via "exports" field in package.json
-    '^swiper/react$': '<rootDir>/node_modules/swiper/swiper-react.mjs',
-    // Mock Swiper styles since they are not needed for unit tests
-    '^swiper/css(?:/.*)?$': '<rootDir>/__mocks__/styleMock.js',
+    // Spread the defaults, since they would be replaced otherwise. They already cover styles,
+    // assets and the swiper mappings.
+    ...jestConfig.moduleNameMapper,
   },
   modulePathIgnorePatterns: [
     '<rootDir>/.*/dist/.*',

--- a/utils/unit-tests/.npmignore
+++ b/utils/unit-tests/.npmignore
@@ -1,0 +1,7 @@
+# Tests of this package are not part of the published package
+spec.js
+spec.jsx
+*.spec.js
+*.spec.jsx
+__tests__
+__snapshots__

--- a/utils/unit-tests/README.md
+++ b/utils/unit-tests/README.md
@@ -79,6 +79,56 @@ __NOTE: Options which hold an object or an array - like `moduleNameMapper`, `set
 default configuration first to keep it, as shown above. Without that, the mappings for styles and
 assets are lost, and imports of stylesheets or images within the tested components fail.__
 
+## Test utilities
+
+### `createMockStore`
+
+Creates a minimal Redux store for component tests. It implements the contract that `react-redux`
+relies on, without pulling in the reducers of the application:
+
+```js
+import { createMockStore } from '@shopgate/pwa-unit-test/testUtils';
+
+const store = createMockStore({ counter: 0 });
+
+mount(
+  <Provider store={store}>
+    <MyComponent />
+  </Provider>
+);
+```
+
+Dispatched actions are recorded, so they can be asserted on. `store.dispatch` is a jest mock:
+
+```js
+expect(store.getActions()).toEqual([{ type: 'INCREMENT' }]);
+expect(store.dispatch).toHaveBeenCalledWith({ type: 'INCREMENT' });
+
+store.clearActions();
+```
+
+__NOTE: `getActions()` reads the recorded calls of the `dispatch` mock, so a `jest.clearAllMocks()`
+- e.g. within a `beforeEach` - also clears the recorded actions. Create the store after that call,
+or use `store.clearActions()` to reset only this store.__
+
+By default the state doesn't change when an action is dispatched, which keeps it predictable. Use
+`setState` to simulate a state change - the subscribers are notified, so connected components
+re-render:
+
+```js
+store.setState({ counter: 5 });
+store.setState(current => ({ counter: current.counter + 1 }));
+```
+
+Pass a reducer as second argument to also apply dispatched actions to the state, e.g. to assert
+what a component renders after it dispatched something:
+
+```js
+const store = createMockStore({ counter: 0 }, (state, action) => (
+  action.type === 'INCREMENT' ? { counter: state.counter + 1 } : state
+));
+```
+
 ## About Shopgate
 
 Shopgate is the leading mobile commerce platform.

--- a/utils/unit-tests/README.md
+++ b/utils/unit-tests/README.md
@@ -66,11 +66,18 @@ const defaultConfig = require('@shopgate/pwa-unit-test/jest.config');
 module.exports = {
   ...defaultConfig,
   moduleNameMapper: {
-    '^Components(.*)$': '<rootDir>/components',
-    '^Styles(.*)$': '<rootDir>/styles',
+    // Keep the default mappings - they would be replaced otherwise
+    ...defaultConfig.moduleNameMapper,
+    '^Components(.*)$': '<rootDir>/components$1',
+    '^Styles(.*)$': '<rootDir>/styles$1',
   },
 };
 ```
+
+__NOTE: Options which hold an object or an array - like `moduleNameMapper`, `setupFiles` or
+`transformIgnorePatterns` - are replaced and not merged when they are set. Spread the value of the
+default configuration first to keep it, as shown above. Without that, the mappings for styles and
+assets are lost, and imports of stylesheets or images within the tested components fail.__
 
 ## About Shopgate
 

--- a/utils/unit-tests/jest.config.js
+++ b/utils/unit-tests/jest.config.js
@@ -12,6 +12,8 @@ const babelOptions = {
 };
 const babelTransform = [babelJest, babelOptions];
 
+const stylesMock = require.resolve('./mocks/styles.js');
+
 /** @type {import('jest').Config} */
 module.exports = {
   testEnvironment: 'jsdom',
@@ -19,9 +21,13 @@ module.exports = {
   moduleFileExtensions: ['js', 'jsx', 'json', 'mjs', 'ts', 'tsx'],
   moduleNameMapper: {
     // Mock styles since they are not needed for unit tests
-    '\\.(css|sass)$': '<rootDir>/__mocks__/styleMock.js',
+    '\\.(css|sass|scss|less)$': stylesMock,
+    // Mock assets since they are not needed for unit tests
+    '\\.(jpg|jpeg|png|gif|webp|svg|ico|eot|otf|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': require.resolve('./mocks/assets.js'),
     // Fix issue with Swiper ES module imports that work via "exports" field in package.json
     '^swiper/react$': '<rootDir>/node_modules/swiper/swiper-react.mjs',
+    // Mock Swiper styles - they are imported without a file extension
+    '^swiper/css(?:/.*)?$': stylesMock,
   },
   transform: {
     '^.+\\.jsx?$': babelTransform,
@@ -38,8 +44,11 @@ module.exports = {
     '/coverage/',
     '/config/',
   ],
+  // @shopgate packages are published untranspiled, so they need to be transformed as well. Within
+  // this repository they are symlinked to their sources outside of node_modules, which is why the
+  // missing entry didn't surface here, but only within extensions which install them for real.
   transformIgnorePatterns: [
-    'node_modules/(?!(swiper|dom7|intl-messageformat|@formatjs|tslib)/)',
+    'node_modules/(?!(@shopgate|swiper|dom7|intl-messageformat|@formatjs|tslib)/)',
   ],
   unmockedModulePathPatterns: [
     'node_modules/react/',

--- a/utils/unit-tests/jest.config.js
+++ b/utils/unit-tests/jest.config.js
@@ -14,6 +14,18 @@ const babelTransform = [babelJest, babelOptions];
 
 const stylesMock = require.resolve('./mocks/styles.js');
 
+/**
+ * Swiper exposes its React build via the "exports" field of its package.json, which jest can't
+ * resolve. Mapping it to the concrete file fixes that. Resolving it from this package works for
+ * consumers as well, and only falls back to the rootDir of the consumer when swiper is installed
+ * somewhere this package can't reach.
+ */
+let swiperReact = '<rootDir>/node_modules/swiper/swiper-react.mjs';
+
+try {
+  swiperReact = require.resolve('swiper/react');
+} catch (e) { /* swiper is not installed */ }
+
 /** @type {import('jest').Config} */
 module.exports = {
   testEnvironment: 'jsdom',
@@ -24,8 +36,7 @@ module.exports = {
     '\\.(css|sass|scss|less)$': stylesMock,
     // Mock assets since they are not needed for unit tests
     '\\.(jpg|jpeg|png|gif|webp|svg|ico|eot|otf|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': require.resolve('./mocks/assets.js'),
-    // Fix issue with Swiper ES module imports that work via "exports" field in package.json
-    '^swiper/react$': '<rootDir>/node_modules/swiper/swiper-react.mjs',
+    '^swiper/react$': swiperReact,
     // Mock Swiper styles - they are imported without a file extension
     '^swiper/css(?:/.*)?$': stylesMock,
   },

--- a/utils/unit-tests/mocks/appCommand.js
+++ b/utils/unit-tests/mocks/appCommand.js
@@ -1,0 +1,73 @@
+/**
+ * Mock for @shopgate/pwa-core/classes/AppCommand.
+ *
+ * The published packages don't contain their __mocks__ folders, so consumers like extensions can't
+ * rely on the manual mock of the package itself. Without a chainable mock the app commands that
+ * are dispatched on module level - e.g. by the Scanner class - throw as soon as a component from
+ * @shopgate/engage is imported.
+ */
+let dispatchError = false;
+
+const mockedSetCommandName = jest.fn(name => name);
+const mockedSetCommandParams = jest.fn(params => params);
+const mockedSetLibVersion = jest.fn(version => version);
+const mockedBuildCommand = jest.fn(command => command);
+const mockedDispatch = jest.fn(params => params);
+
+/**
+ * Causes that the dispatch method resolves with FALSE.
+ * @param {boolean} value Trigger an error or not.
+ */
+const triggerDispatchError = (value = true) => {
+  dispatchError = value;
+};
+
+const mockedAppCommand = jest.fn().mockImplementation(function MockedAppCommand() {
+  this.name = '';
+  this.params = null;
+  this.libVersion = '9.0';
+
+  this.setCommandName = (name) => {
+    this.name = mockedSetCommandName(name);
+    return this;
+  };
+
+  this.setCommandParams = (params) => {
+    this.params = mockedSetCommandParams(params);
+    return this;
+  };
+
+  this.setLibVersion = (version) => {
+    this.libVersion = mockedSetLibVersion(version);
+    return this;
+  };
+
+  this.buildCommand = () => {
+    const command = this.name ? {
+      c: this.name,
+      ...this.params && { p: this.params },
+    } : null;
+
+    return mockedBuildCommand(command);
+  };
+
+  this.dispatch = (params) => {
+    mockedDispatch(params);
+    const success = !dispatchError;
+    dispatchError = false;
+    return Promise.resolve(success);
+  };
+
+  return this;
+});
+
+module.exports = {
+  __esModule: true,
+  default: mockedAppCommand,
+  mockedSetCommandName,
+  mockedSetCommandParams,
+  mockedSetLibVersion,
+  mockedBuildCommand,
+  mockedDispatch,
+  triggerDispatchError,
+};

--- a/utils/unit-tests/mocks/assets.js
+++ b/utils/unit-tests/mocks/assets.js
@@ -1,7 +1,7 @@
 /**
  * Replacement for asset imports (images, fonts, media) which are irrelevant for unit tests.
  *
- * Written in CommonJS on purpose, so that it also works for consumers which don't transform files
- * within their node_modules folder.
+ * Written in CommonJS on purpose, so that the mapping also works for consumers which replaced the
+ * transformIgnorePatterns of this package with ones that don't transform @shopgate packages.
  */
 module.exports = '';

--- a/utils/unit-tests/mocks/assets.js
+++ b/utils/unit-tests/mocks/assets.js
@@ -1,0 +1,7 @@
+/**
+ * Replacement for asset imports (images, fonts, media) which are irrelevant for unit tests.
+ *
+ * Written in CommonJS on purpose, so that it also works for consumers which don't transform files
+ * within their node_modules folder.
+ */
+module.exports = '';

--- a/utils/unit-tests/mocks/i18n.js
+++ b/utils/unit-tests/mocks/i18n.js
@@ -1,0 +1,25 @@
+/**
+ * Mock for @shopgate/engage/core/helpers/i18n.
+ *
+ * The published packages don't contain their __mocks__ folders, so consumers like extensions can't
+ * rely on the manual mock of the package itself. Without it the translation helpers are not
+ * initialized, so components which render a translated string don't work.
+ */
+const i18n = {
+  ready: true,
+  init: () => {},
+  text: input => input || '',
+  price: () => 'p',
+  number: () => 'n',
+  date: () => 'd',
+  time: () => 't',
+  getLang: () => 'de-DE',
+  getPath: path => path,
+  has: path => typeof path === 'string' && /^\S+\.\S+/.test(path),
+};
+
+module.exports = {
+  __esModule: true,
+  i18n,
+  getWeekDaysOrder: () => ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+};

--- a/utils/unit-tests/mocks/styles.js
+++ b/utils/unit-tests/mocks/styles.js
@@ -1,0 +1,7 @@
+/**
+ * Replacement for style imports which are irrelevant for unit tests.
+ *
+ * Written in CommonJS on purpose, so that it also works for consumers which don't transform files
+ * within their node_modules folder.
+ */
+module.exports = {};

--- a/utils/unit-tests/mocks/styles.js
+++ b/utils/unit-tests/mocks/styles.js
@@ -1,7 +1,7 @@
 /**
  * Replacement for style imports which are irrelevant for unit tests.
  *
- * Written in CommonJS on purpose, so that it also works for consumers which don't transform files
- * within their node_modules folder.
+ * Written in CommonJS on purpose, so that the mapping also works for consumers which replaced the
+ * transformIgnorePatterns of this package with ones that don't transform @shopgate packages.
  */
 module.exports = {};

--- a/utils/unit-tests/mocks/useTheme.js
+++ b/utils/unit-tests/mocks/useTheme.js
@@ -1,0 +1,18 @@
+/**
+ * Mock for @shopgate/engage/styles/theme/hooks/useTheme.
+ *
+ * The published packages don't contain their __mocks__ folders, so consumers like extensions can't
+ * rely on the manual mock of the package itself. Without a theme object the styles of components
+ * from @shopgate/pwa-ui-shared throw when they access theme values.
+ *
+ * The theme is created with the published createTheme helper, so this mock doesn't need to
+ * duplicate any theme defaults.
+ */
+const { createTheme } = require('@shopgate/engage/styles/theme/createTheme');
+
+const theme = createTheme({});
+
+module.exports = {
+  __esModule: true,
+  default: () => theme,
+};

--- a/utils/unit-tests/package.json
+++ b/utils/unit-tests/package.json
@@ -22,9 +22,13 @@
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.19",
+    "@types/jest": "^29.5.14",
+    "@types/react": "^17.0.83",
     "jest": "^29.7.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-redux": "^8.1.3",
+    "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "jest": "^29.7.0",

--- a/utils/unit-tests/testSetup.js
+++ b/utils/unit-tests/testSetup.js
@@ -4,6 +4,22 @@ const Adapter = require('@wojtekmaj/enzyme-adapter-react-17');
 Enzyme.configure({ adapter: new Adapter() });
 
 /**
+ * Checks whether a module can be resolved. Consumers of this package don't necessarily have all
+ * of the mocked packages installed, and jest.mock() resolves the module path even when a factory
+ * is passed, so mocking an absent module would break the whole setup.
+ * @param {string} modulePath Path of the module.
+ * @returns {boolean} Whether the module can be resolved.
+ */
+const canResolve = (modulePath) => {
+  try {
+    require.resolve(modulePath);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+/**
  * The mocks below are provided by this package instead of relying on the manual __mocks__ folders
  * of the mocked packages. Those folders are stripped from the published packages, so consumers
  * like extensions would silently fall back to automocks, which breaks as soon as a component from
@@ -15,7 +31,40 @@ Enzyme.configure({ adapter: new Adapter() });
 /* eslint-disable global-require */
 
 // Mock the translation helpers, since they are not initialized during test runs
-jest.mock('@shopgate/engage/core/helpers/i18n', () => require('./mocks/i18n'));
+if (canResolve('@shopgate/engage/core/helpers/i18n')) {
+  jest.mock('@shopgate/engage/core/helpers/i18n', () => require('./mocks/i18n'));
+}
+
+// Mock the AppCommand class by default to avoid log spamming during test runs
+if (canResolve('@shopgate/pwa-core/classes/AppCommand')) {
+  jest.mock('@shopgate/pwa-core/classes/AppCommand', () => require('./mocks/appCommand'));
+}
+
+// Mock the useTheme hook to prevent failing tests due to missing theme object
+if (canResolve('@shopgate/engage/styles/theme/hooks/useTheme')) {
+  jest.mock('@shopgate/engage/styles/theme/hooks/useTheme', () => require('./mocks/useTheme'));
+}
+
+// Mock the media provider styles to prevent failing tests
+if (canResolve('@shopgate/pwa-common/collections/media-providers/style')) {
+  jest.mock('@shopgate/pwa-common/collections/media-providers/style', () => ({
+    responsiveContainer: 'responsiveContainer',
+    consentContainer: 'consentContainer',
+    consentLink: 'consentLink',
+    consentIcon: 'consentIcon',
+  }));
+}
+
+// The themes are not installed for consumers like extensions. They can't be mocked virtually,
+// since a virtual mock is only applied to imports which use this exact module path.
+if (canResolve('@shopgate/theme-gmd/extensions/reducers')) {
+  jest.mock('@shopgate/theme-gmd/extensions/reducers', () => null);
+}
+
+if (canResolve('@shopgate/theme-ios11/extensions/reducers')) {
+  jest.mock('@shopgate/theme-ios11/extensions/reducers', () => null);
+}
+/* eslint-enable global-require */
 
 const localStorageMock = (() => {
   let store = {};
@@ -34,34 +83,3 @@ const localStorageMock = (() => {
 })();
 
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
-
-// Mock the AppCommand class by default to avoid log spamming during test runs
-jest.mock('@shopgate/pwa-core/classes/AppCommand', () => require('./mocks/appCommand'));
-
-// Mock the extension reducers of the themes when they are available. Consumers like extensions
-// don't have the themes installed, where resolving them would throw. They can't be mocked
-// virtually, since a virtual mock is only applied to imports which use this exact module path.
-[
-  '@shopgate/theme-gmd/extensions/reducers',
-  '@shopgate/theme-ios11/extensions/reducers',
-].forEach((modulePath) => {
-  try {
-    require.resolve(modulePath);
-  } catch (e) {
-    return;
-  }
-
-  jest.mock(modulePath, () => null);
-});
-
-// Mock the media provider styles to prevent failing tests
-jest.mock('@shopgate/pwa-common/collections/media-providers/style', () => ({
-  responsiveContainer: 'responsiveContainer',
-  consentContainer: 'consentContainer',
-  consentLink: 'consentLink',
-  consentIcon: 'consentIcon',
-}));
-
-// Mock the useTheme hook to prevent failing tests due to missing theme object
-jest.mock('@shopgate/engage/styles/theme/hooks/useTheme', () => require('./mocks/useTheme'));
-/* eslint-enable global-require */

--- a/utils/unit-tests/testSetup.js
+++ b/utils/unit-tests/testSetup.js
@@ -3,7 +3,19 @@ const Adapter = require('@wojtekmaj/enzyme-adapter-react-17');
 
 Enzyme.configure({ adapter: new Adapter() });
 
-jest.mock('@shopgate/engage/core/helpers/i18n');
+/**
+ * The mocks below are provided by this package instead of relying on the manual __mocks__ folders
+ * of the mocked packages. Those folders are stripped from the published packages, so consumers
+ * like extensions would silently fall back to automocks, which breaks as soon as a component from
+ * @shopgate/engage is imported.
+ *
+ * The mock factories have to require their module lazily and inline, which is enforced by
+ * babel-plugin-jest-hoist.
+ */
+/* eslint-disable global-require */
+
+// Mock the translation helpers, since they are not initialized during test runs
+jest.mock('@shopgate/engage/core/helpers/i18n', () => require('./mocks/i18n'));
 
 const localStorageMock = (() => {
   let store = {};
@@ -24,9 +36,23 @@ const localStorageMock = (() => {
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 
 // Mock the AppCommand class by default to avoid log spamming during test runs
-jest.mock('@shopgate/pwa-core/classes/AppCommand');
-jest.mock('@shopgate/theme-gmd/extensions/reducers', () => null);
-jest.mock('@shopgate/theme-ios11/extensions/reducers', () => null);
+jest.mock('@shopgate/pwa-core/classes/AppCommand', () => require('./mocks/appCommand'));
+
+// Mock the extension reducers of the themes when they are available. Consumers like extensions
+// don't have the themes installed, where resolving them would throw. They can't be mocked
+// virtually, since a virtual mock is only applied to imports which use this exact module path.
+[
+  '@shopgate/theme-gmd/extensions/reducers',
+  '@shopgate/theme-ios11/extensions/reducers',
+].forEach((modulePath) => {
+  try {
+    require.resolve(modulePath);
+  } catch (e) {
+    return;
+  }
+
+  jest.mock(modulePath, () => null);
+});
 
 // Mock the media provider styles to prevent failing tests
 jest.mock('@shopgate/pwa-common/collections/media-providers/style', () => ({
@@ -37,4 +63,5 @@ jest.mock('@shopgate/pwa-common/collections/media-providers/style', () => ({
 }));
 
 // Mock the useTheme hook to prevent failing tests due to missing theme object
-jest.mock('@shopgate/engage/styles/theme/hooks/useTheme');
+jest.mock('@shopgate/engage/styles/theme/hooks/useTheme', () => require('./mocks/useTheme'));
+/* eslint-enable global-require */

--- a/utils/unit-tests/testUtils/createMockStore.ts
+++ b/utils/unit-tests/testUtils/createMockStore.ts
@@ -3,8 +3,17 @@
  *
  * This module is only meant to be imported from test files, since it uses the jest globals.
  */
+import type { Observable, Reducer, Store } from 'redux';
 
 type Listener = () => void;
+
+/**
+ * Symbol.observable is not part of the language, so redux resolves it with a string fallback. The
+ * same fallback is needed here - without it the computed property key would be undefined, and the
+ * store wouldn't fulfill the contract it claims to.
+ */
+const $$observable = ((typeof Symbol === 'function' && Symbol.observable)
+  || '@@observable') as typeof Symbol.observable;
 
 /** An action which was dispatched to the store. */
 export interface MockAction {
@@ -15,13 +24,13 @@ export interface MockAction {
 /** Reducer which is applied to the dispatched actions. */
 export type MockReducer<S> = (state: S, action: MockAction) => S;
 
-export interface MockStore<S> {
-  /** Returns the current state. */
-  getState: () => S;
+/**
+ * A store which satisfies the Store contract of redux, so that it can be passed to the Provider
+ * of react-redux without a cast, extended by the helpers which are useful within tests.
+ */
+export interface MockStore<S> extends Store<S, MockAction> {
   /** Records every dispatched action. Assert on it like on any other jest mock. */
-  dispatch: jest.Mock<MockAction, [MockAction]>;
-  /** Registers a listener which is invoked whenever the state changed. Returns an unsubscribe. */
-  subscribe: (listener: Listener) => () => void;
+  dispatch: jest.Mock<MockAction, [MockAction]> & Store<S, MockAction>['dispatch'];
   /** Replaces the state and notifies the subscribers, so connected components re-render. */
   setState: (next: S | ((current: S) => S)) => void;
   /** Returns the dispatched actions in the order they were dispatched. */
@@ -46,6 +55,7 @@ export const createMockStore = <S>(
   reducer?: MockReducer<S>
 ): MockStore<S> => {
   let state = initialState;
+  let currentReducer = reducer;
   const listeners = new Set<Listener>();
 
   /**
@@ -58,25 +68,64 @@ export const createMockStore = <S>(
   };
 
   const dispatch = jest.fn((action: MockAction): MockAction => {
-    if (reducer) {
-      state = reducer(state, action);
+    if (currentReducer) {
+      state = currentReducer(state, action);
       notify();
     }
 
     return action;
   });
 
-  return {
-    getState: () => state,
-    dispatch,
-    subscribe: (listener: Listener) => {
-      listeners.add(listener);
+  const subscribe = (listener: Listener) => {
+    listeners.add(listener);
 
-      return () => {
-        listeners.delete(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  const getState = () => state;
+
+  /**
+   * Part of the redux Store contract. Tests don't observe the store, so this only satisfies the
+   * interface.
+   * @returns The observable of the store.
+   */
+  const observable = (): Observable<S> => ({
+    subscribe: (observer) => {
+      /**
+       * Forwards the current state to the observer.
+       */
+      const handleChange = () => {
+        if (observer.next) {
+          observer.next(getState());
+        }
       };
+
+      handleChange();
+
+      return { unsubscribe: subscribe(handleChange) };
     },
-    setState: (next) => {
+    [$$observable]() {
+      return this;
+    },
+  } as Observable<S>);
+
+  /**
+   * redux declares Symbol.observable as a plain symbol, so TypeScript widens the computed key to
+   * a symbol index and can't verify that this exact member is implemented. The assertion is only
+   * needed for that key - the store is verified against the contract in the spec.
+   */
+  return {
+    getState,
+    dispatch: dispatch as MockStore<S>['dispatch'],
+    subscribe,
+    replaceReducer: (nextReducer: Reducer<S, MockAction>) => {
+      currentReducer = nextReducer as MockReducer<S>;
+      notify();
+    },
+    [$$observable]: observable,
+    setState: (next: S | ((current: S) => S)) => {
       state = typeof next === 'function' ? (next as (current: S) => S)(state) : next;
       notify();
     },
@@ -84,5 +133,5 @@ export const createMockStore = <S>(
     clearActions: () => {
       dispatch.mockClear();
     },
-  };
+  } as unknown as MockStore<S>;
 };

--- a/utils/unit-tests/testUtils/createMockStore.ts
+++ b/utils/unit-tests/testUtils/createMockStore.ts
@@ -1,0 +1,88 @@
+/**
+ * Minimal Redux store for component tests.
+ *
+ * This module is only meant to be imported from test files, since it uses the jest globals.
+ */
+
+type Listener = () => void;
+
+/** An action which was dispatched to the store. */
+export interface MockAction {
+  type: string;
+  [key: string]: unknown;
+}
+
+/** Reducer which is applied to the dispatched actions. */
+export type MockReducer<S> = (state: S, action: MockAction) => S;
+
+export interface MockStore<S> {
+  /** Returns the current state. */
+  getState: () => S;
+  /** Records every dispatched action. Assert on it like on any other jest mock. */
+  dispatch: jest.Mock<MockAction, [MockAction]>;
+  /** Registers a listener which is invoked whenever the state changed. Returns an unsubscribe. */
+  subscribe: (listener: Listener) => () => void;
+  /** Replaces the state and notifies the subscribers, so connected components re-render. */
+  setState: (next: S | ((current: S) => S)) => void;
+  /** Returns the dispatched actions in the order they were dispatched. */
+  getActions: () => MockAction[];
+  /** Forgets all recorded actions. */
+  clearActions: () => void;
+}
+
+/**
+ * Creates a Redux store for component tests. It implements the contract that react-redux relies on
+ * - getState, dispatch and subscribe - without pulling in the reducers of the application.
+ *
+ * By default dispatched actions are only recorded, which keeps the state predictable while
+ * asserting that a component dispatches the right action. Pass a reducer to also apply the
+ * dispatched actions to the state, e.g. to assert what a component renders afterwards.
+ * @param initialState The state the store starts with.
+ * @param reducer Optional reducer which is applied to dispatched actions.
+ * @returns The mocked store.
+ */
+export const createMockStore = <S>(
+  initialState: S,
+  reducer?: MockReducer<S>
+): MockStore<S> => {
+  let state = initialState;
+  const listeners = new Set<Listener>();
+
+  /**
+   * Notifies all subscribers about a state change.
+   */
+  const notify = (): void => {
+    listeners.forEach((listener) => {
+      listener();
+    });
+  };
+
+  const dispatch = jest.fn((action: MockAction): MockAction => {
+    if (reducer) {
+      state = reducer(state, action);
+      notify();
+    }
+
+    return action;
+  });
+
+  return {
+    getState: () => state,
+    dispatch,
+    subscribe: (listener: Listener) => {
+      listeners.add(listener);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    setState: (next) => {
+      state = typeof next === 'function' ? (next as (current: S) => S)(state) : next;
+      notify();
+    },
+    getActions: () => dispatch.mock.calls.map(([action]) => action),
+    clearActions: () => {
+      dispatch.mockClear();
+    },
+  };
+};

--- a/utils/unit-tests/testUtils/index.ts
+++ b/utils/unit-tests/testUtils/index.ts
@@ -1,0 +1,1 @@
+export * from './createMockStore';

--- a/utils/unit-tests/testUtils/spec.tsx
+++ b/utils/unit-tests/testUtils/spec.tsx
@@ -1,0 +1,149 @@
+/* eslint-disable extra-rules/no-single-line-objects */
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider, useDispatch, useSelector } from 'react-redux';
+import { createMockStore } from './createMockStore';
+import type { MockAction } from './createMockStore';
+
+interface TestState {
+  counter: number;
+}
+
+/**
+ * Component which reads from and dispatches to the store, to verify that the mocked store
+ * satisfies what react-redux expects from a store.
+ * @returns The rendered component.
+ */
+const Counter = () => {
+  const counter = useSelector((state: TestState) => state.counter);
+  const dispatch = useDispatch();
+
+  return (
+    <button type="button" onClick={() => dispatch({ type: 'INCREMENT' })}>
+      {counter}
+    </button>
+  );
+};
+
+/**
+ * Reducer which increments the counter.
+ * @param state The current state.
+ * @param action The dispatched action.
+ * @returns The new state.
+ */
+const reducer = (state: TestState, action: MockAction): TestState =>
+  (action.type === 'INCREMENT' ? { counter: state.counter + 1 } : state);
+
+describe('createMockStore()', () => {
+  it('should expose the initial state', () => {
+    expect(createMockStore({ counter: 1 }).getState()).toEqual({ counter: 1 });
+  });
+
+  it('should record dispatched actions', () => {
+    const store = createMockStore({ counter: 0 });
+
+    store.dispatch({ type: 'FIRST' });
+    store.dispatch({ type: 'SECOND', payload: 42 });
+
+    expect(store.dispatch).toHaveBeenCalledTimes(2);
+    expect(store.getActions()).toEqual([
+      { type: 'FIRST' },
+      { type: 'SECOND', payload: 42 },
+    ]);
+  });
+
+  it('should forget recorded actions', () => {
+    const store = createMockStore({ counter: 0 });
+
+    store.dispatch({ type: 'FIRST' });
+    store.clearActions();
+
+    expect(store.getActions()).toEqual([]);
+  });
+
+  it('should not change the state without a reducer', () => {
+    const store = createMockStore({ counter: 0 });
+
+    store.dispatch({ type: 'INCREMENT' });
+
+    expect(store.getState()).toEqual({ counter: 0 });
+  });
+
+  it('should notify subscribers when the state is replaced', () => {
+    const store = createMockStore({ counter: 0 });
+    const listener = jest.fn();
+
+    store.subscribe(listener);
+    store.setState({ counter: 5 });
+
+    expect(store.getState()).toEqual({ counter: 5 });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('should support updating the state based on the current one', () => {
+    const store = createMockStore({ counter: 1 });
+
+    store.setState(current => ({ counter: current.counter + 1 }));
+
+    expect(store.getState()).toEqual({ counter: 2 });
+  });
+
+  it('should stop notifying after unsubscribing', () => {
+    const store = createMockStore({ counter: 0 });
+    const listener = jest.fn();
+
+    store.subscribe(listener)();
+    store.setState({ counter: 1 });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should apply dispatched actions to the state when a reducer is passed', () => {
+    const store = createMockStore({ counter: 0 }, reducer);
+
+    store.dispatch({ type: 'INCREMENT' });
+
+    expect(store.getState()).toEqual({ counter: 1 });
+  });
+
+  describe('within react-redux', () => {
+    it('should provide the state to a connected component', () => {
+      const store = createMockStore<TestState>({ counter: 7 });
+
+      const wrapper = mount(
+        <Provider store={store as never}>
+          <Counter />
+        </Provider>
+      );
+
+      expect(wrapper.find('button').text()).toBe('7');
+    });
+
+    it('should record actions which a connected component dispatches', () => {
+      const store = createMockStore<TestState>({ counter: 0 });
+
+      mount(
+        <Provider store={store as never}>
+          <Counter />
+        </Provider>
+      ).find('button').simulate('click');
+
+      expect(store.getActions()).toEqual([{ type: 'INCREMENT' }]);
+    });
+
+    it('should re-render a connected component when the state changes', () => {
+      const store = createMockStore<TestState>({ counter: 0 }, reducer);
+
+      const wrapper = mount(
+        <Provider store={store as never}>
+          <Counter />
+        </Provider>
+      );
+
+      wrapper.find('button').simulate('click');
+
+      expect(wrapper.find('button').text()).toBe('1');
+    });
+  });
+});
+/* eslint-enable extra-rules/no-single-line-objects */

--- a/utils/unit-tests/testUtils/spec.tsx
+++ b/utils/unit-tests/testUtils/spec.tsx
@@ -98,6 +98,34 @@ describe('createMockStore()', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  it('should fulfill the store contract of redux', () => {
+    const store = createMockStore({ counter: 0 });
+    // redux resolves the observable symbol with a string fallback
+    const observableKey = (typeof Symbol === 'function' && Symbol.observable) || '@@observable';
+
+    expect(typeof store.getState).toBe('function');
+    expect(typeof store.dispatch).toBe('function');
+    expect(typeof store.subscribe).toBe('function');
+    expect(typeof store.replaceReducer).toBe('function');
+    const members = store as unknown as Record<string | symbol, unknown>;
+
+    expect(typeof members[observableKey]).toBe('function');
+    // a missing Symbol.observable fallback would produce a key of "undefined"
+    expect(Object.keys(store)).not.toContain('undefined');
+  });
+
+  it('should apply the reducer which replaceReducer was called with', () => {
+    const store = createMockStore({ counter: 0 });
+
+    // replaceReducer takes a redux reducer, where the state can be undefined
+    // eslint-disable-next-line default-param-last
+    store.replaceReducer((state = { counter: 0 }, action) =>
+      (action.type === 'INCREMENT' ? { counter: state.counter + 1 } : state));
+    store.dispatch({ type: 'INCREMENT' });
+
+    expect(store.getState()).toEqual({ counter: 1 });
+  });
+
   it('should apply dispatched actions to the state when a reducer is passed', () => {
     const store = createMockStore({ counter: 0 }, reducer);
 
@@ -111,7 +139,7 @@ describe('createMockStore()', () => {
       const store = createMockStore<TestState>({ counter: 7 });
 
       const wrapper = mount(
-        <Provider store={store as never}>
+        <Provider store={store}>
           <Counter />
         </Provider>
       );
@@ -123,7 +151,7 @@ describe('createMockStore()', () => {
       const store = createMockStore<TestState>({ counter: 0 });
 
       mount(
-        <Provider store={store as never}>
+        <Provider store={store}>
           <Counter />
         </Provider>
       ).find('button').simulate('click');
@@ -135,7 +163,7 @@ describe('createMockStore()', () => {
       const store = createMockStore<TestState>({ counter: 0 }, reducer);
 
       const wrapper = mount(
-        <Provider store={store as never}>
+        <Provider store={store}>
           <Counter />
         </Provider>
       );

--- a/utils/unit-tests/tsconfig.build.json
+++ b/utils/unit-tests/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "noEmit": false,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.spec.*",
+    "**/spec.*",
+    "**/__tests__/**",
+    "**/__snapshots__/**",
+    "coverage"
+  ]
+}

--- a/utils/unit-tests/tsconfig.json
+++ b/utils/unit-tests/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "lib": ["DOM", "ES2019"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+
+    "skipLibCheck": true,
+
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["dist", "node_modules", "coverage"]
+}


### PR DESCRIPTION
# Description

Makes `@shopgate/pwa-unit-test` usable from within an extension. Until now an extension could
install the package, but its default config didn't work outside of this repository, so every
extension had to work around it locally.

Three fixes were needed:

- `transformIgnorePatterns` didn't include `@shopgate`. The packages are published untranspiled, so
  their ESM reached the CommonJS loader unchanged. Within this repository they are symlinked to
  sources outside of `node_modules`, which is why it only surfaced in extensions.
- `moduleNameMapper` pointed at `<rootDir>/__mocks__/styleMock.js`, which only exists here. Styles
  and assets are now mocked from within the package, and `swiper/css` / `swiper/react` are resolved
  instead of hardcoded.
- `testSetup.js` mocked `AppCommand`, `useTheme` and `i18n` without a factory, which relied on the
  `__mocks__` folders of those packages - those are stripped on release, so extensions silently
  fell back to automocks. Importing anything from `@shopgate/engage` then threw. The mocks now ship
  with this package, and each `jest.mock()` is guarded so consumers without the mocked package
  installed are not broken.

Also adds `createMockStore` under `@shopgate/pwa-unit-test/testUtils` - a minimal Redux store for
component tests, so extensions don't have to hand-roll one. The package is transpiled on release
now (`TRANSPILED_UTILS`) and ships type declarations.

The root `jest.config.js` was spreading nothing from the defaults, so the new mappings would never
have been exercised here. It now spreads them - see the new README note.

**Note:** `normalize-build` no longer strips every `*mocks*` folder, only `__mocks__`. Folders named
`mocks` hold fixtures which are meant to be shared, so `libraries/engage/mocks`,
`libraries/common/helpers/mocks` and `libraries/engage/product/selectors/mocks` (7 files) are
published from now on.

## Type of change

- [x] Enhancement :rocket: (non-breaking change which adds functionality)

## How to test it

`yarn test` in the repository root - everything stays green (509 suites, 2876 tests, 614 snapshots).

To verify the actual goal, build and install the package into an extension:

```
make release-dry-run
cp -R utils/unit-tests/dist <extension>/frontend/node_modules/@shopgate/pwa-unit-test
```

The extension's `frontend/jest.config.js` can then be reduced to

```js
module.exports = require('@shopgate/pwa-unit-test/jest.config');
```

and `yarn test` passes. Verified with `ext-recharge-subscriptions`, whose local `jest-shim/`
workaround folder becomes obsolete and can be deleted in a follow-up.