### PR TITLE
Reworked cms preview iFrame origin validation

### DIFF
--- a/libraries/engage/page/components/Widgets/__tests__/helpers.spec.js
+++ b/libraries/engage/page/components/Widgets/__tests__/helpers.spec.js
@@ -1,0 +1,51 @@
+import { ALLOWED_PAGE_PREVIEW_ORIGINS } from '../constants';
+import { isAllowedOrigin } from '../helpers';
+
+describe('engage > page > components > Widgets > helpers', () => {
+  describe('isAllowedOrigin()', () => {
+    it('should match origins without a wildcard exactly', () => {
+      expect(isAllowedOrigin('http://localhost:1337', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(true);
+      expect(isAllowedOrigin('http://localhost:1338', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+      expect(isAllowedOrigin('https://localhost:1337', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+    });
+
+    it('should match sub domains at any depth', () => {
+      expect(isAllowedOrigin('https://app.shopgate.com', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(true);
+      expect(isAllowedOrigin('https://admin-mono-us.shopgate.com', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(true);
+      expect(isAllowedOrigin('https://next.us.admin.shopgate.com', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(true);
+      expect(isAllowedOrigin('https://app.shopgatedev.com', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(true);
+      expect(isAllowedOrigin('https://app.shopgatepg.com', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(true);
+    });
+
+    it('should not match the bare domain of a wildcard pattern', () => {
+      expect(isAllowedOrigin('https://shopgate.com', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+    });
+
+    it('should not match origins that only contain an allowed domain', () => {
+      expect(isAllowedOrigin('https://app.shopgate.com.attacker.example', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+      expect(isAllowedOrigin('https://attacker.example/app.shopgate.com', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+      expect(isAllowedOrigin('https://shopgateXcom', ['https://*.shopgate.com'])).toBe(false);
+      expect(isAllowedOrigin('https://app.myshopgate.com', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+    });
+
+    it('should enforce the scheme of a wildcard pattern', () => {
+      expect(isAllowedOrigin('http://app.shopgate.com', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+    });
+
+    it('should not match a port that was not part of the pattern', () => {
+      expect(isAllowedOrigin('https://app.shopgate.com:8443', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+    });
+
+    it('should reject values that are no usable origins', () => {
+      expect(isAllowedOrigin('null', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+      expect(isAllowedOrigin('', ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+      expect(isAllowedOrigin(undefined, ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+      expect(isAllowedOrigin(null, ALLOWED_PAGE_PREVIEW_ORIGINS)).toBe(false);
+    });
+
+    it('should reject every origin when no patterns are given', () => {
+      expect(isAllowedOrigin('https://app.shopgate.com')).toBe(false);
+      expect(isAllowedOrigin('https://app.shopgate.com', [])).toBe(false);
+    });
+  });
+});

--- a/libraries/engage/page/components/Widgets/constants.js
+++ b/libraries/engage/page/components/Widgets/constants.js
@@ -1,7 +1,8 @@
 /**
- * List of allowed origin patterns for cms page preview iFrame communication. Incoming messages are
- * only processed when their origin matches one of these patterns, and outgoing messages are only
- * posted to origins that matched before.
+ * List of allowed origin patterns for cms page preview iFrame communication. Both directions are
+ * validated against these patterns: incoming messages are only processed when their origin matches,
+ * and outgoing messages are only posted to a matching origin - either the origin of the last
+ * accepted incoming message, or the origin of the embedding document.
  *
  * A "*" acts as a wildcard for one or more domain labels, so "https://*.shopgate.com" matches
  * "https://app.shopgate.com" as well as "https://next.us.admin.shopgate.com", but neither

--- a/libraries/engage/page/components/Widgets/constants.js
+++ b/libraries/engage/page/components/Widgets/constants.js
@@ -1,15 +1,17 @@
 /**
- * List of allowed origins for cms page preview iFrame communication.
+ * List of allowed origin patterns for cms page preview iFrame communication. Incoming messages are
+ * only processed when their origin matches one of these patterns, and outgoing messages are only
+ * posted to origins that matched before.
+ *
+ * A "*" acts as a wildcard for one or more domain labels, so "https://*.shopgate.com" matches
+ * "https://app.shopgate.com" as well as "https://next.us.admin.shopgate.com", but neither
+ * "https://shopgate.com" nor "https://evil.shopgate.com.attacker.example". Every other character
+ * is matched literally, which means that scheme and port always have to match exactly.
  */
 export const ALLOWED_PAGE_PREVIEW_ORIGINS = [
-  'https://next.admin.shopgatedev.com',
-  'https://next.admin.shopgatepg.com',
-  'https://next.admin.shopgate.com',
-  'https://next.us.admin.shopgate.com',
-  'https://admin-mono.shopgatedev.com',
-  'https://admin-mono.shopgatepg.com',
-  'https://admin-mono.shopgate.com',
-  'https://admin-mono-us.shopgate.com',
+  'https://*.shopgate.com',
+  'https://*.shopgatedev.com',
+  'https://*.shopgatepg.com',
   'http://localhost.localdev.cc',
   'http://localhost:1337',
 ];

--- a/libraries/engage/page/components/Widgets/helpers.js
+++ b/libraries/engage/page/components/Widgets/helpers.js
@@ -50,3 +50,65 @@ export function checkScheduled({ from, to, timezoneOffset } = {}) {
     isExpired,
   };
 }
+
+/**
+ * Regular expression source that a "*" within an allowed origin pattern is replaced with. It
+ * matches one or more domain labels, but never a dot at the very end, so that the suffix of the
+ * pattern stays anchored to the end of the origin.
+ */
+const ORIGIN_WILDCARD_SOURCE = '(?:[a-zA-Z0-9-]+\\.)*[a-zA-Z0-9-]+';
+
+// Cache for regular expressions that were already created from an origin pattern.
+const originPatternCache = new Map();
+
+/**
+ * Converts an allowed origin pattern into an anchored regular expression. Every character except
+ * the "*" wildcard is matched literally.
+ * @param {string} pattern The origin pattern e.g. "https://*.shopgate.com".
+ * @returns {RegExp} The regular expression for the pattern.
+ */
+const createOriginRegExp = (pattern) => {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^${escaped.split('\\*').join(ORIGIN_WILDCARD_SOURCE)}$`);
+};
+
+/**
+ * Checks if an origin is covered by a list of allowed origin patterns.
+ * @param {string} origin The origin to check e.g. "https://app.shopgate.com".
+ * @param {Array<string>} [patterns] The allowed origin patterns.
+ * @returns {boolean} Whether the origin is allowed.
+ */
+export const isAllowedOrigin = (origin, patterns = []) => {
+  // Opaque origins are serialized as "null" and must never be trusted.
+  if (typeof origin !== 'string' || origin === '' || origin === 'null') {
+    return false;
+  }
+
+  return patterns.some((pattern) => {
+    if (typeof pattern !== 'string' || pattern === '') {
+      return false;
+    }
+
+    if (!pattern.includes('*')) {
+      return pattern === origin;
+    }
+
+    if (!originPatternCache.has(pattern)) {
+      originPatternCache.set(pattern, createOriginRegExp(pattern));
+    }
+
+    return originPatternCache.get(pattern).test(origin);
+  });
+};
+
+/**
+ * Determines the origin of the document that embeds the current page.
+ * @returns {string|null} The referrer origin, or null when it can't be determined.
+ */
+export const getReferrerOrigin = () => {
+  try {
+    return new URL(document.referrer).origin;
+  } catch (e) {
+    return null;
+  }
+};

--- a/libraries/engage/page/components/Widgets/hooks.js
+++ b/libraries/engage/page/components/Widgets/hooks.js
@@ -141,6 +141,11 @@ export const usePreviewIframeCommunication = (isActive = false) => {
   }, [considerContainerMarginsOnScroll]);
 
   const { sendToParent } = useIframeMessenger((data) => {
+    // Allowed parents can also emit unrelated messages with arbitrary payloads.
+    if (typeof data !== 'object' || data === null) {
+      return;
+    }
+
     if (data.type === 'receivePageConfig') {
       // Page preview config received from the parent window.
       dispatch(receivePageConfigV2({

--- a/libraries/engage/page/components/Widgets/hooks.js
+++ b/libraries/engage/page/components/Widgets/hooks.js
@@ -10,7 +10,7 @@ import {
   ALLOWED_PAGE_PREVIEW_ORIGINS,
   CONSIDER_CONTAINER_MARGINS_ON_SCROLL_DEFAULT,
 } from './constants';
-import { getScrollContainer } from './helpers';
+import { getScrollContainer, isAllowedOrigin, getReferrerOrigin } from './helpers';
 import { WidgetsPreviewContext } from './WidgetsPreviewContext';
 import {
   dispatchWidgetPreviewEvent,
@@ -34,22 +34,26 @@ import {
 /**
  * Hook for postMessage communication when your component is inside an iframe.
  *
- * Listens on window for "message" events from any origin in parentOrigins,
- * and only calls onMessage(data, rawEvent) if both origin and source match.
+ * Listens on window for "message" events, and only calls onMessage(data, rawEvent) if the origin
+ * of the event is covered by parentOrigins and the message actually came from window.parent.
  *
  * @param {function(MessageData, any): void} onMessage
  *   Callback invoked when a trusted message arrives. Receives data and the
  *   raw event (so you can inspect origin, source, etc.).
  * @param {string[]} parentOrigins
- *   Array of allowed parent origin strings (e.g.
- *   ['https://a.example.com','https://b.example.com']).
+ *   Array of allowed parent origin patterns (e.g.
+ *   ['https://a.example.com','https://*.example.com']). See ALLOWED_PAGE_PREVIEW_ORIGINS for
+ *   details about the supported wildcard syntax.
+ * @param {boolean} [enabled]
+ *   Whether the message listener is supposed to be attached.
  * @returns {IframeMessengerResult}
  *   An object with a single method:
  *   • sendToParent(data, [targetOrigin]): void
  *     – Posts data up to window.parent. By default it uses the most recently
- *       seen origin (from an incoming message). If none, uses parentOrigins[0].
+ *       seen origin (from an incoming message), otherwise the origin of the embedding document.
+ *       Nothing is sent when neither of them is covered by parentOrigins.
  */
-function useIframeMessenger(onMessage, parentOrigins) {
+function useIframeMessenger(onMessage, parentOrigins, enabled = true) {
   // Keep a ref to the latest onMessage callback so the listener always has it.
   const onMessageRef = useRef(onMessage);
   useEffect(() => {
@@ -63,22 +67,20 @@ function useIframeMessenger(onMessage, parentOrigins) {
    * Send a message up to the parent window.
    * @param {MessageData} data       - The data object to post.
    * @param {string}      [targetOrigin]
-   *   Optional override for the origin to post to. Must be one of
-   *   parentOrigins. If omitted, uses the last seen origin (lastOriginRef),
-   *   or parentOrigins[0], or "*" if array is empty.
+   *   Optional override for the origin to post to. Must be covered by parentOrigins. If omitted,
+   *   the last seen origin (lastOriginRef) or the origin of the embedding document is used.
    */
   const sendToParent = useCallback(
     (data, targetOrigin) => {
-      // Determine which origin to use: explicit, then last seen, then first, then "*".
-      const originToUse =
-        typeof targetOrigin === 'string'
-          ? targetOrigin
-          : lastOriginRef.current || new URL(document.referrer).origin || parentOrigins[0] || '*';
+      // Determine which origin to use: explicit, then last seen, then the embedding document.
+      // Patterns are no valid postMessage targets, so an unresolved origin aborts the send.
+      const originToUse = [targetOrigin, lastOriginRef.current, getReferrerOrigin()]
+        .find(origin => isAllowedOrigin(origin, parentOrigins));
 
       if (!originToUse) {
         logger.warn(
-          'useIframeMessenger: no targetOrigin available. ' +
-            'Provide parentOrigins or pass targetOrigin.'
+          'useIframeMessenger: no allowed targetOrigin available. ' +
+            'Provide parentOrigins or pass an allowed targetOrigin.'
         );
         return;
       }
@@ -90,13 +92,17 @@ function useIframeMessenger(onMessage, parentOrigins) {
 
   // Attach / detach the "message" listener.
   useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
     /**
      * Handler for incoming postMessage events.
      * @param {any} rawEvent  – The original MessageEvent object.
      */
     function handler(rawEvent) {
-      // Only proceed if the origin is in our whitelist.
-      if (!parentOrigins.includes(rawEvent.origin)) return;
+      // Only proceed if the origin is covered by our whitelist.
+      if (!isAllowedOrigin(rawEvent.origin, parentOrigins)) return;
       // Ensure the message actually came from window.parent.
       if (rawEvent.source !== window.parent) return;
 
@@ -111,7 +117,7 @@ function useIframeMessenger(onMessage, parentOrigins) {
     return () => {
       window.removeEventListener('message', handler);
     };
-  }, [parentOrigins, sendToParent]);
+  }, [enabled, parentOrigins, sendToParent]);
 
   return { sendToParent };
 }
@@ -208,7 +214,7 @@ export const usePreviewIframeCommunication = (isActive = false) => {
         });
       }
     }
-  }, ALLOWED_PAGE_PREVIEW_ORIGINS);
+  }, ALLOWED_PAGE_PREVIEW_ORIGINS, isActive);
 
   useWidgetPreviewEvent('widget-clicked', (e) => {
     if (!isActive) {

--- a/libraries/engage/page/components/Widgets/hooks.js
+++ b/libraries/engage/page/components/Widgets/hooks.js
@@ -117,7 +117,7 @@ function useIframeMessenger(onMessage, parentOrigins, enabled = true) {
     return () => {
       window.removeEventListener('message', handler);
     };
-  }, [enabled, parentOrigins, sendToParent]);
+  }, [enabled, parentOrigins]);
 
   return { sendToParent };
 }


### PR DESCRIPTION
# Description

The CMS page preview validated the origin of its iFrame messages against a hardcoded list of exact
admin URLs. Every new admin hostname required adding an entry and releasing the PWA — most recently
the four `app.*` domains.

The list is now made up of wildcard patterns (`https://*.shopgate.com` and the dev/pg equivalents),
which covers all current and future admin hostnames and shrinks the list from 14 entries to 5.

While in there, three related issues in the messaging layer were fixed:

- Outgoing messages fell back to `parentOrigins[0]` and ultimately `'*'`, which posted to whatever
  site framed the preview. Every target origin is now validated, and nothing is sent if none
  resolves.
- `new URL(document.referrer).origin` threw a `TypeError` when the referrer was empty.
- The `message` listener was attached on every page that renders widgets. It is now only attached
  in preview mode.

Wildcard matching is anchored at both ends and escapes all other characters, so scheme and port
still have to match exactly and `https://app.shopgate.com.attacker.example` is rejected. Unit tests
cover the matcher.

## Type of change

- [ ] Bug Fix :bug: (non-breaking change which fixes an issue)
- [ ] Enhancement :rocket: (non-breaking change which adds functionality)
- [ ] Breaking Change :boom: (fix or feature that would cause existing functionality to not work as expected)
- [ ] Polish :nail_care: (Just some cleanups)
- [x] Internal :house: Only relates to internal processes.

